### PR TITLE
tproxy: Config for overall timeout for a connection

### DIFF
--- a/tproxy/src/config.rs
+++ b/tproxy/src/config.rs
@@ -47,6 +47,8 @@ pub struct Timeouts {
     pub write: Duration,
     #[serde(with = "serde_duration")]
     pub shutdown: Duration,
+    #[serde(with = "serde_duration")]
+    pub total: Duration,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/tproxy/src/proxy/tls_passthough.rs
+++ b/tproxy/src/proxy/tls_passthough.rs
@@ -72,7 +72,7 @@ pub(crate) async fn proxy_to_app(
         TcpStream::connect((target_ip, port)),
     )
     .await
-    .context("connection timeout")?
+    .context("connecting timeout")?
     .context("failed to connect to tapp")?;
     outbound
         .write_all(&buffer)

--- a/tproxy/src/proxy/tls_terminate.rs
+++ b/tproxy/src/proxy/tls_terminate.rs
@@ -145,7 +145,7 @@ impl TlsTerminateProxy {
             TcpStream::connect((host.ip, port)),
         )
         .await
-        .map_err(|_| anyhow::anyhow!("connection timeout"))?
+        .map_err(|_| anyhow::anyhow!("connecting timeout"))?
         .context("failed to connect to app")?;
         bridge(
             IgnoreUnexpectedEofStream::new(tls_stream),

--- a/tproxy/tproxy.toml
+++ b/tproxy/tproxy.toml
@@ -49,6 +49,8 @@ idle = "10m"
 write = "5s"
 # Timeout for shutting down a connection.
 shutdown = "5s"
+# Timeout for total connection duration.
+total = "5h"
 
 [core.recycle]
 enabled = true


### PR DESCRIPTION
There are many connections that remains there keeping the fd usage. This PR allow tproxy to limit the life duration of a connect, default to 5 hours, so that any connection's max live time is limited.