### PR TITLE
gw: Add RPC for Gateway Info

### DIFF
--- a/gateway/gateway.toml
+++ b/gateway/gateway.toml
@@ -61,6 +61,7 @@ connect_top_n = 3
 localhost_enabled = false
 app_address_ns_prefix = "_dstack-app-address"
 workers = 32
+external_port = 443
 
 [core.proxy.timeouts]
 # Timeout for establishing a connection to the target app.

--- a/gateway/rpc/proto/gateway_rpc.proto
+++ b/gateway/rpc/proto/gateway_rpc.proto
@@ -140,14 +140,23 @@ message GatewayState {
   repeated GatewayNodeInfo nodes = 1;
   repeated AppInstanceInfo apps = 2;
 }
+message InfoResponse {
+  // The base domain of the ZT-HTTPS
+  string base_domain = 1;
+  // The external port of the ZT-HTTPS
+  uint32 external_port = 2;
+}
 
 service Gateway {
+
   // Register a new proxied CVM.
   rpc RegisterCvm(RegisterCvmRequest) returns (RegisterCvmResponse) {}
   // List all ACME account URIs and the public key history of the certificates for the Content Addressable HTTPS.
   rpc AcmeInfo(google.protobuf.Empty) returns (AcmeInfoResponse) {}
   // Merge state from other Gateway instances.
   rpc UpdateState(GatewayState) returns (google.protobuf.Empty) {}
+  // Get the gateway info
+  rpc Info(google.protobuf.Empty) returns (InfoResponse) {}
 }
 
 message RenewCertResponse {

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -70,6 +70,7 @@ pub struct ProxyConfig {
     pub tls_crypto_provider: CryptoProvider,
     pub tls_versions: Vec<TlsVersion>,
     pub base_domain: String,
+    pub external_port: u16,
     pub listen_addr: Ipv4Addr,
     pub listen_port: u16,
     pub agent_port: u16,

--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -13,8 +13,8 @@ use certbot::{CertBot, WorkDir};
 use cmd_lib::run_cmd as cmd;
 use dstack_gateway_rpc::{
     gateway_server::{GatewayRpc, GatewayServer},
-    AcmeInfoResponse, GatewayState, GuestAgentConfig, QuotedPublicKey, RegisterCvmRequest,
-    RegisterCvmResponse, WireGuardConfig, WireGuardPeer,
+    AcmeInfoResponse, GatewayState, GuestAgentConfig, InfoResponse, QuotedPublicKey,
+    RegisterCvmRequest, RegisterCvmResponse, WireGuardConfig, WireGuardPeer,
 };
 use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, RawQuoteArgs};
 use fs_err as fs;
@@ -764,6 +764,14 @@ impl GatewayRpc for RpcHandler {
             .update_state(nodes, apps)
             .context("failed to update state")?;
         Ok(())
+    }
+
+    async fn info(self) -> Result<InfoResponse> {
+        let state = self.state.lock();
+        Ok(InfoResponse {
+            base_domain: state.config.proxy.base_domain.clone(),
+            external_port: state.config.proxy.external_port as u32,
+        })
     }
 }
 


### PR DESCRIPTION
With this PR, CVM can get the zt-https domain in the pre launch script:

```
(base) jovyan@tdx:~$ ssh root@localhost
██████╗ ███████╗████████╗ █████╗  ██████╗██╗  ██╗    ████████╗███████╗███████╗     ██████╗ ███████╗
██╔══██╗██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝    ╚══██╔══╝██╔════╝██╔════╝    ██╔═══██╗██╔════╝
██║  ██║███████╗   ██║   ███████║██║     █████╔╝        ██║   █████╗  █████╗      ██║   ██║███████╗
██║  ██║╚════██║   ██║   ██╔══██║██║     ██╔═██╗        ██║   ██╔══╝  ██╔══╝      ██║   ██║╚════██║
██████╔╝███████║   ██║   ██║  ██║╚██████╗██║  ██╗       ██║   ███████╗███████╗    ╚██████╔╝███████║
╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝       ╚═╝   ╚══════╝╚══════╝     ╚═════╝ ╚══════╝

Welcome to Dstack!
root@tdx:~# jq -r .gateway_urls[0] /dstack/.host-shared/.sys-config.json   
https://tproxy.1022.kvin.wang:12002
root@tdx:~# curl -k https://tproxy.1022.kvin.wang:12002/prpc/Tproxy.Info
{"base_domain":"app.kvin.wang","external_port":12004}root@tdx:~# 
root@tdx:~# 
```