### PR TITLE
Disable scale ext for protos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,5 +23,8 @@ jobs:
     - name: Run Clippy
       run: cargo clippy -- -D warnings --allow unused_variables 
     
+    - name: Cargo fmt check
+      run: cargo fmt --check --all
+
     - name: Run tests
       run: cargo test

--- a/kms/rpc/build.rs
+++ b/kms/rpc/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let mut builder = prpc_build::configure()
         .out_dir(out_dir)
         .mod_prefix("super::")
+        .build_scale_ext(false)
         .disable_package_emission();
     builder = builder.type_attribute(".kms", "#[::prpc::serde_helpers::prpc_serde_bytes]");
     builder = builder.type_attribute(

--- a/kms/rpc/src/generated.rs
+++ b/kms/rpc/src/generated.rs
@@ -2,4 +2,3 @@ pub use kms::*;
 
 #[allow(async_fn_in_trait)]
 mod kms;
-mod protos_codec_extensions;

--- a/tappd/rpc/build.rs
+++ b/tappd/rpc/build.rs
@@ -4,6 +4,7 @@ fn main() {
     let mut builder = prpc_build::configure()
         .out_dir(out_dir)
         .mod_prefix("super::")
+        .build_scale_ext(false)
         .disable_package_emission();
     builder = builder.type_attribute(".tappd", "#[::prpc::serde_helpers::prpc_serde_bytes]");
     builder = builder.type_attribute(

--- a/tappd/rpc/src/generated.rs
+++ b/tappd/rpc/src/generated.rs
@@ -1,5 +1,4 @@
 pub use tappd::*;
 
-mod protos_codec_extensions;
 #[allow(async_fn_in_trait)]
 mod tappd;

--- a/teepod/rpc/build.rs
+++ b/teepod/rpc/build.rs
@@ -4,6 +4,7 @@ fn main() {
     let mut builder = prpc_build::configure()
         .out_dir(out_dir)
         .mod_prefix("super::")
+        .build_scale_ext(false)
         .disable_package_emission();
     builder = builder.type_attribute(".teepod", "#[::prpc::serde_helpers::prpc_serde_bytes]");
     builder = builder.type_attribute(

--- a/teepod/rpc/src/generated.rs
+++ b/teepod/rpc/src/generated.rs
@@ -1,5 +1,4 @@
 pub use teepod::*;
 
-mod protos_codec_extensions;
 #[allow(async_fn_in_trait)]
 mod teepod;

--- a/tproxy/rpc/build.rs
+++ b/tproxy/rpc/build.rs
@@ -4,6 +4,7 @@ fn main() {
     let mut builder = prpc_build::configure()
         .out_dir(out_dir)
         .mod_prefix("super::")
+        .build_scale_ext(false)
         .disable_package_emission();
     builder = builder.type_attribute(".tproxy", "#[::prpc::serde_helpers::prpc_serde_bytes]");
     builder = builder.type_attribute(

--- a/tproxy/rpc/src/generated.rs
+++ b/tproxy/rpc/src/generated.rs
@@ -1,5 +1,4 @@
 pub use tproxy::*;
 
-mod protos_codec_extensions;
 #[allow(async_fn_in_trait)]
 mod tproxy;


### PR DESCRIPTION
It is no longer needed as we don't face substrate any more.