### PR TITLE
fix(gateway): move get_meta to admin API for v0.3.x

### DIFF
--- a/tproxy/rpc/proto/tproxy_rpc.proto
+++ b/tproxy/rpc/proto/tproxy_rpc.proto
@@ -91,8 +91,6 @@ service Tproxy {
   rpc RegisterCvm(RegisterCvmRequest) returns (RegisterCvmResponse) {}
   // List all ACME account URIs and the public key history of the certificates for the Content Addressable HTTPS.
   rpc AcmeInfo(google.protobuf.Empty) returns (AcmeInfoResponse) {}
-  // Summary API for inspect.
-  rpc GetMeta(google.protobuf.Empty) returns (GetMetaResponse);
 }
 
 message RenewCertResponse {
@@ -113,4 +111,6 @@ service Admin {
   rpc ReloadCert(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   // Set CAA records
   rpc SetCaa(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  // Summary API for inspect.
+  rpc GetMeta(google.protobuf.Empty) returns (GetMetaResponse);
 }

--- a/tproxy/src/main_service.rs
+++ b/tproxy/src/main_service.rs
@@ -20,7 +20,7 @@ use tokio_rustls::TlsAcceptor;
 use tproxy_rpc::TappdConfig;
 use tproxy_rpc::{
     tproxy_server::{TproxyRpc, TproxyServer},
-    AcmeInfoResponse, GetMetaResponse, RegisterCvmRequest, RegisterCvmResponse, WireGuardConfig,
+    AcmeInfoResponse, RegisterCvmRequest, RegisterCvmResponse, WireGuardConfig,
 };
 use tracing::{debug, error, info, warn};
 
@@ -491,34 +491,6 @@ impl TproxyRpc for RpcHandler {
         Ok(AcmeInfoResponse {
             account_uri,
             hist_keys: keys.into_iter().collect(),
-        })
-    }
-
-    async fn get_meta(self) -> Result<GetMetaResponse> {
-        let state = self.state.lock();
-        let handshakes = state.latest_handshakes(None)?;
-
-        // Total registered instances
-        let registered = state.state.instances.len();
-
-        // Get current timestamp
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .context("system time before Unix epoch")?
-            .as_secs();
-
-        // Count online instances (those with handshakes in last 5 minutes)
-        let online = handshakes
-            .values()
-            .filter(|(ts, _)| {
-                // Skip instances that never connected (ts == 0)
-                *ts != 0 && (now - *ts) < 300
-            })
-            .count();
-
-        Ok(GetMetaResponse {
-            registered: registered as u32,
-            online: online as u32,
         })
     }
 }


### PR DESCRIPTION
The `get_meta` API is proposed for heartbeat in the admin API. When we move `list` and `get_info` APIs to separate admin RPC, we'll need to move this API as well.

This PR is proposed for the dstack v0.3.x branch.