### PR TITLE
Deterministic RTMR3

### DIFF
--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -27,6 +27,8 @@ pub struct AppCompose {
     pub key_provider: Option<KeyProviderKind>,
     #[serde(default)]
     pub allowed_envs: Vec<String>,
+    #[serde(default)]
+    pub no_instance_id: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]

--- a/kms/tapp/deploy-to-teepod.sh
+++ b/kms/tapp/deploy-to-teepod.sh
@@ -91,6 +91,7 @@ $CLI compose \
   --local-key-provider \
   --public-logs \
   --public-sysinfo \
+  --no-instance-id \
   --output .app-compose.json
 
 # Remove the temporary file as it is no longer needed

--- a/ra-tls/src/attestation.rs
+++ b/ra-tls/src/attestation.rs
@@ -165,13 +165,14 @@ impl<T> Attestation<T> {
         } else {
             sha256(&[&key_provider_info])
         };
-        let mr_aggregated = sha256(&[
+        let mr_system = sha256(&[
             &td_report.mr_td,
             &rtmrs[0],
             &rtmrs[1],
             &rtmrs[2],
             &mr_key_provider,
         ]);
+        let mr_aggregated = sha256(&[&td_report.mr_td, &rtmrs[0], &rtmrs[1], &rtmrs[2], &rtmrs[3]]);
         let mr_image = sha256(&[&td_report.mr_td, &rtmrs[1], &rtmrs[2]]);
         Ok(AppInfo {
             app_id: self.find_event_payload("app-id").unwrap_or_default(),
@@ -183,8 +184,9 @@ impl<T> Attestation<T> {
             rtmr1: rtmrs[1],
             rtmr2: rtmrs[2],
             rtmr3: rtmrs[3],
-            mr_aggregated,
             mr_image,
+            mr_system,
+            mr_aggregated,
             mr_key_provider,
             key_provider_info,
         })
@@ -342,6 +344,9 @@ pub struct AppInfo {
     /// Runtime MR3
     #[serde(with = "hex_bytes")]
     pub rtmr3: [u8; 48],
+    /// Measurement of everything except the app info
+    #[serde(with = "hex_bytes")]
+    pub mr_system: [u8; 32],
     /// Measurement of the entire vm execution environment
     #[serde(with = "hex_bytes")]
     pub mr_aggregated: [u8; 32],

--- a/ra-tls/src/attestation.rs
+++ b/ra-tls/src/attestation.rs
@@ -174,11 +174,10 @@ impl<T> Attestation<T> {
         ]);
         let mr_image = sha256(&[&td_report.mr_td, &rtmrs[1], &rtmrs[2]]);
         Ok(AppInfo {
-            app_id: self.find_event_payload("app-id")?,
+            app_id: self.find_event_payload("app-id").unwrap_or_default(),
             compose_hash: self.find_event_payload("compose-hash")?,
-            instance_id: self.find_event_payload("instance-id")?,
+            instance_id: self.find_event_payload("instance-id").unwrap_or_default(),
             device_id,
-            rootfs_hash: self.find_event_payload("rootfs-hash")?,
             mrtd: td_report.mr_td,
             rtmr0: rtmrs[0],
             rtmr1: rtmrs[1],
@@ -328,9 +327,6 @@ pub struct AppInfo {
     /// ID of the device
     #[serde(with = "hex_bytes")]
     pub device_id: Vec<u8>,
-    /// Rootfs hash
-    #[serde(with = "hex_bytes")]
-    pub rootfs_hash: Vec<u8>,
     /// TCB info
     #[serde(with = "hex_bytes")]
     pub mrtd: [u8; 48],

--- a/tdxctl/src/fde_setup.rs
+++ b/tdxctl/src/fde_setup.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use crate::{
-    cmd_gen_app_keys, cmd_show,
+    cmd_gen_app_keys, cmd_show_mrs,
     crypto::dh_decrypt,
     gen_app_keys_from_seed,
     host_api::HostApi,
@@ -575,8 +575,7 @@ impl SetupFdeArgs {
         extend_rtmr3("boot-mr-done", &[])?;
 
         if host_shared.app_compose.key_provider().is_kms() {
-            // Show the RTMR
-            cmd_show()?;
+            cmd_show_mrs()?;
         }
 
         host.notify_q("boot.progress", "requesting app keys").await;
@@ -612,8 +611,7 @@ impl SetupFdeArgs {
         host.notify_q("boot.progress", "rootfs ready").await;
 
         if !host_shared.app_compose.key_provider().is_kms() {
-            // Show the RTMR
-            cmd_show()?;
+            cmd_show_mrs()?;
         }
         Ok(())
     }

--- a/tdxctl/src/fde_setup.rs
+++ b/tdxctl/src/fde_setup.rs
@@ -554,7 +554,9 @@ impl SetupFdeArgs {
                 rand_id
             };
         }
-        let instance_id = {
+        let instance_id = if host_shared.app_compose.no_instance_id {
+            vec![]
+        } else {
             let mut id_path = instance_info.instance_id_seed.clone();
             id_path.extend_from_slice(&instance_info.app_id);
             sha256(&id_path)[..20].to_vec()
@@ -567,7 +569,6 @@ impl SetupFdeArgs {
         host.notify_q("boot.progress", "extending RTMRs").await;
 
         extend_rtmr3("system-preparing", &[])?;
-        extend_rtmr3("rootfs-hash", &self.rootfs_hash)?;
         extend_rtmr3("app-id", &instance_info.app_id)?;
         extend_rtmr3("compose-hash", &compose_hash)?;
         extend_rtmr3("instance-id", &instance_id)?;

--- a/tdxctl/src/main.rs
+++ b/tdxctl/src/main.rs
@@ -284,10 +284,10 @@ impl core::fmt::Debug for ParsedReport {
     }
 }
 
-fn cmd_show() -> Result<()> {
+fn cmd_show_mrs() -> Result<()> {
     let attestation = ra_tls::attestation::Attestation::local()?;
     let app_info = attestation.decode_app_info(false)?;
-    println!("========== App Info ==========");
+    println!("========== Measurement Report ==========");
     serde_json::to_writer_pretty(io::stdout(), &app_info)?;
     println!();
     Ok(())
@@ -516,7 +516,7 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Report => cmd_report()?,
         Commands::Quote => cmd_quote()?,
-        Commands::Show => cmd_show()?,
+        Commands::Show => cmd_show_mrs()?,
         Commands::Extend(extend_args) => {
             cmd_extend(extend_args)?;
         }

--- a/teepod/src/console.html
+++ b/teepod/src/console.html
@@ -1163,6 +1163,7 @@
                         "public_sysinfo": vmForm.value.public_sysinfo,
                         "local_key_provider_enabled": vmForm.value.local_key_provider_enabled,
                         "allowed_envs": vmForm.value.encrypted_envs.map(env => env.key),
+                        "no_instance_id": !vmForm.value.tproxy_enabled,
                     };
 
                     if (vmForm.value.preLaunchScript?.trim()) {

--- a/teepod/src/teepod-cli.py
+++ b/teepod/src/teepod-cli.py
@@ -396,10 +396,17 @@ class TeepodCLI:
         compose_hash = hashlib.sha256(compose_file.encode()).hexdigest()
         return compose_hash[:40]
 
-    def create_app_compose(self, name: str, prelaunch_script: str, docker_compose: str,
-                           kms_enabled: bool, tproxy_enabled: bool, local_key_provider_enabled: bool,
-                           public_logs: bool, public_sysinfo: bool,
+    def create_app_compose(self,
+                           name: str,
+                           prelaunch_script: str,
+                           docker_compose: str,
+                           kms_enabled: bool,
+                           tproxy_enabled: bool,
+                           local_key_provider_enabled: bool,
+                           public_logs: bool,
+                           public_sysinfo: bool,
                            envs: Optional[Dict],
+                           no_instance_id: bool,
                            output: str,
                            ) -> None:
         """Create a new app compose file"""
@@ -414,6 +421,7 @@ class TeepodCLI:
             "public_logs": public_logs,
             "public_sysinfo": public_sysinfo,
             "allowed_envs": [k for k in envs.keys()],
+            "no_instance_id": no_instance_id,
         }
         if prelaunch_script:
             app_compose["prelaunch_script"] = prelaunch_script
@@ -771,6 +779,8 @@ def main():
     compose_parser.add_argument(
         '--env-file', help='File with environment variables to encrypt', default=None)
     compose_parser.add_argument(
+        '--no-instance-id', action='store_true', help='Disable instance ID')
+    compose_parser.add_argument(
         '--output', required=True, help='Path to output app-compose.json file')
 
     # Deploy command
@@ -856,6 +866,7 @@ def main():
             public_logs=args.public_logs,
             public_sysinfo=args.public_sysinfo,
             envs=parse_env_file(args.env_file),
+            no_instance_id=args.no_instance_id,
             output=args.output
         )
     elif args.command == 'deploy':

--- a/tproxy/tapp/deploy-to-teepod.sh
+++ b/tproxy/tapp/deploy-to-teepod.sh
@@ -121,6 +121,7 @@ $CLI compose \
   --env-file .app_env \
   --public-logs \
   --public-sysinfo \
+  --no-instance-id \
   --output .app-compose.json
 
 # Remove the temporary file as it is no longer needed


### PR DESCRIPTION
This PR introduces an option `no_instance_id` in the app-compose.json, which removes the instance-id from RTMR3.
This PR also eliminates the `rootfs_hash` from RTMR3, as it is already measured in RTMR2.