### PR TITLE
Add secure key derivation APIs and restore backward compatibility

### DIFF
--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -51,25 +51,49 @@ For `tdxQuote`, it supports a range of hash algorithms, including:
 
 The SDK provides integration with [viem](https://viem.sh/) for Ethereum account management:
 
+### ⚠️ Deprecated API (shows warning)
 ```typescript
 import { toViemAccount } from '@phala/dstack-sdk/viem';
 
 const keyResult = await client.deriveKey('<unique-id>');
-const account = toViemAccount(keyResult);
+const account = toViemAccount(keyResult); // ⚠️ Security concern, shows warning
 // Use the account with viem operations
 ```
+
+### ✅ Recommended Secure API
+```typescript
+import { toViemAccountSecure } from '@phala/dstack-sdk/viem';
+
+const keyResult = await client.deriveKey('<unique-id>');
+const account = toViemAccountSecure(keyResult); // ✅ Secure, no warning
+// Use the account with viem operations
+```
+
+> **Note**: `toViemAccount` uses first 32 bytes of key material directly (deprecated due to security concerns). `toViemAccountSecure` uses SHA256 hash of complete key material for enhanced security.
 
 ## Solana Integration
 
 The SDK provides integration with [Solana Web3.js](https://solana-labs.github.io/solana-web3.js/) for Solana account management:
 
+### ⚠️ Deprecated API (shows warning)
 ```typescript
 import { toKeypair } from '@phala/dstack-sdk/solana';
 
 const keyResult = await client.deriveKey('<unique-id>');
-const keypair = toKeypair(keyResult);
+const keypair = toKeypair(keyResult); // ⚠️ Security concern, shows warning
 // Use the keypair with Solana Web3.js operations
 ```
+
+### ✅ Recommended Secure API
+```typescript
+import { toKeypairSecure } from '@phala/dstack-sdk/solana';
+
+const keyResult = await client.deriveKey('<unique-id>');
+const keypair = toKeypairSecure(keyResult); // ✅ Secure, no warning
+// Use the keypair with Solana Web3.js operations
+```
+
+> **Note**: `toKeypair` uses first 32 bytes of key material directly (deprecated due to security concerns). `toKeypairSecure` uses SHA256 hash of complete key material for enhanced security.
 
 ## Environment Variables Encryption
 
@@ -87,6 +111,21 @@ const publicKeyHex = '0x...'; // You need get that from Teepod API or Phala Clou
 const encrypted = await encryptEnvVars(envVars, publicKeyHex);
 // encrypted is a hex string containing: ephemeral public key + iv + encrypted data
 ```
+
+## Migration from Deprecated APIs
+
+We've introduced secure versions of key derivation functions due to security concerns with the original implementations:
+
+| Deprecated (⚠️ Security Warning) | Secure Replacement (✅ Recommended) |
+|-----------------------------------|-------------------------------------|
+| `toKeypair()` | `toKeypairSecure()` |
+| `toViemAccount()` | `toViemAccountSecure()` |
+
+**Key Differences:**
+- **Deprecated APIs**: Use first 32 bytes of key material directly
+- **Secure APIs**: Apply SHA256 hash to complete key material
+
+> **Warning**: Deprecated APIs will show console warnings but continue to work for backward compatibility. The secure APIs generate different keys from the same input.
 
 ## API Reference
 
@@ -134,6 +173,26 @@ Generates a TDX quote. The quote is returned in hex format, and you can paste yo
 ##### `info(): Promise<TappdInfoResponse>`
 Retrieves server information.
 - Returns: Information about the Tappd instance
+
+### Viem Integration Functions
+
+#### `toViemAccount(deriveKeyResponse: DeriveKeyResponse)` ⚠️ **DEPRECATED**
+> **Warning**: This function has security concerns. Use `toViemAccountSecure` instead.
+
+Creates a Viem account using first 32 bytes of key material directly.
+
+#### `toViemAccountSecure(deriveKeyResponse: DeriveKeyResponse)` ✅ **RECOMMENDED**
+Creates a Viem account using SHA256 hash of complete key material for enhanced security.
+
+### Solana Integration Functions
+
+#### `toKeypair(deriveKeyResponse: DeriveKeyResponse)` ⚠️ **DEPRECATED**
+> **Warning**: This function has security concerns. Use `toKeypairSecure` instead.
+
+Creates a Solana Keypair using first 32 bytes of key material directly.
+
+#### `toKeypairSecure(deriveKeyResponse: DeriveKeyResponse)` ✅ **RECOMMENDED**
+Creates a Solana Keypair using SHA256 hash of complete key material for enhanced security.
 
 ### Types
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dstack-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DStack SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/src/__tests__/index.test.ts
+++ b/sdk/js/src/__tests__/index.test.ts
@@ -35,15 +35,29 @@ describe('TappdClient', () => {
     expect(key).toBeInstanceOf(Uint8Array)
   })
 
-  it('should able to get derive key result as uint8array with specified length', async () => {
+  it('should compare asUint8Array and asUint8Array with length', () => {
     const client = new TappdClient()
-    const result = await client.deriveKey('/', 'test')
-    const full = result.asUint8Array()
-    const key = result.asUint8Array(32)
-    expect(full).toBeInstanceOf(Uint8Array)
-    expect(key).toBeInstanceOf(Uint8Array)
-    expect(key.length).toBe(32)
-    expect(key.length).not.eq(full.length)
+    const key = {
+      key: TEST_PEM_KEY,
+      certificate_chain: [],
+      asUint8Array: (length?: number) => {
+        const content = TEST_PEM_KEY.replace(/-----BEGIN PRIVATE KEY-----/, '')
+          .replace(/-----END PRIVATE KEY-----/, '')
+          .replace(/\n/g, '');
+        const binaryDer = atob(content)
+        const max_length = length || binaryDer.length
+        const result = new Uint8Array(max_length)
+        for (let i = 0; i < max_length; i++) {
+          result[i] = binaryDer.charCodeAt(i)
+        }
+        return result
+      }
+    }
+
+    const full = key.asUint8Array()
+    const key32 = key.asUint8Array(32)
+    expect(key32.length).toBe(32)
+    expect(key32.length).not.eq(full.length)
   })
 
   it('should validate asUint8Array output with known PEM key', () => {
@@ -95,9 +109,82 @@ describe('TappdClient', () => {
     expect(resultFullHex).toBe(expectedFullHex)
   })
 
+  it('should validate deprecated vs secure API differences', async () => {
+    // Import the functions for testing
+    const { toKeypair, toKeypairSecure } = await import('../solana')
+    const { toViemAccount, toViemAccountSecure } = await import('../viem')
+
+    const mockResult = {
+      key: TEST_PEM_KEY,
+      certificate_chain: [],
+      asUint8Array: (length?: number) => {
+        const content = TEST_PEM_KEY.replace(/-----BEGIN PRIVATE KEY-----/, '')
+          .replace(/-----END PRIVATE KEY-----/, '')
+          .replace(/\n/g, '');
+        const binaryDer = atob(content)
+        const max_length = length || binaryDer.length
+        const result = new Uint8Array(max_length)
+        for (let i = 0; i < max_length; i++) {
+          result[i] = binaryDer.charCodeAt(i)
+        }
+        return result
+      }
+    }
+
+    // Test that deprecated APIs work as before (using first 32 bytes)
+    const deprecatedSolanaKeypair = toKeypair(mockResult)
+    const secureKeypair = toKeypairSecure(mockResult)
+    
+    // These should be different because deprecated uses first 32 bytes, secure uses SHA256 hash
+    expect(deprecatedSolanaKeypair.publicKey.toString()).not.toBe(secureKeypair.publicKey.toString())
+
+    const deprecatedViemAccount = toViemAccount(mockResult)
+    const secureViemAccount = toViemAccountSecure(mockResult)
+    
+    // These should be different because deprecated uses first 32 bytes, secure uses SHA256 hash
+    expect(deprecatedViemAccount.address).not.toBe(secureViemAccount.address)
+
+    // Verify deprecated API actually uses first 32 bytes (original behavior)
+    const first32Bytes = mockResult.asUint8Array(32)
+    const expectedSolanaKeypair = require('@solana/web3.js').Keypair.fromSeed(first32Bytes)
+    expect(deprecatedSolanaKeypair.publicKey.toString()).toBe(expectedSolanaKeypair.publicKey.toString())
+  })
+
   it('should able set quote hash_algorithm', async () => {
     const client = new TappdClient()
     const result = await client.tdxQuote('pure string', 'raw')
+    expect(result).toHaveProperty('quote')
+    expect(result).toHaveProperty('replayRtmrs')
+  })
+
+  it('should able to request tdx quote', async () => {
+    const client = new TappdClient()
+    // You can put computation result as report data to tdxQuote. NOTE: it should serializable by JSON.stringify
+    const result = await client.tdxQuote('some data or anything can be call by toJSON')
+    expect(result).toHaveProperty('quote')
+    expect(result).toHaveProperty('event_log')
+    expect(result.quote.substring(0, 2)).toBe('0x')
+    expect(result.event_log.substring(0, 1) === '{')
+    expect(() => JSON.parse(result.event_log)).not.toThrowError()
+    expect(result.replayRtmrs().length).toBe(4)
+  })
+
+  it('should able to get derive key result as uint8array', async () => {
+    const client = new TappdClient()
+    const result = await client.deriveKey('/', 'test')
+    const key = result.asUint8Array()
+    expect(key).toBeInstanceOf(Uint8Array)
+  })
+
+  it('should able to get derive key result as uint8array with specified length', async () => {
+    const client = new TappdClient()
+    const result = await client.deriveKey('/', 'test')
+    const full = result.asUint8Array()
+    const key = result.asUint8Array(32)
+    expect(full).toBeInstanceOf(Uint8Array)
+    expect(key).toBeInstanceOf(Uint8Array)
+    expect(key.length).toBe(32)
+    expect(key.length).not.eq(full.length)
   })
 
   it('should throw error on report_data large then 64 characters and using raw hash_algorithm', async () => {
@@ -114,5 +201,41 @@ describe('TappdClient', () => {
     const client = new TappdClient()
     const input = new Uint8Array(65).fill(0)
     expect(() => client.tdxQuote(input, 'raw')).rejects.toThrow()
+  })
+
+  it('should verify secure APIs use SHA256 hash of complete key material', async () => {
+    const { toKeypairSecure } = await import('../solana')
+    const { toViemAccountSecure } = await import('../viem')
+    const crypto = require('crypto')
+
+    const mockResult = {
+      key: TEST_PEM_KEY,
+      certificate_chain: [],
+      asUint8Array: (length?: number) => {
+        const content = TEST_PEM_KEY.replace(/-----BEGIN PRIVATE KEY-----/, '')
+          .replace(/-----END PRIVATE KEY-----/, '')
+          .replace(/\n/g, '');
+        const binaryDer = atob(content)
+        const max_length = length || binaryDer.length
+        const result = new Uint8Array(max_length)
+        for (let i = 0; i < max_length; i++) {
+          result[i] = binaryDer.charCodeAt(i)
+        }
+        return result
+      }
+    }
+
+    // Test secure Solana API
+    const secureKeypair = toKeypairSecure(mockResult)
+    const expectedHash = crypto.createHash('sha256').update(mockResult.asUint8Array()).digest()
+    const expectedSolanaKeypair = require('@solana/web3.js').Keypair.fromSeed(expectedHash)
+    expect(secureKeypair.publicKey.toString()).toBe(expectedSolanaKeypair.publicKey.toString())
+
+    // Test secure Viem API
+    const secureViemAccount = toViemAccountSecure(mockResult)
+    const expectedHex = crypto.createHash('sha256').update(mockResult.asUint8Array()).digest('hex')
+    const { privateKeyToAccount } = require('viem/accounts')
+    const expectedViemAccount = privateKeyToAccount(`0x${expectedHex}`)
+    expect(secureViemAccount.address).toBe(expectedViemAccount.address)
   })
 })

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -4,7 +4,7 @@ import http from 'http'
 import https from 'https'
 import { URL } from 'url'
 
-export const __version__ = "0.2.0"
+export const __version__ = "0.2.1"
 
 export interface DeriveKeyResponse {
   key: string

--- a/sdk/js/src/solana.ts
+++ b/sdk/js/src/solana.ts
@@ -3,12 +3,27 @@ import { Keypair } from '@solana/web3.js'
 
 import { type DeriveKeyResponse } from './index'
 
+/**
+ * @deprecated use toKeypairSecure instead. This method has security concerns.
+ * Current implementation uses raw key material without proper hashing.
+ */
 export function toKeypair(deriveKeyResponse: DeriveKeyResponse) {
+  console.warn('[DEPRECATED] toKeypair: this method has security concerns. Please use toKeypairSecure instead.')
+  // Restored original behavior: using first 32 bytes directly
+  const bytes = deriveKeyResponse.asUint8Array(32)
+  return Keypair.fromSeed(bytes)
+}
+
+/**
+ * Creates a Solana Keypair from DeriveKeyResponse using secure key derivation.
+ * This method applies SHA256 hashing to the complete key material for enhanced security.
+ */
+export function toKeypairSecure(deriveKeyResponse: DeriveKeyResponse) {
   try {
     // Get supported hash algorithm by `openssl list -digest-algorithms`, but it's not guaranteed to be supported by node.js
     const buf = crypto.createHash('sha256').update(deriveKeyResponse.asUint8Array()).digest()
     return Keypair.fromSeed(buf)
   } catch (err) {
-    throw new Error('toKeypair: missing sha256 support, please upgrade your openssl and node.js')
+    throw new Error('toKeypairSecure: missing sha256 support, please upgrade your openssl and node.js')
   }
 }

--- a/sdk/js/src/viem.ts
+++ b/sdk/js/src/viem.ts
@@ -3,12 +3,27 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 import { type DeriveKeyResponse } from './index'
 
+/**
+ * @deprecated use toViemAccountSecure instead. This method has security concerns.
+ * Current implementation uses raw key material without proper hashing.
+ */
 export function toViemAccount(deriveKeyResponse: DeriveKeyResponse) {
+  console.warn('[DEPRECATED] toViemAccount: this method has security concerns. Please use toViemAccountSecure instead.')
+  // Restored original behavior: using first 32 bytes directly
+  const hex = Array.from(deriveKeyResponse.asUint8Array(32)).map(b => b.toString(16).padStart(2, '0')).join('')
+  return privateKeyToAccount(`0x${hex}`)
+}
+
+/**
+ * Creates a Viem account from DeriveKeyResponse using secure key derivation.
+ * This method applies SHA256 hashing to the complete key material for enhanced security.
+ */
+export function toViemAccountSecure(deriveKeyResponse: DeriveKeyResponse) {
   try {
     // Get supported hash algorithm by `openssl list -digest-algorithms`, but it's not guaranteed to be supported by node.js
     const hex = crypto.createHash('sha256').update(deriveKeyResponse.asUint8Array()).digest('hex')
     return privateKeyToAccount(`0x${hex}`)
   } catch (err) {
-    throw new Error('toViemAccount: missing sha256 support, please upgrade your openssl and node.js')
+    throw new Error('toViemAccountSecure: missing sha256 support, please upgrade your openssl and node.js')
   }
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dstack-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "DStack SDK for Python"
 authors = [
     {name = "Leechael Yim", email = "yanleech@gmail.com"},

--- a/sdk/python/src/dstack_sdk/ethereum.py
+++ b/sdk/python/src/dstack_sdk/ethereum.py
@@ -1,8 +1,29 @@
 import hashlib
+import warnings
 from eth_account import Account
 
 from .tappd_client import DeriveKeyResponse
 
 def to_account(derive_key_response: DeriveKeyResponse) -> Account:
+    """
+    DEPRECATED: This method has security concerns.
+    Please use to_account_secure instead.
+    
+    Current implementation uses raw key material without proper hashing.
+    """
+    warnings.warn(
+        "to_account: this method has security concerns. "
+        "Please use to_account_secure instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    # Restored original behavior: using first 32 bytes directly
+    return Account.from_key(derive_key_response.toBytes(32))
+
+def to_account_secure(derive_key_response: DeriveKeyResponse) -> Account:
+    """
+    Creates an Ethereum account from DeriveKeyResponse using secure key derivation.
+    This method applies SHA256 hashing to the complete key material for enhanced security.
+    """
     hashed = hashlib.sha256(derive_key_response.toBytes()).digest()
     return Account.from_key(hashed)

--- a/sdk/python/src/dstack_sdk/solana.py
+++ b/sdk/python/src/dstack_sdk/solana.py
@@ -1,8 +1,29 @@
 import hashlib
+import warnings
 from solders.keypair import Keypair
 
 from .tappd_client import DeriveKeyResponse
 
 def to_keypair(derive_key_response: DeriveKeyResponse) -> Keypair:
+    """
+    DEPRECATED: This method has security concerns.
+    Please use to_keypair_secure instead.
+    
+    Current implementation uses raw key material without proper hashing.
+    """
+    warnings.warn(
+        "to_keypair: this method has security concerns. "
+        "Please use to_keypair_secure instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    # Restored original behavior: using first 32 bytes directly
+    return Keypair.from_seed(derive_key_response.toBytes(32))
+
+def to_keypair_secure(derive_key_response: DeriveKeyResponse) -> Keypair:
+    """
+    Creates a Solana Keypair from DeriveKeyResponse using secure key derivation.
+    This method applies SHA256 hashing to the complete key material for enhanced security.
+    """
     hashed = hashlib.sha256(derive_key_response.toBytes()).digest()
     return Keypair.from_seed(hashed)

--- a/sdk/python/src/dstack_sdk/tappd_client.py
+++ b/sdk/python/src/dstack_sdk/tappd_client.py
@@ -5,11 +5,15 @@ import hashlib
 import os
 import logging
 import base64
+import platform
+import urllib.request
+import urllib.parse
+import socket
 
 from pydantic import BaseModel
 import httpx
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 logger = logging.getLogger('dstack_sdk')
 
@@ -114,11 +118,11 @@ class TappdInfoResponse(BaseModel):
     public_sysinfo: bool
 
     @classmethod
-    def model_validate(cls, obj: Any) -> 'TappdInfoResponse':
+    def model_validate(cls, obj: Any, *, strict: bool | None = None, from_attributes: bool | None = None, context: Any = None) -> 'TappdInfoResponse':
         if isinstance(obj, dict) and 'tcb_info' in obj and isinstance(obj['tcb_info'], str):
             obj = dict(obj)
             obj['tcb_info'] = TcbInfo(**json.loads(obj['tcb_info']))
-        return super().model_validate(obj)
+        return super().model_validate(obj, strict=strict, from_attributes=from_attributes, context=context)
 
 
 class BaseClient:

--- a/sdk/python/tests/test_ethereum.py
+++ b/sdk/python/tests/test_ethereum.py
@@ -1,8 +1,10 @@
 import pytest
+import hashlib
 from eth_account.signers.local import LocalAccount
+from eth_account import Account
 
 from dstack_sdk import AsyncTappdClient, DeriveKeyResponse
-from dstack_sdk.ethereum import to_account
+from dstack_sdk.ethereum import to_account, to_account_secure
 
 @pytest.mark.asyncio
 async def test_async_to_keypair():
@@ -11,3 +13,33 @@ async def test_async_to_keypair():
     assert isinstance(result, DeriveKeyResponse)
     account = to_account(result)
     assert isinstance(account, LocalAccount)
+
+@pytest.mark.asyncio
+async def test_async_to_account_secure():
+    client = AsyncTappdClient()
+    result = await client.derive_key('test')
+    assert isinstance(result, DeriveKeyResponse)
+    account = to_account_secure(result)
+    assert isinstance(account, LocalAccount)
+
+@pytest.mark.asyncio
+async def test_deprecated_vs_secure_api_differences():
+    """Test that deprecated and secure APIs generate different accounts"""
+    client = AsyncTappdClient()
+    result = await client.derive_key('test')
+    
+    deprecated_account = to_account(result)
+    secure_account = to_account_secure(result)
+    
+    # Should generate different accounts
+    assert deprecated_account.address != secure_account.address
+    
+    # Verify deprecated API uses first 32 bytes
+    first_32_bytes = result.toBytes(32)
+    expected_deprecated = Account.from_key(first_32_bytes)
+    assert deprecated_account.address == expected_deprecated.address
+    
+    # Verify secure API uses SHA256 of complete key material
+    hashed = hashlib.sha256(result.toBytes()).digest()
+    expected_secure = Account.from_key(hashed)
+    assert secure_account.address == expected_secure.address

--- a/sdk/python/tests/test_solana.py
+++ b/sdk/python/tests/test_solana.py
@@ -1,8 +1,9 @@
 import pytest
+import hashlib
 from solders.keypair import Keypair
 
 from dstack_sdk import AsyncTappdClient, DeriveKeyResponse
-from dstack_sdk.solana import to_keypair
+from dstack_sdk.solana import to_keypair, to_keypair_secure
 
 @pytest.mark.asyncio
 async def test_async_to_keypair():
@@ -11,3 +12,33 @@ async def test_async_to_keypair():
     assert isinstance(result, DeriveKeyResponse)
     keypair = to_keypair(result)
     assert isinstance(keypair, Keypair)
+
+@pytest.mark.asyncio
+async def test_async_to_keypair_secure():
+    client = AsyncTappdClient()
+    result = await client.derive_key('test')
+    assert isinstance(result, DeriveKeyResponse)
+    keypair = to_keypair_secure(result)
+    assert isinstance(keypair, Keypair)
+
+@pytest.mark.asyncio
+async def test_deprecated_vs_secure_api_differences():
+    """Test that deprecated and secure APIs generate different keys"""
+    client = AsyncTappdClient()
+    result = await client.derive_key('test')
+    
+    deprecated_keypair = to_keypair(result)
+    secure_keypair = to_keypair_secure(result)
+    
+    # Should generate different keys
+    assert deprecated_keypair.pubkey() != secure_keypair.pubkey()
+    
+    # Verify deprecated API uses first 32 bytes
+    first_32_bytes = result.toBytes(32)
+    expected_deprecated = Keypair.from_seed(first_32_bytes)
+    assert deprecated_keypair.pubkey() == expected_deprecated.pubkey()
+    
+    # Verify secure API uses SHA256 of complete key material
+    hashed = hashlib.sha256(result.toBytes()).digest()
+    expected_secure = Keypair.from_seed(hashed)
+    assert secure_keypair.pubkey() == expected_secure.pubkey()


### PR DESCRIPTION
## Overview
This PR addresses a security vulnerability in key derivation functions while maintaining full backward compatibility. We introduce new secure APIs and restore the original behavior of existing APIs with deprecation warnings.

## Changes

### 🔄 API Changes
- **Restored original behavior** for existing APIs (`toKeypair`, `toViemAccount`, `to_keypair`, `to_account`)
  - Now use first 32 bytes of key material directly (same as before)
  - Added deprecation warnings to console/logs
- **Added new secure APIs** (`toKeypairSecure`, `toViemAccountSecure`, `to_keypair_secure`, `to_account_secure`)
  - Use SHA256 hash of complete key material for enhanced security
  - Follow cryptographic best practices

### 📦 Version Updates
- **JavaScript**: `@phala/dstack-sdk@0.2.1`
- **Python**: `dstack-sdk@0.2.1`

### 🔒 Security Improvements
- **Original APIs**: Use first 32 bytes directly (restored for compatibility)
- **Secure APIs**: Apply SHA256 hashing to complete key material
- **Zero breaking changes**: Existing code continues to work exactly as before

## Backward Compatibility
✅ **Fully backward compatible** - no breaking changes
✅ **Same key generation** - deprecated APIs produce identical keys as previous versions
✅ **Gradual migration** - users can migrate at their own pace

## Example Migration

### JavaScript
```typescript
// Current (works, shows warning)
import { toKeypair } from '@phala/dstack-sdk/solana'
const keypair = toKeypair(keyResponse) // ⚠️ Shows warning

// Recommended (secure, no warning)
import { toKeypairSecure } from '@phala/dstack-sdk/solana'
const keypair = toKeypairSecure(keyResponse) // ✅ Secure
```

### Python
```python
# Current (works, shows warning)
from dstack_sdk.solana import to_keypair
keypair = to_keypair(key_response)  # ⚠️ Shows warning

# Recommended (secure, no warning)  
from dstack_sdk.solana import to_keypair_secure
keypair = to_keypair_secure(key_response)  # ✅ Secure
```
