### PR TITLE
tappd: Don't reuse connections in healthy check client

### DIFF
--- a/tappd/src/main.rs
+++ b/tappd/src/main.rs
@@ -121,13 +121,12 @@ async fn run_watchdog(port: u16) {
     info!("Watchdog enabled, interval={watchdog_usec}us, heartbeat={heatbeat_interval:?}",);
     let mut interval = tokio::time::interval(heatbeat_interval);
 
-    // Create HTTP client for health checks
-    let client = reqwest::Client::new();
-
     let probe_url = format!("http://localhost:{port}/prpc/Worker.Version");
     loop {
         interval.tick().await;
 
+        // Create HTTP client for health checks
+        let client = reqwest::Client::new();
         // Perform health check
         match client.get(&probe_url).send().await {
             Ok(response) if response.status().is_success() => {


### PR DESCRIPTION
This fixes the error in the CVM console log:
```
tappd[643]: 2025-03-19T07:31:23.259508Z ERROR tappd: Health check request failed
```