### PR TITLE
cvm: Only allow wihtelisted envs

### DIFF
--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -1116,7 +1116,8 @@
                         "tproxy_enabled": vmForm.value.tproxy_enabled,
                         "public_logs": vmForm.value.public_logs,
                         "public_sysinfo": vmForm.value.public_sysinfo,
-                        "local_key_provider_enabled": vmForm.value.local_key_provider_enabled
+                        "local_key_provider_enabled": vmForm.value.local_key_provider_enabled,
+                        "allowed_envs": vmForm.value.encrypted_envs.map(env => env.key),
                     };
 
                     if (vmForm.value.preLaunchScript?.trim()) {


### PR DESCRIPTION
Now the env var names required to be declared in the app-compose.json to be passed in to Tapp.

This prevents hidden arbitrary env variables from being passed to TApp.