### PR TITLE
tappd: Better logs filter

### DIFF
--- a/tappd/src/http_routes.rs
+++ b/tappd/src/http_routes.rs
@@ -1,5 +1,6 @@
 use crate::rpc_service::{list_containers, AppState, ExternalRpcHandler, InternalRpcHandler};
 use anyhow::Result;
+use docker_logs::parse_duration;
 use ra_rpc::{rocket_helper::handle_prpc, RpcCall};
 use rinja::Template;
 use rocket::futures::StreamExt;
@@ -135,26 +136,38 @@ async fn external_prpc_get(
     .await
 }
 
-#[get("/logs/<container_name>?<since>&<until>&<follow>&<text>&<timestamps>&<bare>")]
+#[get("/logs/<container_name>?<since>&<until>&<follow>&<text>&<timestamps>&<bare>&<tail>")]
 fn get_logs(
     container_name: String,
-    since: Option<i64>,
-    until: Option<i64>,
+    since: Option<&str>,
+    until: Option<&str>,
     follow: bool,
     text: bool,
     bare: bool,
     timestamps: bool,
+    tail: Option<String>,
 ) -> TextStream![String] {
     // default to 1 hour ago
-    let since = since.unwrap_or_else(|| chrono::Utc::now().timestamp().saturating_sub(3600).max(0));
+    let since = parse_duration(since.unwrap_or("1h"));
+    let until = until.map_or(Ok(0), |u| parse_duration(u));
+    let tail = tail.unwrap_or("1000".to_string());
     TextStream! {
+        let Ok(since) = since else {
+            yield serde_json::json!({ "error": "Invalid since" }).to_string();
+            return;
+        };
+        let Ok(until) = until else {
+            yield serde_json::json!({ "error": "Invalid until" }).to_string();
+            return;
+        };
         let config = docker_logs::LogConfig {
             since,
-            until: until.unwrap_or(0),
+            until,
             follow,
             text,
             bare,
             timestamps,
+            tail,
         };
         let mut stream = match docker_logs::get_logs(&container_name, config) {
             Ok(stream) => stream,
@@ -177,7 +190,9 @@ pub fn external_routes() -> Vec<Route> {
 }
 
 mod docker_logs {
-    use anyhow::Result;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use anyhow::{Context, Result};
     use base64::Engine;
     use bollard::container::{LogOutput, LogsOptions};
     use bollard::Docker;
@@ -190,6 +205,42 @@ mod docker_logs {
         pub text: bool,
         pub bare: bool,
         pub timestamps: bool,
+        pub tail: String,
+    }
+
+    pub fn parse_duration(duration: &str) -> Result<i64> {
+        parse_duration_inner(duration, SystemTime::now())
+    }
+
+    fn parse_duration_inner(duration: &str, now: SystemTime) -> Result<i64> {
+        if duration.is_empty() {
+            return Ok(0);
+        }
+
+        // If the string contains only digits, treat as seconds
+        if duration.chars().all(|c| c.is_ascii_digit()) {
+            return duration.parse::<i64>().context("Invalid duration");
+        }
+
+        let (value, unit) = duration
+            .split_at_checked(duration.len() - 1)
+            .context("Invalid duration")?;
+
+        let value = value.parse::<u64>().context("Invalid duration")?;
+
+        let seconds = match unit {
+            "s" => value,
+            "m" => value * 60,
+            "h" => value * 3600,
+            "d" => value * 24 * 3600,
+            _ => {
+                anyhow::bail!("Invalid time unit. Use s, m, h, or d");
+            }
+        };
+        let now = now
+            .duration_since(UNIX_EPOCH)
+            .context("Failed to get current time")?;
+        Ok(now.as_secs().saturating_sub(seconds) as i64)
     }
 
     pub fn get_logs(
@@ -203,16 +254,17 @@ mod docker_logs {
             text,
             bare,
             timestamps,
+            tail,
         } = config;
         let docker = Docker::connect_with_local_defaults()?;
-        let options = LogsOptions::<String> {
+        let options = LogsOptions {
             stdout: true,
             stderr: true,
             since,
             until,
             follow,
             timestamps,
-            ..Default::default()
+            tail: tail.to_string(),
         };
 
         Ok(docker
@@ -243,5 +295,69 @@ mod docker_logs {
         })
         .to_string();
         format!("{log_line}\n")
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        #[test]
+        fn test_parse_duration_empty() {
+            assert_eq!(parse_duration("").unwrap(), 0);
+        }
+
+        #[test]
+        fn test_parse_duration_numeric() {
+            // When passing just numbers, it should treat as seconds
+            let result = parse_duration("120").unwrap();
+            assert_eq!(result, 120);
+        }
+
+        #[test]
+        fn test_parse_duration_units() {
+            let now = SystemTime::now();
+            let now_secs = now
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+
+            // Test seconds
+            assert_eq!(parse_duration_inner("30s", now).unwrap(), now_secs - 30);
+
+            // Test minutes
+            assert_eq!(parse_duration_inner("5m", now).unwrap(), now_secs - (5 * 60));
+
+            // Test hours
+            assert_eq!(parse_duration_inner("2h", now).unwrap(), now_secs - (2 * 3600));
+
+            // Test days
+            assert_eq!(parse_duration_inner("1d", now).unwrap(), now_secs - (24 * 3600));
+        }
+
+        #[test]
+        fn test_parse_duration_errors() {
+            // Invalid unit
+            assert!(parse_duration("30x").is_err());
+
+            // No numeric value
+            assert!(parse_duration("h").is_err());
+
+            // Invalid numeric value
+            assert!(parse_duration("abc").is_err());
+            assert!(parse_duration("abc").is_err());
+
+            // Empty unit
+            assert!(parse_duration("30").is_ok());
+        }
+
+        #[test]
+        fn test_parse_duration_large_values() {
+            // Test with a large number that shouldn't overflow
+            assert!(parse_duration("999999999s").is_ok());
+
+            // Test with a very large number of days
+            assert!(parse_duration("365d").is_ok());
+        }
     }
 }

--- a/tappd/templates/dashboard.html
+++ b/tappd/templates/dashboard.html
@@ -205,7 +205,7 @@
                 <td>{{name|cname}}</td>
                 <td>{{container.status}}</td>
                 <td>
-                    <a href="/logs/{{name|cname}}?text&bare&timestamps&follow" target="_blank">View Logs</a>
+                    <a href="/logs/{{name|cname}}?text&bare&timestamps&follow&since=1d&tail=1000" target="_blank">View Logs</a>
                 </td>
             </tr>
             {% endfor %}

--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -1068,7 +1068,7 @@
                 };
 
                 const showLog = async (id) => {
-                    window.open(`/logs?id=${id}&follow=true&ansi=false&lines=10000`, '_blank');
+                    window.open(`/logs?id=${id}&follow=true&ansi=false&lines=1000`, '_blank');
                 };
 
                 const showDashboard = async (vm) => {


### PR DESCRIPTION
Allows human readable `since=` and allows `tail=`. (e.g. `since=1h`, `tail=1000`).