### PR TITLE
teepod: Compatible for v0.3.x images

### DIFF
--- a/dstack-types/src/shared_filenames.rs
+++ b/dstack-types/src/shared_filenames.rs
@@ -7,3 +7,8 @@ pub const DECRYPTED_ENV: &str = ".decrypted-env";
 pub const DECRYPTED_ENV_JSON: &str = ".decrypted-env.json";
 pub const INSTANCE_INFO: &str = ".instance_info";
 pub const HOST_SHARED_DIR: &str = "/tapp/.host-shared";
+
+pub mod compat_v3 {
+    pub const SYS_CONFIG: &str = "config.json";
+    pub const ENCRYPTED_ENV: &str = "encrypted-env";
+}

--- a/teepod/src/app/image.rs
+++ b/teepod/src/app/image.rs
@@ -23,6 +23,22 @@ pub struct ImageInfo {
 }
 
 impl ImageInfo {
+    pub fn version_tuple(&self) -> Option<(u16, u16, u16)> {
+        let version = self
+            .version
+            .split('.')
+            .take(3)
+            .map(|v| v.parse::<u16>())
+            .collect::<Result<Vec<_>, _>>()
+            .ok()?;
+        if version.len() < 3 {
+            return None;
+        }
+        Some((version[0], version[1], version[2]))
+    }
+}
+
+impl ImageInfo {
     pub fn load(filename: impl AsRef<Path>) -> Result<Self> {
         let file = fs::File::open(filename.as_ref()).context("failed to open image info")?;
         let info: ImageInfo =

--- a/teepod/src/config.rs
+++ b/teepod/src/config.rs
@@ -101,6 +101,16 @@ pub struct CvmConfig {
     pub gpu: GpuConfig,
     /// Use sudo to run the VM
     pub user: String,
+
+    /// The CA certificate
+    #[serde(default)]
+    pub ca_cert: String,
+    /// The tmp CA certificate
+    #[serde(default)]
+    pub tmp_ca_cert: String,
+    /// The tmp CA key
+    #[serde(default)]
+    pub tmp_ca_key: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
We introduced breaking changes in v0.4 that prevented teepod from launching v0.3.x images. This PR implements backward compatibility in teepod to support v0.3.x images.