### PR TITLE
fix(vmm-cli): unmatched app_compose when no key provider id.

### DIFF
--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -418,7 +418,7 @@ class VmmCLI:
                            kms_enabled: bool,
                            gateway_enabled: bool,
                            local_key_provider_enabled: bool,
-                           key_provider_id: str,
+                           key_provider_id: str | None,
                            public_logs: bool,
                            public_sysinfo: bool,
                            envs: Optional[Dict],
@@ -426,6 +426,7 @@ class VmmCLI:
                            output: str,
                            ) -> None:
         """Create a new app compose file"""
+        envs = envs or {}
         app_compose = {
             "manifest_version": 2,
             "name": name,
@@ -434,7 +435,7 @@ class VmmCLI:
             "kms_enabled": kms_enabled,
             "gateway_enabled": gateway_enabled,
             "local_key_provider_enabled": local_key_provider_enabled,
-            "key_provider_id": key_provider_id,
+            "key_provider_id": key_provider_id or "",
             "public_logs": public_logs,
             "public_sysinfo": public_sysinfo,
             "allowed_envs": [k for k in envs.keys()],


### PR DESCRIPTION
When deploying KMS without the `key_provider_id`, dstack-utils returns an error:

```
dstack-prepare.sh[412]: 2025-06-23T15:13:32.575049Z  INFO cmd_lib::builtins: Mounting host-shared
dstack-prepare.sh[412]: 2025-06-23T15:13:32.589631Z  INFO cmd_lib::builtins: Copying host-shared files
dstack-prepare.sh[412]: 2025-06-23T15:13:32.601762Z  INFO cmd_lib::builtins: Unmounting host-shared
dstack-prepare.sh[412]: Error: Failed to parse json
dstack-prepare.sh[412]: Caused by:
dstack-prepare.sh[412]:     invalid type: null, expected a string at line 9 column 27
[FAILED] Failed to start DStack Guest Preparation Service.
```

Fixed it by setting `key_provider_id` to an empty string when it's `None` in vmm-cli.py