### PR TITLE
Support for upgrading App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,9 @@ name = "kms"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
+ "fs-err 3.0.0",
  "hex",
  "hex_fmt",
  "kms-rpc",

--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ The TXT record value `3327603e03f5bd1f830812ca4a789277fc31f577:8043` means that 
 
 Given the config `TPROXY_LISTEN_PORT_PASSTHROUGH=9008`, now we can go to [`https://tapp-nginx.kvin.wang:9008`](https://tapp-nginx.kvin.wang:9008) and the request will be handled by the service listening on `8043` in Tapp `3327603e03f5bd1f830812ca4a789277fc31f577`.
 
+## Upgrade an App
+
+Got to the teepod webpage, click the [Upgrade] button, select or paste the compose file you want to upgrade to, and click the [Upgrade] button again.
+Upon successful initiation of the upgrade, you'll see a message prompting you to run the following command in your terminal to authorize the upgrade through KMS:
+
+```shell
+./kms-allow-upgrade.sh <app_id> <upgraded_app_id>
+```
+
+The app id does not change after the upgrade. Stop and start the app to apply the upgrade.
+
 ## HTTPS Certificate Transparency
 
 In the tutorial above, we used a TLS certificate with a private key external to the TEE (Tproxy-CVM here). To establish trust, we need to generate and maintain the certificate's private key within the TEE and provide evidence that all TLS certificates for the domain were originate solely from Tproxy-CVM.

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ RUN_DIR=`pwd`/run
 IMAGE_NAME=dstack-0.1.0
 IMAGE_TMP_DIR=`pwd`/tmp/images/$IMAGE_NAME
 CERBOT_WORKDIR=$RUN_DIR/certbot
+KMS_UPGRADE_REGISTRY_DIR=$RUN_DIR/kms/upgrade_registry
+KMS_CERT_LOG_DIR=$RUN_DIR/kms/cert_log/
 
 CONFIG_FILE=$SCRIPT_DIR/build-config.sh
 if [ -f build-config.sh ]; then
@@ -119,6 +121,8 @@ mandatory = false
 root_ca_cert = "$CERTS_DIR/root-ca.cert"
 root_ca_key = "$CERTS_DIR/root-ca.key"
 subject_postfix = ".phala"
+upgrade_registry_dir = "$KMS_UPGRADE_REGISTRY_DIR"
+cert_log_dir = "$KMS_CERT_LOG_DIR"
 
 [core.allowed_mr]
 allow_all = true
@@ -207,7 +211,17 @@ renew_days_before = 10
 renew_timeout = 120
 EOF
 
-# Step 5: prepare run dir
+cat <<EOF > kms-allow-upgrade.sh
+#!/bin/bash
+if [ \$# -ne 2 ]; then
+    echo "Usage: \$0 <app_id> <upgraded_app_id>"
+    exit 1
+fi
+mkdir -p "$KMS_UPGRADE_REGISTRY_DIR/\$1"
+touch "$KMS_UPGRADE_REGISTRY_DIR/\$1/\$2"
+EOF
+chmod +x kms-allow-upgrade.sh
+
 mkdir -p $RUN_DIR
 mkdir -p $CERBOT_WORKDIR/backup/preinstalled
 

--- a/kms/Cargo.toml
+++ b/kms/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.88"
+chrono = "0.4.38"
 clap = { version = "4.5.18", features = ["derive"] }
+fs-err = "3.0.0"
 hex = "0.4.3"
 hex_fmt = "0.3.0"
 kms-rpc = { version = "0.1.0", path = "./rpc" }

--- a/kms/kms.toml
+++ b/kms/kms.toml
@@ -19,6 +19,7 @@ mandatory = false
 root_ca_cert = "/etc/kms/certs/ca.cert"
 root_ca_key = "/etc/kms/certs/ca.key"
 subject_postfix = ".local"
+cert_log_dir = "/var/log/kms"
 
 [core.allowed_mr]
 allow_all = false

--- a/kms/kms.toml
+++ b/kms/kms.toml
@@ -20,6 +20,7 @@ root_ca_cert = "/etc/kms/certs/ca.cert"
 root_ca_key = "/etc/kms/certs/ca.key"
 subject_postfix = ".local"
 cert_log_dir = "/var/log/kms"
+allow_any_upgrade = true
 
 [core.allowed_mr]
 allow_all = false
@@ -27,3 +28,5 @@ mrtd = []
 rtmr0 = []
 rtmr1 = []
 rtmr2 = []
+
+[core.app_upgrade_registry]

--- a/kms/kms.toml
+++ b/kms/kms.toml
@@ -20,7 +20,8 @@ root_ca_cert = "/etc/kms/certs/ca.cert"
 root_ca_key = "/etc/kms/certs/ca.key"
 subject_postfix = ".local"
 cert_log_dir = "/var/log/kms"
-allow_any_upgrade = true
+allow_any_upgrade = false
+upgrade_registry_dir = "/var/run/kms/upgrade_registry"
 
 [core.allowed_mr]
 allow_all = false
@@ -28,5 +29,3 @@ mrtd = []
 rtmr0 = []
 rtmr1 = []
 rtmr2 = []
-
-[core.app_upgrade_registry]

--- a/kms/src/config.rs
+++ b/kms/src/config.rs
@@ -29,8 +29,8 @@ pub(crate) struct KmsConfig {
     pub root_ca_key: String,
     pub subject_postfix: String,
     pub cert_log_dir: String,
-    pub app_upgrade_registry: String,
     pub allow_any_upgrade: bool,
+    pub upgrade_registry_dir: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/kms/src/config.rs
+++ b/kms/src/config.rs
@@ -26,6 +26,7 @@ pub(crate) struct KmsConfig {
     pub root_ca_cert: String,
     pub root_ca_key: String,
     pub subject_postfix: String,
+    pub cert_log_dir: String,
 }
 
 #[derive(Debug, Clone)]

--- a/kms/src/config.rs
+++ b/kms/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use rocket::figment::{
     providers::{Format, Toml},
@@ -27,6 +29,13 @@ pub(crate) struct KmsConfig {
     pub root_ca_key: String,
     pub subject_postfix: String,
     pub cert_log_dir: String,
+    pub app_upgrade_registry: String,
+    pub allow_any_upgrade: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AppUpgradeRegistry {
+    pub registry: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone)]

--- a/kms/src/ct_log.rs
+++ b/kms/src/ct_log.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use fs_err as fs;
+
+pub(crate) fn iter_ct_log_files(log_dir: &Path) -> Result<impl Iterator<Item = PathBuf>> {
+    // Certs files at log_dir/YYYYMMDD/xxx.cert
+    let day_dirs = fs::read_dir(log_dir)?.filter_map(|entry| {
+        let path = entry.ok()?.path();
+        if path.is_dir() {
+            Some(path)
+        } else {
+            None
+        }
+    });
+
+    Ok(day_dirs
+        .flat_map(|dir| {
+            let iter = fs::read_dir(dir).ok()?.filter_map(|entry| {
+                let path = entry.ok()?.path();
+                if path.is_file() && path.ends_with(".cert") {
+                    Some(path)
+                } else {
+                    None
+                }
+            });
+            Some(iter)
+        })
+        .flatten())
+}
+
+pub(crate) fn ct_log_write_cert(app_id: &str, cert: &str, log_dir: &str) -> Result<()> {
+    // filename: %Y%d%m-%H%M%S.%sn.%app_id.cert
+    let log_dir = Path::new(log_dir);
+    let now = Utc::now();
+    let day = now.format("%Y%d%m").to_string();
+    let base_filename = format!("{}-{app_id}", now.format("%Y%d%m-%H%M%S"));
+    let day_dir = log_dir.join(day);
+    fs::create_dir_all(&day_dir).context("failed to create ct log dir")?;
+    let cert_log_path = find_available_filename(&day_dir, &base_filename)
+        .context("failed to find available filename")?;
+    fs::write(cert_log_path, cert).context("faile to write ct log cert")?;
+    Ok(())
+}
+
+fn binary_search(mut upper: usize, is_ok: impl Fn(usize) -> bool) -> Option<usize> {
+    let mut lower = 0;
+    if is_ok(0) {
+        return Some(0);
+    }
+    if !is_ok(upper) {
+        return None;
+    }
+    while lower < upper {
+        let mid = lower + (upper - lower) / 2;
+        if is_ok(mid) {
+            upper = mid;
+        } else {
+            lower = mid + 1;
+        }
+    }
+    Some(upper)
+}
+
+fn find_available_filename(dir: &Path, base_filename: &str) -> Option<PathBuf> {
+    fn mk_filename(dir: &Path, base_filename: &str, index: usize) -> PathBuf {
+        dir.join(format!("{base_filename}.{index}.cert"))
+    }
+    let available_index = binary_search(4096, |i| {
+        !std::path::Path::new(&mk_filename(dir, base_filename, i)).exists()
+    })?;
+    Some(mk_filename(dir, base_filename, available_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_binary_search_simple() {
+        for i in 0..=4096 {
+            let result = binary_search(4096, |x| x >= i);
+            assert_eq!(result, Some(i));
+        }
+    }
+}

--- a/kms/src/main.rs
+++ b/kms/src/main.rs
@@ -5,6 +5,7 @@ use tracing::info;
 mod config;
 mod main_service;
 mod web_routes;
+mod ct_log;
 
 #[derive(Parser)]
 #[command(author, version, about)]

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -12,7 +12,7 @@ use ra_tls::{
     kdf::derive_ecdsa_key_pair,
     qvl::quote::{Report, TDReport10},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     config::{AllowedMr, KmsConfig},
@@ -96,11 +96,12 @@ impl RpcHandler {
         if self.state.inner.config.allow_any_upgrade {
             return Ok(());
         }
-        let registry_file_path = &self.state.inner.config.app_upgrade_registry;
-        let flag_file_path = format!("{registry_file_path}/{app_id}/{upgraded_app_id}");
+        let registry_dir = &self.state.inner.config.upgrade_registry_dir;
+        let flag_file_path = format!("{registry_dir}/{app_id}/{upgraded_app_id}");
         if fs::metadata(&flag_file_path).is_ok() {
             return Ok(());
         }
+        warn!("Denied upgrade from {app_id} to {upgraded_app_id}");
         bail!("Upgrade denied");
     }
 }

--- a/ra-tls/src/attestation.rs
+++ b/ra-tls/src/attestation.rs
@@ -79,6 +79,12 @@ impl Attestation {
             .map(|event| truncate(&event.digest, 40).to_string())
     }
 
+    /// Decode the upgraded app-id from the event log
+    pub fn decode_upgraded_app_id(&self) -> Result<String> {
+        self.find_event(3, "upgraded-app-id")
+            .map(|event| truncate(&event.digest, 40).to_string())
+    }
+
     /// Decode the rootfs hash from the event log
     pub fn decode_rootfs_hash(&self) -> Result<String> {
         self.find_event(3, "rootfs-hash")

--- a/run.sh
+++ b/run.sh
@@ -13,10 +13,10 @@ PROCESS_NAME=qemu
 INITRD=${IMAGE_PATH}/$(jq -r '.initrd' ${IMG_METADATA})
 KERNEL=${IMAGE_PATH}/$(jq -r '.kernel' ${IMG_METADATA})
 CDROM=${IMAGE_PATH}/$(jq -r '.rootfs' ${IMG_METADATA})
+TDVF_FIRMWARE=${IMAGE_PATH}/$(jq -r '.bios' ${IMG_METADATA})
 CMDLINE=$(jq -r '.cmdline' ${IMG_METADATA})
 CONFIG_DIR=${VMDIR}/shared
 TD=${TD:-1}
-TDVF_FIRMWARE=/usr/share/ovmf/OVMF.fd
 RO=${RO:-on}
 CID=$(( ( RANDOM % 10000 )  + 3 ))
 
@@ -33,8 +33,8 @@ if [ "${TD}" == "1" ]; then
 	MACHINE_ARGS=",confidential-guest-support=tdx,hpet=off"
 	PROCESS_NAME=td
 	TDX_ARGS="-device vhost-vsock-pci,guest-cid=${CID} -object tdx-guest,id=tdx"
-	BIOS="-bios ${TDVF_FIRMWARE}"
 fi
+BIOS="-bios ${TDVF_FIRMWARE}"
 
 sleep 2
 
@@ -52,6 +52,6 @@ qemu-system-x86_64 \
 		   -device virtio-net-pci,netdev=nic0_td -netdev user,id=nic0_td \
 		   -drive file=${VDA},if=none,id=virtio-disk0 -device virtio-blk-pci,drive=virtio-disk0 \
 		   -cdrom ${CDROM} \
-		   -virtfs local,path=${CONFIG_DIR},mount_tag=config,readonly=${RO},security_model=mapped,id=virtfs0 \
+		   -virtfs local,path=${CONFIG_DIR},mount_tag=host-shared,readonly=${RO},security_model=mapped,id=virtfs0 \
 		   ${ARGS} \
 		   -append "${CMDLINE}"

--- a/teepod/rpc/proto/teepod_rpc.proto
+++ b/teepod/rpc/proto/teepod_rpc.proto
@@ -40,6 +40,14 @@ message CreateVMRequest {
   uint32 disk_size = 6;
 }
 
+// Message for upgrading an app request
+message UpgradeAppRequest {
+  // ID of the VM
+  string id = 1;
+  // Compose file to be used for the VM
+  string compose_file = 2;
+}
+
 // Message for VM list response
 message VMListResponse {
   // List of VMs
@@ -56,6 +64,8 @@ service Teepod {
   rpc StopVM(Id) returns (google.protobuf.Empty);
   // RPC to remove a VM
   rpc RemoveVM(Id) returns (google.protobuf.Empty);
+  // RPC to upgrade an app
+  rpc UpgradeApp(UpgradeAppRequest) returns (Id);
 
   // RPC to list all VMs
   rpc ListVms(google.protobuf.Empty) returns (VMListResponse);

--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -13,27 +13,27 @@
             margin: 0;
             padding: 20px;
         }
-
+        
         h1 {
             color: #333;
         }
-
+        
         form {
             margin-bottom: 20px;
         }
-
+        
         input,
         button,
         textarea {
             margin: 5px 0;
             padding: 5px;
         }
-
+        
         #vmList {
             border: 1px solid #ddd;
             padding: 10px;
         }
-
+        
         .vm-item {
             border: 1px solid #e0e0e0;
             border-radius: 8px;
@@ -42,25 +42,25 @@
             background: #fff;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
         }
-
+        
         .vm-info {
             display: flex;
             gap: 20px;
             margin-bottom: 10px;
         }
-
+        
         .vm-detail {
             display: flex;
             align-items: center;
             gap: 5px;
         }
-
+        
         .vm-actions {
             display: flex;
             gap: 10px;
             flex-wrap: wrap;
         }
-
+        
         .action-btn {
             padding: 6px 12px;
             border: none;
@@ -71,52 +71,52 @@
             gap: 5px;
             transition: all 0.2s;
         }
-
+        
         .action-btn:hover {
             transform: translateY(-1px);
         }
-
+        
         .start {
             background: #4CAF50;
             color: white;
         }
-
+        
         .stop {
             background: #f44336;
             color: white;
         }
-
+        
         .remove {
             background: #9e9e9e;
             color: white;
         }
-
+        
         .logs {
             background: #2196F3;
             color: white;
         }
-
+        
         .info {
             background: #673AB7;
             color: white;
         }
-
+        
         .status-created {
             color: #FFC107;
         }
-
+        
         .status-running {
             color: #4CAF50;
         }
-
+        
         .status-stopping {
             color: #FF9800;
         }
-
+        
         .status-stopped {
             color: #f44336;
         }
-
+        
         .status-exited {
             color: #9E9E9E;
         }
@@ -126,18 +126,18 @@
             max-width: 600px;
             margin: 20px 0;
         }
-
+        
         .form-group {
             margin-bottom: 15px;
         }
-
+        
         .form-group label {
             display: block;
             margin-bottom: 5px;
             font-weight: bold;
             color: #333;
         }
-
+        
         .form-group input,
         .form-group textarea {
             width: 100%;
@@ -146,21 +146,21 @@
             border-radius: 4px;
             font-size: 14px;
         }
-
+        
         .form-group textarea {
             min-height: 120px;
             resize: vertical;
         }
-
+        
         .form-group input[type="file"] {
             border: none;
             padding: 0;
         }
-
+        
         .form-group input[type="number"] {
             width: 150px;
         }
-
+        
         .submit-btn {
             background-color: #2196F3;
             color: white;
@@ -171,11 +171,11 @@
             font-size: 16px;
             transition: background-color 0.2s;
         }
-
+        
         .submit-btn:hover {
             background-color: #1976D2;
         }
-
+        
         .submit-btn:active {
             transform: translateY(1px);
         }
@@ -187,7 +187,7 @@
             gap: 15px;
             margin-bottom: 15px;
         }
-
+        
         .form-grid .form-group {
             margin-bottom: 0;
             padding: 10px;
@@ -195,11 +195,11 @@
             border-radius: 4px;
             background-color: #f9f9f9;
         }
-
+        
         .form-group.full-width {
             grid-column: 1 / -1;
         }
-
+        
         .form-grid .form-group input {
             /* Adjust for padding */
             width: calc(100% - 16px);
@@ -210,7 +210,7 @@
             /* Include padding in width calculation */
             box-sizing: border-box;
         }
-
+        
         .form-group input:focus {
             outline: none;
             border-color: #2196F3;
@@ -223,20 +223,73 @@
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
             border-radius: 8px;
         }
-
+        
         #vmList tr:hover {
             background-color: #f5f5f5;
         }
-
+        
         #vmList th {
             font-weight: bold;
             color: #333;
         }
-
+        
         .vm-actions {
             display: flex;
             gap: 8px;
             flex-wrap: wrap;
+        }
+    </style>
+    <style>
+        .dialog-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 1000;
+        }
+        
+        .dialog {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            width: 500px;
+            max-width: 90%;
+        }
+        
+        .upgrade {
+            background: #FF9800;
+            color: white;
+        }
+        
+        .success-message {
+            margin: 10px 0;
+            padding: 10px;
+            background: #E8F5E9;
+            border: 1px solid #4CAF50;
+            border-radius: 4px;
+            color: #2E7D32;
+            position: relative;
+        }
+        
+        .close-btn {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            background: none;
+            border: none;
+            font-size: 20px;
+            cursor: pointer;
+            color: #2E7D32;
+            padding: 0 5px;
+        }
+        
+        .close-btn:hover {
+            color: #1B5E20;
         }
     </style>
 </head>
@@ -273,8 +326,7 @@
 
                 <div class="form-group">
                     <label for="diskSize">Disk Size (GB)</label>
-                    <input id="diskSize" v-model.number="vmForm.disk_size" type="number" placeholder="Disk size in GB"
-                        required>
+                    <input id="diskSize" v-model.number="vmForm.disk_size" type="number" placeholder="Disk size in GB" required>
                 </div>
 
                 <div class="form-group">
@@ -285,8 +337,7 @@
 
             <div class="form-group">
                 <label for="composeFile">Docker Compose File</label>
-                <textarea id="composeFile" v-model="vmForm.compose_file"
-                    placeholder="Paste your docker-compose.yml here" required></textarea>
+                <textarea id="composeFile" v-model="vmForm.compose_file" placeholder="Paste your docker-compose.yml here" required></textarea>
             </div>
 
             <button type="submit" class="submit-btn">Create VM</button>
@@ -329,25 +380,61 @@
                                 <button class="action-btn info" @click="showAppInfo(vm.app_url)" title="View App Info">
                                     <i class="fas fa-info-circle"></i> Dashboard
                                 </button>
+                                <button class="action-btn upgrade" @click="showUpgradeDialog(vm)" title="Upgrade VM">
+                                    <i class="fas fa-arrow-up"></i> Upgrade
+                                </button>
                             </div>
                         </td>
                     </tr>
                 </tbody>
             </table>
         </div>
+
+        <div v-if="upgradeDialog.show" class="dialog-overlay">
+            <div class="dialog">
+                <h3>Upgrade VM</h3>
+                <div class="form-group">
+                    <label for="upgradeFile">Upload New Compose File</label>
+                    <input id="upgradeFile" type="file" @change="loadUpgradeFile" accept=".yml,.yaml,.txt">
+                </div>
+                <div class="form-group">
+                    <label for="upgradeCompose">Docker Compose File</label>
+                    <textarea id="upgradeCompose" v-model="upgradeDialog.compose_file" placeholder="Paste your new docker-compose.yml here" required></textarea>
+                </div>
+                <div class="vm-actions">
+                    <button class="action-btn upgrade" @click="upgradeVM">Upgrade</button>
+                    <button class="action-btn remove" @click="upgradeDialog.show = false">Cancel</button>
+                </div>
+            </div>
+        </div>
+
+        <div v-if="upgradeMessage" class="success-message">
+            {{ upgradeMessage }}
+            <button class="close-btn" @click="upgradeMessage = ''">×</button>
+        </div>
     </div>
 
-    <script>
-        const { createApp, ref, onMounted } = Vue;
 
-        function rpcCall(method, params) {
-            return fetch(`/prpc/Teepod.${method}?json`, {
+    <script>
+        const {
+            createApp,
+            ref,
+            onMounted
+        } = Vue;
+
+        async function rpcCall(method, params) {
+            const response = await fetch(`/prpc/Teepod.${method}?json`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(params || {}),
             });
+            if (!response.ok) {
+                const error = await response.text();
+                alert(`RPC call failed: ${error}`);
+            }
+            return response;
         }
 
         createApp({
@@ -363,7 +450,14 @@
                 });
                 const images = ref([]);
 
-                const loadVMList = async () => {
+                const upgradeDialog = ref({
+                    show: false,
+                    vm: null,
+                    compose_file: ''
+                });
+                const upgradeMessage = ref('');
+
+                const loadVMList = async() => {
                     try {
                         const response = await rpcCall('ListVms');
                         const data = await response.json();
@@ -373,7 +467,7 @@
                     }
                 };
 
-                const createVM = async () => {
+                const createVM = async() => {
                     try {
                         const _response = await rpcCall('CreateVM', vmForm.value);
                         loadVMList();
@@ -383,9 +477,11 @@
                     }
                 };
 
-                const stopVM = async (id) => {
+                const stopVM = async(id) => {
                     try {
-                        const _response = await rpcCall('StopVM', { id });
+                        const _response = await rpcCall('StopVM', {
+                            id
+                        });
                         loadVMList();
                     } catch (error) {
                         console.error('Error stopping VM:', error);
@@ -393,9 +489,11 @@
                     }
                 };
 
-                const startVM = async (id) => {
+                const startVM = async(id) => {
                     try {
-                        const _response = await rpcCall('StartVM', { id });
+                        const _response = await rpcCall('StartVM', {
+                            id
+                        });
                         loadVMList();
                     } catch (error) {
                         console.error('Error starting VM:', error);
@@ -403,9 +501,11 @@
                     }
                 };
 
-                const removeVM = async (id) => {
+                const removeVM = async(id) => {
                     try {
-                        const _response = await rpcCall('RemoveVM', { id });
+                        const _response = await rpcCall('RemoveVM', {
+                            id
+                        });
                         loadVMList();
                     } catch (error) {
                         console.error('Error removing VM:', error);
@@ -413,11 +513,11 @@
                     }
                 };
 
-                const showLog = async (id) => {
+                const showLog = async(id) => {
                     window.open(`/logs?id=${id}&follow=false&ansi=false`, '_blank');
                 };
 
-                const showAppInfo = async (app_url) => {
+                const showAppInfo = async(app_url) => {
                     if (app_url) {
                         window.open(app_url, '_blank');
                     } else {
@@ -437,13 +537,48 @@
                     }
                 };
 
-                const loadImages = async () => {
+                const loadImages = async() => {
                     try {
                         const response = await rpcCall('ListImages');
                         const data = await response.json();
                         images.value = data.images;
                     } catch (error) {
                         console.error('error loading images:', error);
+                    }
+                };
+
+                const showUpgradeDialog = (vm) => {
+                    upgradeDialog.value = {
+                        show: true,
+                        vm: vm,
+                        compose_file: ''
+                    };
+                };
+
+                const loadUpgradeFile = (event) => {
+                    const file = event.target.files[0];
+                    if (file) {
+                        const reader = new FileReader();
+                        reader.onload = (e) => {
+                            upgradeDialog.value.compose_file = e.target.result;
+                        };
+                        reader.readAsText(file);
+                    }
+                };
+
+                const upgradeVM = async() => {
+                    try {
+                        const response = await rpcCall('UpgradeApp', {
+                            id: upgradeDialog.value.vm.id,
+                            compose_file: upgradeDialog.value.compose_file
+                        });
+                        const data = await response.json();
+                        upgradeDialog.value.show = false;
+                        upgradeMessage.value = `Upgrade initiated successfully! Next step:\n./kms-allow-upgrade.sh ${upgradeDialog.value.vm.app_id} ${data.id}`;
+                        loadVMList();
+                    } catch (error) {
+                        console.error('error upgrading VM:', error);
+                        alert('failed to upgrade VM');
                     }
                 };
 
@@ -462,7 +597,12 @@
                     removeVM,
                     showLog,
                     showAppInfo,
-                    loadComposeFile
+                    loadComposeFile,
+                    upgradeDialog,
+                    upgradeMessage,
+                    showUpgradeDialog,
+                    loadUpgradeFile,
+                    upgradeVM
                 };
             }
         }).mount('#app');

--- a/teepod/src/vm.rs
+++ b/teepod/src/vm.rs
@@ -116,7 +116,7 @@ pub(crate) mod run {
         }
 
         pub fn start(&mut self, qemu_bin: &Path) -> Result<()> {
-            if self.started {
+            if self.is_running() {
                 bail!("VM already running");
             }
             let process = super::qemu::run_vm(qemu_bin, &self.config, &self.workdir)?;
@@ -135,6 +135,7 @@ pub(crate) mod run {
                 if status.success() {
                     info!("VM exited successfully");
                 } else {
+                    let todo = "Dont show error if VM is stopped by user";
                     error!("VM exited with status: {:#?}", status);
                     if let Some(mut output) = cloned_child.take_stderr() {
                         let mut stderr = String::new();


### PR DESCRIPTION
This PR adds support for upgrading App with a new docker-compose.yaml.

Steps:

- Submit the new docker-compose.yaml at teepod dashboard
- Run the shell script to add the upgrade to KMS whitelist

How it works:

When the new docker-compose.yaml is submitted, it replaces the old one in the VM instance directory.

In the later boot stage in initramfs, two app IDs are measured to RTMR and reported to KMS - the original `app_id` calculated from the docker-compose.yaml used to deploy the app, and the `upgraded_app_id` calculated from the new docker-compose.yaml.

KMS checks if the `app_id` is allowed to upgrade to `upgraded_app_id` in the whitelist. If yes, it returns the key of the original `app_id`.

After upgrade, the `app_id` of the App remains unchanged.
