### PR TITLE
Add workarounds for wg endpoint changes

### DIFF
--- a/basefiles/app-compose.service
+++ b/basefiles/app-compose.service
@@ -8,8 +8,8 @@ Type=oneshot
 RemainAfterExit=true
 EnvironmentFile=-/tapp/env
 WorkingDirectory=/tapp
-ExecStart=/usr/bin/env app-compose.sh
-ExecStop=/usr/bin/env docker compose stop
+ExecStart=/bin/app-compose.sh
+ExecStop=/bin/docker compose stop
 StandardOutput=journal+console
 StandardError=journal+console
 

--- a/basefiles/tboot.service
+++ b/basefiles/tboot.service
@@ -5,7 +5,7 @@ Before=app-compose.service tappd.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/env tboot.sh
+ExecStart=/bin/tboot.sh
 RemainAfterExit=yes
 StandardOutput=journal+console
 StandardError=journal+console

--- a/basefiles/wg-checker.service
+++ b/basefiles/wg-checker.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=WireGuard Endpoint Checker Service
+After=network-online.target tboot.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/wg-checker.sh
+Restart=always
+RestartSec=10
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/basefiles/wg-checker.sh
+++ b/basefiles/wg-checker.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+get_conf_endpoint() {
+    grep "Endpoint" /etc/wireguard/wg0.conf | awk "{print \$3}"
+}
+
+get_current_endpoint() {
+    wg show wg0 endpoints | awk "{print \$2}"
+}
+
+check_endpoint() {
+    CONF_ENDPOINT=$(get_conf_endpoint)
+    CURRENT_ENDPOINT=$(get_current_endpoint)
+
+    if [ "$CURRENT_ENDPOINT" != "$CONF_ENDPOINT" ]; then
+        echo "Wg endpoint changed from $CONF_ENDPOINT to $CURRENT_ENDPOINT."
+        wg syncconf wg0 <(wg-quick strip wg0)
+    fi
+}
+
+while true; do
+    if [ -f /etc/wireguard/wg0.conf ]; then
+        check_endpoint
+    fi
+    sleep 10
+done


### PR DESCRIPTION
Our previously released images suffers from WireGuard connectivity issues. The root cause was identified as a bug in the QEMU built-in NAT, which occasionally incorrectly translates the WireGuard server's IP address to `10.0.2.3`, leading to incorrect endpoint field updates

To resolve this, we've implemented dual safeguards:
- Iptables-based filtering to restrict packet transmission from authorized endpoints only. (Thanks to @nanometerzhu's good idea.)
- Automated endpoint monitoring service with self-recovery. (Serving as a failsafe for the iptables rule.)