### PR TITLE
teepod: Support for custom netdev

### DIFF
--- a/teepod/src/app.rs
+++ b/teepod/src/app.rs
@@ -163,6 +163,7 @@ impl App {
             manifest,
             image,
             tdx_config: Some(TdxConfig { cid }),
+            networking: self.config.networking.clone(),
         };
         if vm_config.manifest.disk_size > self.config.cvm.max_disk_size {
             bail!(

--- a/teepod/src/config.rs
+++ b/teepod/src/config.rs
@@ -120,6 +120,28 @@ pub struct Config {
     pub cvm: CvmConfig,
     /// Gateway configuration
     pub gateway: GatewayConfig,
+
+    /// Networking configuration
+    pub networking: Networking,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+pub enum Networking {
+    User(UserNetworking),
+    Custom(CustomNetworking),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserNetworking {
+    pub net: String,
+    pub dhcp_start: String,
+    pub restrict: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CustomNetworking {
+    pub netdev: String,
 }
 
 impl Config {

--- a/teepod/teepod.toml
+++ b/teepod/teepod.toml
@@ -7,6 +7,13 @@ log_level = "debug"
 port = 8080
 kms_url = "http://127.0.0.1:8081"
 
+
+[networking]
+mode = "user"
+net = "10.0.2.0/24"
+dhcp_start = "10.0.2.10"
+restrict = false
+
 [cvm]
 ca_cert = "../certs/ca.cert"
 tmp_ca_cert = "../certs/tmp-ca.cert"


### PR DESCRIPTION
This is necessary for TaaS as the default slirp networking lacks network ACL feature.