### PR TITLE
tproxy: Support for addressing by instance id

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,13 @@ After the container deployed, it should need some time to start the CVM and the 
 
 Once the app is deployed and listening on an HTTP port, you can access the HTTP service via tproxy's public domain. The ingress mapping rules are:
 
-- `<app_id>.<base_domain>` maps to port `80` in the CVM.
-- `<app_id>-<port>.<base_domain>` maps to port `<port>` in the CVM.
+- `<id>[s].<base_domain>` maps to port `80` or `443` if with `s` in the CVM.
+- `<id>-<port>[s].<base_domain>` maps to port `<port>` in the CVM.
 
 For example, `3327603e03f5bd1f830812ca4a789277fc31f577-8080.app.kvin.wang` maps to port `8080` in the CVM.
+
+Where the `<id>` can be either the app id or the instance id. If the app id is used, one of the instances will be selected by the load balancer.
+If the `id-port` part ends with `s`, it means the TLS connection will be passthrough to the app rather than terminating at tproxy.
 
 You can also ssh into the CVM to inspect more information, if your deployment uses the image `dstack-x.x.x-dev`:
 

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -110,6 +110,9 @@ impl KmsRpc for RpcHandler {
     async fn get_app_key(self) -> Result<AppKeyResponse> {
         let attest = self.ensure_attested()?;
         let app_id = attest.decode_app_id().context("Failed to decode app ID")?;
+        let instance_id = attest
+            .decode_instance_id()
+            .context("Failed to decode instance ID")?;
         let upgraded_app_id = attest
             .decode_upgraded_app_id()
             .context("Failed to decode upgraded app ID")?;
@@ -130,8 +133,9 @@ impl KmsRpc for RpcHandler {
         let app_disk_key = derive_ecdsa_key_pair(
             &state.root_ca.key,
             &[
-                app_id.as_bytes(),
                 rootfs_hash.as_bytes(),
+                app_id.as_bytes(),
+                instance_id.as_bytes(),
                 "app-disk-crypt-key".as_bytes(),
             ],
         )

--- a/ra-tls/src/attestation.rs
+++ b/ra-tls/src/attestation.rs
@@ -100,6 +100,12 @@ impl Attestation {
             .map(|event| truncate(&event.digest, 40).to_string())
     }
 
+    /// Decode the instance-id from the event log
+    pub fn decode_instance_id(&self) -> Result<String> {
+        self.find_event(3, "instance-id")
+            .map(|event| truncate(&event.digest, 40).to_string())
+    }
+
     /// Decode the upgraded app-id from the event log
     pub fn decode_upgraded_app_id(&self) -> Result<String> {
         self.find_event(3, "upgraded-app-id")

--- a/tappd/rpc/proto/tappd_rpc.proto
+++ b/tappd/rpc/proto/tappd_rpc.proto
@@ -77,8 +77,10 @@ message Container {
 message WorkerInfo {
   // Worker ID
   string app_id = 1;
+  // App Instance ID
+  string instance_id = 2;
   // App certificate
-  string app_cert = 2;
+  string app_cert = 3;
   // TCB info
-  string tcb_info = 3;
+  string tcb_info = 4;
 }

--- a/tappd/src/http_routes.rs
+++ b/tappd/src/http_routes.rs
@@ -61,6 +61,7 @@ async fn index(state: &State<AppState>) -> Result<RawHtml<String>, String> {
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
     let WorkerInfo {
         app_id,
+        instance_id,
         tcb_info,
         app_cert,
     } = handler
@@ -71,6 +72,7 @@ async fn index(state: &State<AppState>) -> Result<RawHtml<String>, String> {
     let containers = list_containers().await.unwrap_or_default().containers;
     let model = crate::models::Dashboard {
         app_id,
+        instance_id,
         app_cert,
         tcb_info,
         containers,

--- a/tappd/src/models.rs
+++ b/tappd/src/models.rs
@@ -14,6 +14,7 @@ mod filters {
 #[template(path = "dashboard.html")]
 pub struct Dashboard {
     pub app_id: String,
+    pub instance_id: String,
     pub app_cert: String,
     pub tcb_info: String,
     pub containers: Vec<Container>,

--- a/tappd/src/rpc_service.rs
+++ b/tappd/src/rpc_service.rs
@@ -112,6 +112,9 @@ impl WorkerRpc for ExternalRpcHandler {
         let app_id = attestation
             .decode_app_id()
             .context("Failed to decode app id")?;
+        let instance_id = attestation
+            .decode_instance_id()
+            .context("Failed to decode instance_id")?;
         let quote = attestation
             .decode_quote()
             .context("Failed to decode quote")?;
@@ -139,6 +142,7 @@ impl WorkerRpc for ExternalRpcHandler {
         .unwrap_or_default();
         Ok(WorkerInfo {
             app_id,
+            instance_id,
             app_cert: ca.pem_cert.clone(),
             tcb_info,
         })

--- a/tappd/templates/dashboard.html
+++ b/tappd/templates/dashboard.html
@@ -112,6 +112,7 @@
     <h1>Worker Information</h1>
     <div class="info-section">
         <p><strong>App ID:</strong> {{app_id}}</p>
+        <p><strong>Instance ID:</strong> {{instance_id}}</p>
     </div>
     <h2>Deployed Containers</h2>
     <table>

--- a/teepod/rpc/proto/teepod_rpc.proto
+++ b/teepod/rpc/proto/teepod_rpc.proto
@@ -14,9 +14,11 @@ message VmInfo {
   // Uptime in human-readable format
   string uptime = 4;
   // URL to the Tappd console
-  string app_url = 5;
+  optional string app_url = 5;
   // App ID
   string app_id = 6;
+  // Instance ID
+  optional string instance_id = 7;
 }
 
 message Id {

--- a/teepod/src/app.rs
+++ b/teepod/src/app.rs
@@ -234,11 +234,14 @@ impl App {
                 name: info.name,
                 status: info.status.to_string(),
                 uptime: info.uptime,
-                app_url: format!(
-                    "https://{}-{}.{}:{}",
-                    info.app_id, gw.tappd_port, gw.base_domain, gw.port
-                ),
+                app_url: info.instance_id.as_ref().map(|id| {
+                    format!(
+                        "https://{id}-{}.{}:{}",
+                        gw.tappd_port, gw.base_domain, gw.port
+                    )
+                }),
                 app_id: info.app_id,
+                instance_id: info.instance_id,
             })
             .collect()
     }

--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -467,7 +467,7 @@
                                 <button class="action-btn" @click="showLog(vm.id)" title="View Logs">
                                     <i class="fas fa-file-alt"></i> Logs
                                 </button>
-                                <button class="action-btn" @click="showAppInfo(vm.app_url)" title="View App Info">
+                                <button v-if="vm.app_url" class="action-btn" @click="showAppInfo(vm.app_url)" title="View App Info">
                                     <i class="fas fa-info-circle"></i> Dashboard
                                 </button>
                                 <button class="action-btn" @click="showUpgradeDialog(vm)" title="Upgrade VM">

--- a/tproxy/rpc/proto/tproxy_rpc.proto
+++ b/tproxy/rpc/proto/tproxy_rpc.proto
@@ -48,14 +48,16 @@ message ListResponse {
 
 // HostInfo is the information of a host.
 message HostInfo {
+  // The Instance id
+  string id = 1;
   // The IP address of the host.
-  string ip = 1;
+  string ip = 2;
   // The app id of the host.
-  string app_id = 2;
-  // The HTTPS endpoint of the host.
-  string endpoint = 3;
-  // The external ports of the host.
-  repeated uint32 ports = 4;
+  string app_id = 3;
+  // The base domain of the HTTPS endpoint of the host.
+  string base_domain = 4;
+  // The external port of the host.
+  uint32 port = 5;
 }
 
 

--- a/tproxy/src/models.rs
+++ b/tproxy/src/models.rs
@@ -54,8 +54,9 @@ impl<'a, K, V> Iterator for MapValuesIter<'a, K, V> {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HostInfo {
+pub struct InstanceInfo {
     pub id: String,
+    pub app_id: String,
     pub ip: Ipv4Addr,
     pub public_key: String,
 }
@@ -65,7 +66,7 @@ pub struct HostInfo {
 pub struct WgConf<'a> {
     pub private_key: &'a str,
     pub listen_port: u16,
-    pub peers: MapValues<'a, String, HostInfo>,
+    pub peers: MapValues<'a, String, InstanceInfo>,
 }
 
 #[derive(Template)]

--- a/tproxy/src/proxy/tls_passthough.rs
+++ b/tproxy/src/proxy/tls_passthough.rs
@@ -60,7 +60,7 @@ pub(crate) async fn proxy_to_app(
     app_id: &str,
     port: u16,
 ) -> Result<()> {
-    let target_ip = state.lock().get_host(app_id).context("tapp not found")?.ip;
+    let target_ip = state.lock().select_a_host(app_id).context("tapp not found")?.ip;
     let mut outbound = TcpStream::connect((target_ip, port))
         .await
         .context("failed to connect to tapp")?;

--- a/tproxy/src/proxy/tls_terminate.rs
+++ b/tproxy/src/proxy/tls_terminate.rs
@@ -56,7 +56,7 @@ impl TlsTerminateProxy {
         let host = self
             .app_state
             .lock()
-            .get_host(&app_id)
+            .select_a_host(&app_id)
             .context(format!("tapp {app_id} not found"))?;
         let stream = MergedStream {
             buffer,

--- a/tproxy/templates/cvmlist.html
+++ b/tproxy/templates/cvmlist.html
@@ -26,19 +26,15 @@
     <h2>CVM List</h2>
     <table>
         <tr>
+            <th>Instance ID</th>
             <th>App ID</th>
             <th>IP</th>
-            <th>Ports</th>
         </tr>
         {% for host in hosts %}
         <tr>
+            <td>{{ host.id }}</td>
             <td>{{ host.app_id }}</td>
             <td>{{ host.ip }}</td>
-            <td>
-                {% for port in host.ports %}
-                <a href="https://{{ host.endpoint }}:{{ port }}" target="_blank">{{ port }}</a>{% if !loop.last %}, {% endif %}
-                {% endfor %}
-            </td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
This PR
- Adds `instance-id` to CVM, measured to RTMR3.
- tproxy: Support for registering multiple instance per `app-id`.
- tproxy: Support for routing by `instance-id` as well as `app-id`.
