### PR TITLE
prpc: Choose json codec in prpc clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "prpc",
+ "serde",
  "tokio",
  "tokio-vsock",
  "tower-service",
@@ -3420,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "prpc"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf27f5c46f289f99f68086d3a24b58c9f4f66c3143a1780d5c0589c79b17c81"
+checksum = "e36dbacc22fa64d2059cc8df1e929ab9100804ae2011548b6679f923c1172f42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3439,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "prpc-build"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf018aca01f6c5e7b0c312e484b29ebc63cf42404e4c35d105b1703e6350bfb"
+checksum = "5034baf630735948c9df3cd637f77c2897413934ba1f201068d168080ab4e510"
 dependencies = [
  "either",
  "fs-err",
@@ -3544,6 +3545,7 @@ dependencies = [
  "reqwest 0.12.9",
  "rocket",
  "rocket-vsock-listener",
+ "serde",
  "serde_json",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ rcgen = { version = "0.13.1", features = ["pem"] }
 x509-parser = "0.16.0"
 
 # RPC/Protocol
-prpc = "0.4.0"
-prpc-build = "0.4.1"
+prpc = "0.5.0"
+prpc-build = "0.5.1"
 
 # Development/Testing
 bindgen = "0.70.1"

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -14,6 +14,7 @@ hyperlocal.workspace = true
 log.workspace = true
 pin-project-lite = "0.2.15"
 prpc = { workspace = true, optional = true }
+serde.workspace = true
 tokio.workspace = true
 tokio-vsock.workspace = true
 tower-service = "0.3.3"

--- a/ra-rpc/Cargo.toml
+++ b/ra-rpc/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { workspace = true, default-features = false, features = ["rustls-tls"
 ra-tls.workspace = true
 bon.workspace = true
 rocket-vsock-listener = { workspace = true, optional = true }
+serde.workspace = true
 
 [features]
 default = ["rocket", "client"]


### PR DESCRIPTION
For forward compatible reason. Because future third party server side would likely only implement the json codec variant.