### PR TITLE
cvm: disable workqueue for luks

### DIFF
--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -471,7 +471,7 @@ impl<'a> Stage0<'a> {
 
             info "Opening the device";
             echo -n $disk_crypt_key |
-                cryptsetup luksOpen --type luks2 -d- $root_hd $name;
+                cryptsetup --perf-no_read_workqueue --perf-no_write_workqueue --persistent open --type luks2 -d- $root_hd $name;
         }.or(Err(anyhow!("Failed to setup luks volume")))?;
         Ok(())
     }


### PR DESCRIPTION
This should improve the disk IO performance according to https://wiki.archlinux.org/title/Dm-crypt/Specialties#Disable_workqueue_for_increased_solid_state_drive_(SSD)_performance