### PR TITLE
Don't shutdown when tboot.sh fail

### DIFF
--- a/basefiles/tboot.sh
+++ b/basefiles/tboot.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-tdxctl tboot --shutdown-on-fail
+tdxctl tboot


### PR DESCRIPTION
We previously added this as a workaround for the cloud could not get the status if the vm failed to boot. Now there is API the get the boot state, this is no longer needed.