### PR TITLE
cvm: Support for multiple kms and tproxy URLs

### DIFF
--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -82,8 +82,8 @@ impl AppCompose {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct LocalConfig {
-    pub kms_url: Option<String>,
-    pub tproxy_url: Option<String>,
+    pub kms_urls: Vec<String>,
+    pub tproxy_urls: Vec<String>,
     pub pccs_url: Option<String>,
     pub docker_registry: Option<String>,
     pub host_api_url: String,

--- a/tappd/src/guest_api_service.rs
+++ b/tappd/src/guest_api_service.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, path::Path};
 use anyhow::{Context, Result};
 use bollard::{container::ListContainersOptions, Docker};
 use cmd_lib::{run_cmd as cmd, run_fun};
+use dstack_types::LocalConfig;
 use fs_err as fs;
 use guest_api::{
     guest_api_server::{GuestApiRpc, GuestApiServer},
@@ -11,16 +12,10 @@ use guest_api::{
 };
 use host_api::Notification;
 use ra_rpc::{CallContext, RpcCall};
-use serde::Deserialize;
 use tappd_rpc::worker_server::WorkerRpc as _;
 use tracing::error;
 
 use crate::{rpc_service::ExternalRpcHandler, AppState};
-
-#[derive(Deserialize)]
-struct LocalConfig {
-    host_api_url: String,
-}
 
 pub struct GuestApiHandler {
     state: AppState,

--- a/teepod/rpc/proto/teepod_rpc.proto
+++ b/teepod/rpc/proto/teepod_rpc.proto
@@ -132,6 +132,7 @@ message ResizeVmRequest {
 
 message KmsSettings {
   string url = 1;
+  repeated string urls = 2;
 }
 
 message TProxySettings {
@@ -139,6 +140,7 @@ message TProxySettings {
   string base_domain = 2;
   uint32 port = 3;
   uint32 tappd_port = 4;
+  repeated string urls = 5;
 }
 
 message ResourcesSettings {

--- a/teepod/src/app.rs
+++ b/teepod/src/app.rs
@@ -369,8 +369,8 @@ impl App {
             .context("Rootfs hash not found in image info")?;
         let vm_config = serde_json::json!({
             "rootfs_hash": rootfs_hash,
-            "kms_url": cfg.cvm.kms_url,
-            "tproxy_url": cfg.cvm.tproxy_url,
+            "kms_urls": cfg.cvm.kms_urls,
+            "tproxy_urls": cfg.cvm.tproxy_urls,
             "pccs_url": cfg.cvm.pccs_url,
             "docker_registry": cfg.cvm.docker_registry,
             "host_api_url": format!("vsock://2:{}/api", cfg.host_api.port),

--- a/teepod/src/config.rs
+++ b/teepod/src/config.rs
@@ -73,9 +73,9 @@ pub struct CvmConfig {
     #[serde(default)]
     pub qemu_path: PathBuf,
     /// The URL of the KMS server
-    pub kms_url: String,
+    pub kms_urls: Vec<String>,
     /// The URL of the TProxy server
-    pub tproxy_url: String,
+    pub tproxy_urls: Vec<String>,
     /// The URL of the PCCS server
     #[serde(default)]
     pub pccs_url: String,

--- a/teepod/src/main_service.rs
+++ b/teepod/src/main_service.rs
@@ -305,10 +305,26 @@ impl TeepodRpc for RpcHandler {
     async fn get_meta(self) -> Result<GetMetaResponse> {
         Ok(GetMetaResponse {
             kms: Some(KmsSettings {
-                url: self.app.config.cvm.kms_url.clone(),
+                url: self
+                    .app
+                    .config
+                    .cvm
+                    .kms_urls
+                    .first()
+                    .cloned()
+                    .unwrap_or_default(),
+                urls: self.app.config.cvm.kms_urls.clone(),
             }),
             tproxy: Some(TProxySettings {
-                url: self.app.config.cvm.tproxy_url.clone(),
+                url: self
+                    .app
+                    .config
+                    .cvm
+                    .tproxy_urls
+                    .first()
+                    .cloned()
+                    .unwrap_or_default(),
+                urls: self.app.config.cvm.tproxy_urls.clone(),
                 base_domain: self.app.config.gateway.base_domain.clone(),
                 port: self.app.config.gateway.port.into(),
                 tappd_port: self.app.config.gateway.tappd_port.into(),

--- a/teepod/teepod.toml
+++ b/teepod/teepod.toml
@@ -15,8 +15,8 @@ dhcp_start = "10.0.2.10"
 restrict = false
 
 [cvm]
-kms_url = "http://127.0.0.1:8081"
-tproxy_url = "http://127.0.0.1:8082"
+kms_urls = ["http://127.0.0.1:8081"]
+tproxy_urls = ["http://127.0.0.1:8082"]
 # PCCS URL used by guest to verify the quote from local key provider
 pccs_url = ""
 docker_registry = ""


### PR DESCRIPTION
So that cvm can fallback to other kms/tproxy nodes if part of them are down.