### PR TITLE
cvm: Add mr-kms to RTMR3

### DIFF
--- a/kms/src/main.rs
+++ b/kms/src/main.rs
@@ -49,7 +49,7 @@ async fn run_onboard_service(kms_config: KmsConfig, figment: Figment) -> Result<
     }
 
     if !kms_config.onboard.auto_bootstrap_domain.is_empty() {
-        onboard_service::bootstrap_keys(&kms_config)?;
+        onboard_service::bootstrap_keys(&kms_config).await?;
         return Ok(());
     }
 

--- a/tdxctl/src/fde_setup.rs
+++ b/tdxctl/src/fde_setup.rs
@@ -253,6 +253,13 @@ impl SetupFdeArgs {
                 if usage != "kms:rpc" {
                     bail!("Invalid server cert usage: {usage}");
                 }
+                if let Some(att) = &cert.attestation {
+                    let kms_info = att
+                        .decode_app_info(false)
+                        .context("Failed to decode app_info")?;
+                    extend_rtmr3("mr-kms", &kms_info.mr_aggregated)
+                        .context("Failed to extend mr-kms to RTMR3")?;
+                }
                 Ok(())
             }))
             .build()


### PR DESCRIPTION
This PR Adds the mr_aggregated of KMS to RTMR3 if exists, so that the MRs of the  full trust chain are aggregated into the App CVM's MRs.

```
┌──────────────────────────── Application MRs ─────────────────────────────┐
│                                                                           │
│  MRTD                                                                     │
│  RTMR[0-2]                                                                │
│                                                                           │
│  RTMR[3] ─────┬─── App Info                                              │
│               │                                                           │
│               └──────────► ┌─────────── MR-KMS ────────────┐             │
│                            │                                │             │
│                            │  MRTD                          │             │
│                            │  RTMR[0-2]                     │             │
│                            │                                │             │
│                            │  RTMR[3] ─────┬─── KMS Info    │             │
│                            │               │                │             │
│                            │               └─── SGX Key     │             │
│                            │                    Provider    │             │
│                            │                    MREnclave   │             │
│                            └────────────────────────────────┘             │
└───────────────────────────────────────────────────────────────────────────┘
```