### PR TITLE
Fixes tappd starting order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cc-eventlog"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "certbot"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bon",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "certbot-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "certbot",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "certgen"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "ct_monitor"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "guest-api"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "http-client",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "host-api"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "http-client",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "http-body-util",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "iohash"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "kms-rpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2511,7 +2511,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "load_config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "figment",
  "rocket",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "ra-rpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bon",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "ra-tls"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bon",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "rocket-vsock-listener"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "derive_more 1.0.0",
@@ -4821,7 +4821,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supervisor"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bon",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "supervisor-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4963,7 +4963,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tappd"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "tappd-rpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "parity-scale-codec",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-attest"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "cc-eventlog",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-attest-sys"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "tdxctl"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "teepod"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bon",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "teepod-rpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "parity-scale-codec",
@@ -5392,7 +5392,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tproxy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "tproxy-rpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Kevin Wang <wy721@qq.com>", "Leechael <Leechael@github.com>"]
 edition = "2021"
 license = "MIT"

--- a/basefiles/tappd.service
+++ b/basefiles/tappd.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Tappd Service
 After=network.target tboot.service
+Before=docker.service
 
 [Service]
 OOMScoreAdjust=-1000
-ExecStartPre=-/bin/rm -f /var/run/tappd.sock
 ExecStart=/bin/tappd --watchdog
 Restart=always
 User=root

--- a/tappd/tappd.toml
+++ b/tappd/tappd.toml
@@ -16,7 +16,7 @@ compose_file = "/tapp/app-compose.json"
 
 [internal]
 address = "unix:/var/run/tappd.sock"
-reuse = false
+reuse = true
 
 [external]
 address = "0.0.0.0"


### PR DESCRIPTION
When the app mounts tappd.sock into any container, the tappd may fail to start due to a race condition on the start order between Docker. This PR adjusts the service ordering to ensure that tappd is started before Docker.