### PR TITLE
make docker restart always and run as daemon

### DIFF
--- a/key-provider-build/docker-compose.yaml
+++ b/key-provider-build/docker-compose.yaml
@@ -1,5 +1,14 @@
+x-common: &common-config
+  restart: always
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "100m"
+      max-file: "5"
+
 services:
   gramine-sealing-key-provider:
+    <<: *common-config
     container_name: gramine-sealing-key-provider
     build:
       context: .
@@ -18,6 +27,7 @@ services:
   # proxy to access the local pccs for the aesm service
   # The local PCCS is supposed to be running on the host machine and listening on 127.0.0.1:8081
   pccs-proxy:
+    <<: *common-config
     image: alpine/socat
     container_name: pccs-proxy
     network_mode: host

--- a/key-provider-build/run.sh
+++ b/key-provider-build/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker compose up --build
+docker compose up --build -d


### PR DESCRIPTION
Updates

1. Make docker always restart in docker compose file
2. Make the local provider run as daemon by add `-d` argument to docker compose up
3. Add docker log options to limit the log file size