### PR TITLE
sdk: Remove rootfs_hash from TcbInfo

### DIFF
--- a/sdk/go/dstack/client.go
+++ b/sdk/go/dstack/client.go
@@ -48,13 +48,12 @@ type EventLog struct {
 
 // Represents the TCB information
 type TcbInfo struct {
-	Mrtd       string     `json:"mrtd"`
-	RootfsHash string     `json:"rootfs_hash"`
-	Rtmr0      string     `json:"rtmr0"`
-	Rtmr1      string     `json:"rtmr1"`
-	Rtmr2      string     `json:"rtmr2"`
-	Rtmr3      string     `json:"rtmr3"`
-	EventLog   []EventLog `json:"event_log"`
+	Mrtd     string     `json:"mrtd"`
+	Rtmr0    string     `json:"rtmr0"`
+	Rtmr1    string     `json:"rtmr1"`
+	Rtmr2    string     `json:"rtmr2"`
+	Rtmr3    string     `json:"rtmr3"`
+	EventLog []EventLog `json:"event_log"`
 }
 
 // Represents the response from an info request

--- a/sdk/go/tappd/client.go
+++ b/sdk/go/tappd/client.go
@@ -78,13 +78,12 @@ type EventLog struct {
 
 // Represents the TCB information
 type TcbInfo struct {
-	Mrtd       string     `json:"mrtd"`
-	RootfsHash string     `json:"rootfs_hash"`
-	Rtmr0      string     `json:"rtmr0"`
-	Rtmr1      string     `json:"rtmr1"`
-	Rtmr2      string     `json:"rtmr2"`
-	Rtmr3      string     `json:"rtmr3"`
-	EventLog   []EventLog `json:"event_log"`
+	Mrtd     string     `json:"mrtd"`
+	Rtmr0    string     `json:"rtmr0"`
+	Rtmr1    string     `json:"rtmr1"`
+	Rtmr2    string     `json:"rtmr2"`
+	Rtmr3    string     `json:"rtmr3"`
+	EventLog []EventLog `json:"event_log"`
 }
 
 // Represents the response from an info request

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -28,7 +28,6 @@ export interface EventLog {
 
 export interface TcbInfo {
   mrtd: string
-  rootfs_hash: string
   rtmr0: string
   rtmr1: string
   rtmr2: string

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -91,7 +91,6 @@ class EventLog(BaseModel):
 
 class TcbInfo(BaseModel):
     mrtd: str
-    rootfs_hash: str
     rtmr0: str
     rtmr1: str
     rtmr2: str

--- a/sdk/rust/src/dstack_client.rs
+++ b/sdk/rust/src/dstack_client.rs
@@ -174,8 +174,6 @@ impl InfoResponse {
 pub struct TcbInfo {
     /// The measurement root of trust
     pub mrtd: String,
-    /// The hash of the root filesystem
-    pub rootfs_hash: String,
     /// The value of RTMR0 (Runtime Measurement Register 0)
     pub rtmr0: String,
     /// The value of RTMR1 (Runtime Measurement Register 1)


### PR DESCRIPTION
It was removed from latest dstack.