### PR TITLE
vmm: Auto restart exited VMs

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -62,6 +62,12 @@ pub struct PortMappingConfig {
     pub range: Vec<PortRange>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoRestartConfig {
+    pub enabled: bool,
+    pub interval: u64,
+}
+
 impl PortMappingConfig {
     pub fn is_allowed(&self, protocol: &str, port: u16) -> bool {
         if !self.enabled {
@@ -111,6 +117,9 @@ pub struct CvmConfig {
     /// The tmp CA key
     #[serde(default)]
     pub tmp_ca_key: String,
+
+    /// Auto restart configuration
+    pub auto_restart: AutoRestartConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/vmm/vmm.toml
+++ b/vmm/vmm.toml
@@ -38,6 +38,10 @@ range = [
     { protocol = "tcp", from = 1, to = 20000 },
 ]
 
+[cvm.auto_restart]
+enabled = true
+interval = 20
+
 [cvm.gpu]
 enabled = false
 # The product IDs of the GPUs to discover


### PR DESCRIPTION
When a CVM terminates unexpectedly, the dstack-vmm doesn't initiate a restart.
This PR enables the vmm to monitor terminated VMs at configured intervals and automatically restart them.