### PR TITLE
sdk: Remove more fields in AppInfo

### DIFF
--- a/sdk/curl/api-tappd.md
+++ b/sdk/curl/api-tappd.md
@@ -189,10 +189,7 @@ curl --unix-socket /var/run/tappd.sock http://localhost/prpc/Tappd.Info
   "app_cert": "<certificate-string>",
   "tcb_info": "<tcb-info-string>",
   "app_name": "my-app",
-  "public_logs": true,
-  "public_sysinfo": true,
   "device_id": "<hex-encoded-device-id>",
-  "mr_aggregated": "<hex-encoded-mr-aggregated>",
   "os_image_hash": "<hex-encoded-os-image-hash>",
   "key_provider_info": "<key-provider-info-string>",
   "compose_hash": "<hex-encoded-compose-hash>"

--- a/sdk/curl/api.md
+++ b/sdk/curl/api.md
@@ -154,10 +154,7 @@ curl --unix-socket /var/run/dstack.sock http://dstack/Info
   "app_cert": "<certificate-string>",
   "tcb_info": "<tcb-info-string>",
   "app_name": "my-app",
-  "public_logs": true,
-  "public_sysinfo": true,
   "device_id": "<hex-encoded-device-id>",
-  "mr_aggregated": "<hex-encoded-mr-aggregated>",
   "os_image_hash": "<hex-encoded-os-image-hash>",
   "key_provider_info": "<key-provider-info-string>",
   "compose_hash": "<hex-encoded-compose-hash>"

--- a/sdk/go/dstack/client.go
+++ b/sdk/go/dstack/client.go
@@ -63,10 +63,7 @@ type InfoResponse struct {
 	AppCert         string `json:"app_cert"`
 	TcbInfo         string `json:"tcb_info"`
 	AppName         string `json:"app_name"`
-	PublicLogs      bool   `json:"public_logs"`
-	PublicSysinfo   bool   `json:"public_sysinfo"`
 	DeviceID        string `json:"device_id"`
-	MrAggregated    string `json:"mr_aggregated"`
 	KeyProviderInfo string `json:"key_provider_info"`
 	OsImageHash     string `json:"os_image_hash"`
 	ComposeHash     string `json:"compose_hash"`

--- a/sdk/go/tappd/client.go
+++ b/sdk/go/tappd/client.go
@@ -88,13 +88,11 @@ type TcbInfo struct {
 
 // Represents the response from an info request
 type TappdInfoResponse struct {
-	AppID         string  `json:"app_id"`
-	InstanceID    string  `json:"instance_id"`
-	AppCert       string  `json:"app_cert"`
-	TcbInfo       TcbInfo `json:"tcb_info"`
-	AppName       string  `json:"app_name"`
-	PublicLogs    bool    `json:"public_logs"`
-	PublicSysinfo bool    `json:"public_sysinfo"`
+	AppID      string  `json:"app_id"`
+	InstanceID string  `json:"instance_id"`
+	AppCert    string  `json:"app_cert"`
+	TcbInfo    TcbInfo `json:"tcb_info"`
+	AppName    string  `json:"app_name"`
 }
 
 const INIT_MR = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -339,13 +337,11 @@ func (c *TappdClient) Info(ctx context.Context) (*TappdInfoResponse, error) {
 	}
 
 	var response struct {
-		TcbInfo       string `json:"tcb_info"`
-		AppID         string `json:"app_id"`
-		InstanceID    string `json:"instance_id"`
-		AppCert       string `json:"app_cert"`
-		AppName       string `json:"app_name"`
-		PublicLogs    bool   `json:"public_logs"`
-		PublicSysinfo bool   `json:"public_sysinfo"`
+		TcbInfo    string `json:"tcb_info"`
+		AppID      string `json:"app_id"`
+		InstanceID string `json:"instance_id"`
+		AppCert    string `json:"app_cert"`
+		AppName    string `json:"app_name"`
 	}
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, err
@@ -357,12 +353,10 @@ func (c *TappdClient) Info(ctx context.Context) (*TappdInfoResponse, error) {
 	}
 
 	return &TappdInfoResponse{
-		AppID:         response.AppID,
-		InstanceID:    response.InstanceID,
-		AppCert:       response.AppCert,
-		TcbInfo:       tcbInfo,
-		AppName:       response.AppName,
-		PublicLogs:    response.PublicLogs,
-		PublicSysinfo: response.PublicSysinfo,
+		AppID:      response.AppID,
+		InstanceID: response.InstanceID,
+		AppCert:    response.AppCert,
+		TcbInfo:    tcbInfo,
+		AppName:    response.AppName,
 	}, nil
 }

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -41,10 +41,7 @@ export interface InfoResponse {
   app_cert: string
   tcb_info: TcbInfo
   app_name: string
-  public_logs: boolean
-  public_sysinfo: boolean
   device_id: string
-  mr_aggregated: string
   os_image_hash: string
   key_provider_info: string
   compose_hash: string

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -104,10 +104,7 @@ class InfoResponse(BaseModel):
     app_cert: str
     tcb_info: TcbInfo
     app_name: str
-    public_logs: bool
-    public_sysinfo: bool
     device_id: str
-    mr_aggregated: str
     os_image_hash: str
     key_provider_info: str
     compose_hash: str

--- a/sdk/rust/src/dstack_client.rs
+++ b/sdk/rust/src/dstack_client.rs
@@ -143,14 +143,8 @@ pub struct InfoResponse {
     pub tcb_info: TcbInfo,
     /// The name of the application
     pub app_name: String,
-    /// Whether public logs are enabled
-    pub public_logs: bool,
-    /// Whether public system information is enabled
-    pub public_sysinfo: bool,
     /// The device identifier
     pub device_id: String,
-    /// The aggregated measurement register value
-    pub mr_aggregated: String,
     /// The hash of the OS image
     pub os_image_hash: String,
     /// Information about the key provider

--- a/sdk/rust/tests/test_client.rs
+++ b/sdk/rust/tests/test_client.rs
@@ -66,3 +66,9 @@ async fn test_report_data() {
     };
     assert_eq!(&quote_report.report_data[..], &expected[..]);
 }
+
+#[tokio::test]
+async fn test_info() {
+    let client = AsyncDstackClient::new(None);
+    let _info = client.info().await.unwrap();
+}


### PR DESCRIPTION
These fields no longer exists in the latest API so remove it. 