### PR TITLE
teepod: Support for mapping host port to CVM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,8 @@ TEEPOD_RPC_LISTEN_PORT=9080
 TEEPOD_CID_POOL_START=10000
 # CID pool size
 TEEPOD_CID_POOL_SIZE=1000
+# Whether port mapping is enabled
+TEEPOD_PORT_MAPPING_ENABLED=false
 
 KMS_RPC_LISTEN_PORT=9043
 TPROXY_RPC_LISTEN_PORT=9010
@@ -218,6 +220,12 @@ kms_url = "https://kms.$BASE_DOMAIN:$KMS_RPC_LISTEN_PORT"
 tproxy_url = "https://tproxy.$BASE_DOMAIN:$TPROXY_RPC_LISTEN_PORT"
 cid_start = $TEEPOD_CID_POOL_START
 cid_pool_size = $TEEPOD_CID_POOL_SIZE
+[cvm.port_mapping]
+enabled = $TEEPOD_PORT_MAPPING_ENABLED
+address = "127.0.0.1"
+range = [
+    { protocol = "tcp", from = 1, to = 20000 },
+]
 
 [gateway]
 base_domain = "$TPROXY_PUBLIC_DOMAIN"

--- a/ra-rpc/src/rocket_helper.rs
+++ b/ra-rpc/src/rocket_helper.rs
@@ -96,6 +96,7 @@ pub async fn handle_prpc<S, Call: RpcCall<S>>(
     let call = Call::construct(state, attestation).context("failed to construct call")?;
     let data = data.to_vec();
     let (status_code, output) = call.call(method.to_string(), data, json).await;
+    let todo = "log for errors";
     Ok(Custom(Status::new(status_code), output))
 }
 

--- a/ra-rpc/src/rocket_helper.rs
+++ b/ra-rpc/src/rocket_helper.rs
@@ -96,7 +96,6 @@ pub async fn handle_prpc<S, Call: RpcCall<S>>(
     let call = Call::construct(state, attestation).context("failed to construct call")?;
     let data = data.to_vec();
     let (status_code, output) = call.call(method.to_string(), data, json).await;
-    let todo = "log for errors";
     Ok(Custom(Status::new(status_code), output))
 }
 

--- a/teepod/rpc/proto/teepod_rpc.proto
+++ b/teepod/rpc/proto/teepod_rpc.proto
@@ -40,6 +40,18 @@ message CreateVMRequest {
   uint32 memory = 5;
   // Disk size in GB
   uint32 disk_size = 6;
+  // Port mapping
+  repeated PortMapping ports = 7;
+}
+
+// Message for port mapping
+message PortMapping {
+  // Protocol
+  string protocol = 1;
+  // Host port
+  uint32 host_port = 2;
+  // VM port
+  uint32 vm_port = 3;
 }
 
 // Message for upgrading an app request
@@ -51,9 +63,11 @@ message UpgradeAppRequest {
 }
 
 // Message for VM list response
-message VMListResponse {
+message StatusResponse {
   // List of VMs
   repeated VmInfo vms = 1;
+  // Port mapping enabled
+  bool port_mapping_enabled = 2;
 }
 
 // Service definition for Teepod
@@ -70,7 +84,7 @@ service Teepod {
   rpc UpgradeApp(UpgradeAppRequest) returns (Id);
 
   // RPC to list all VMs
-  rpc ListVms(google.protobuf.Empty) returns (VMListResponse);
+  rpc Status(google.protobuf.Empty) returns (StatusResponse);
   // RPC to list all available images
   rpc ListImages(google.protobuf.Empty) returns (ImageListResponse);
 }

--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -241,8 +241,10 @@
             background: rgba(0, 0, 0, 0.5);
             display: flex;
             justify-content: center;
-            align-items: center;
+            align-items: flex-start;
             z-index: 1000;
+            overflow-y: auto;
+            padding: 20px;
         }
 
         .dialog {
@@ -251,6 +253,7 @@
             border-radius: 8px;
             width: 500px;
             max-width: 90%;
+            margin: 20px auto;
         }
 
         .upgrade {
@@ -424,6 +427,20 @@
                             placeholder="Paste your docker-compose.yml here" required></textarea>
                     </div>
 
+                    <div class="form-group full-width" v-if="config.portMappingEnabled">
+                        <label>Port Mappings</label>
+                        <div v-for="(port, index) in vmForm.ports" :key="index" style="display: flex; gap: 10px; margin-bottom: 10px;">
+                            <select v-model="port.protocol" style="width: 100px;">
+                                <option value="tcp">TCP</option>
+                                <option value="udp">UDP</option>
+                            </select>
+                            <input type="number" v-model.number="port.host_port" placeholder="Host Port" style="width: 120px;">
+                            <input type="number" v-model.number="port.vm_port" placeholder="VM Port" style="width: 120px;">
+                            <button type="button" class="action-btn danger" @click="removePort(index)">Remove</button>
+                        </div>
+                        <button type="button" class="action-btn" @click="addPort">Add Port Mapping</button>
+                    </div>
+
                     <div class="vm-actions">
                         <button type="submit" class="action-btn primary">Deploy</button>
                         <button type="button" class="action-btn remove"
@@ -528,7 +545,8 @@
                     compose_file: '',
                     vcpu: 1,
                     memory: 1024,
-                    disk_size: 20
+                    disk_size: 20,
+                    ports: []
                 });
                 const images = ref([]);
 
@@ -541,6 +559,9 @@
                 const errorMessage = ref('');
 
                 const showCreateDialog = ref(false);
+                const config = ref({
+                    portMappingEnabled: false
+                });
 
                 const rpcCall = async (method, params) => {
                     const response = await fetch(`/prpc/Teepod.${method}?json`, {
@@ -559,9 +580,12 @@
 
                 const loadVMList = async () => {
                     try {
-                        const response = await rpcCall('ListVms');
+                        const response = await rpcCall('Status');
                         const data = await response.json();
                         vms.value = data.vms;
+                        config.value = {
+                            portMappingEnabled: data.port_mapping_enabled
+                        };
                     } catch (error) {
                         console.error('Error loading VM list:', error);
                     }
@@ -699,12 +723,6 @@
         Run: 
         <div class="command-container">
             <code class="command-code">./kms-allow-upgrade.sh ${upgradeDialog.value.vm.app_id} ${data.id}</code>
-            <button 
-                @click="navigator.clipboard.writeText('./kms-allow-upgrade.sh ' + upgradeDialog.value.vm.app_id + ' ' + data.id)"
-                class="copy-button"
-                title="Copy command">
-                📋
-            </button>
         </div>
     </li>
     <li>Restart the instance</li>
@@ -714,6 +732,18 @@
                         console.error('error upgrading VM:', error);
                         alert('failed to upgrade VM');
                     }
+                };
+
+                const addPort = () => {
+                    vmForm.value.ports.push({
+                        protocol: 'tcp',
+                        host_port: null,
+                        vm_port: null
+                    });
+                };
+
+                const removePort = (index) => {
+                    vmForm.value.ports.splice(index, 1);
                 };
 
                 onMounted(() => {
@@ -748,6 +778,9 @@
                     loadUpgradeFile,
                     upgradeVM,
                     showCreateDialog,
+                    addPort,
+                    removePort,
+                    config,
                 };
             }
         }).mount('#app');

--- a/teepod/src/main.rs
+++ b/teepod/src/main.rs
@@ -18,6 +18,8 @@ struct Args {
 
 #[rocket::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let args = Args::parse();
     let figment = config::load_config_figment(args.config.as_deref());
     let config = Config::extract_or_default(&figment)?;

--- a/teepod/teepod.toml
+++ b/teepod/teepod.toml
@@ -16,6 +16,13 @@ max_disk_size = 100
 cid_start = 1000
 cid_pool_size = 1000
 
+[cvm.port_mapping]
+enabled = false
+address = "127.0.0.1"
+range = [
+    { protocol = "tcp", from = 1, to = 20000 },
+]
+
 [gateway]
 base_domain = "localhost"
 port = 8082


### PR DESCRIPTION
After adding config in the `teepod.toml` as below:
```
[cvm.port_mapping]
enabled = true
address = "127.0.0.1"
range = [
    { protocol = "tcp", from = 1, to = 20000 },
]
```

the web UI shows up port mapping config when deploying new instances:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/b74d5ae6-0ac0-45e7-8f41-d7a45684fe76">
