### PR TITLE
compose: Add --remove-orphans to docker compose up

### DIFF
--- a/basefiles/app-compose.sh
+++ b/basefiles/app-compose.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 tdxctl notify-host -e "boot.progress" -d "starting containers" || true
-if ! docker compose up -d; then
+if ! docker compose up --remove-orphans -d; then
     tdxctl notify-host -e "boot.error" -d "failed to start containers"
     exit 1
 fi


### PR DESCRIPTION
So that the previous containers are removed when renamed in docker-compose.yaml