### PR TITLE
cvm: A better way to remove orphans

### DIFF
--- a/basefiles/app-compose.service
+++ b/basefiles/app-compose.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=App Compose Service
-Requires=docker.service
+Wants=docker.service
 After=docker.service tboot.service
 
 [Service]

--- a/basefiles/app-compose.sh
+++ b/basefiles/app-compose.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 tdxctl notify-host -e "boot.progress" -d "starting containers" || true
+
+docker compose up --remove-orphans -d 2>/dev/null || true
+chmod +x /usr/bin/containerd-shim-runc-v2
+systemctl restart docker
+
 if ! docker compose up --remove-orphans -d; then
     tdxctl notify-host -e "boot.error" -d "failed to start containers"
     exit 1

--- a/basefiles/tboot.sh
+++ b/basefiles/tboot.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
+# Temporarily disable container auto-start
+# This will be re-enabled later by app-compose.sh
+chmod -x /usr/bin/containerd-shim-runc-v2
+
 tdxctl tboot


### PR DESCRIPTION
In the previous implementation, the cvm ran `docker compose up --remove-orphans -d` on startup, where the --remove-orphans flag is to remove the containers no longer defined in the compose file after an upgrade.
However, that's not enough. Although `--remove-orphans` removes the orphans, because it runs after the dockerd has started, the orphan containers would still run for a short period of time before being removed, if its RestartPolicy is always or so.

This PR solves it by temporarily disabling the dockerd from being able to start containers in a hacked way: `chmod +x /usr/bin/containerd-shim-runc-v2` before the dockerd starts. And recovering it after the docker compose has removed the orphans.
