### PR TITLE
tproxy: Auto set ulimit -n

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { version = "1.42.0" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 safe-write = "0.1.1"
+nix = "0.29.0"
 
 # Serialization/Parsing
 bon = "3.2.0"

--- a/tproxy/Cargo.toml
+++ b/tproxy/Cargo.toml
@@ -33,5 +33,8 @@ certbot.workspace = true
 bytes.workspace = true
 safe-write.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["resource"] }
+
 [dev-dependencies]
 insta.workspace = true

--- a/tproxy/src/config.rs
+++ b/tproxy/src/config.rs
@@ -124,6 +124,7 @@ pub struct Config {
     pub pccs_url: String,
     pub recycle: RecycleConfig,
     pub state_path: String,
+    pub set_ulimit: bool,
 }
 
 pub const CONFIG_FILENAME: &str = "tproxy.toml";

--- a/tproxy/tproxy.toml
+++ b/tproxy/tproxy.toml
@@ -9,6 +9,8 @@ port = 8010
 [core]
 pccs_url = "https://api.trustedservices.intel.com/tdx/certification/v4"
 state_path = "./tproxy-state.json"
+# auto set soft ulimit to hard ulimit
+set_ulimit = true
 
 [core.certbot]
 workdir = "/etc/certbot"


### PR DESCRIPTION
To prevent the `Too many open files` error caused by the 1024 soft limit, tproxy automatically increases the threshold to the maximum hard limit (typically 1M).