### PR TITLE
jssdk: Add back TappdClient for compatibility

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dstack-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Dstack SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dstack-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Dstack SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/src/__tests__/index.test.ts
+++ b/sdk/js/src/__tests__/index.test.ts
@@ -1,12 +1,17 @@
 import { expect, describe, it, vi } from 'vitest'
-import { DstackClient } from '../index'
+import { DstackClient, TappdClient } from '../index'
 
 describe('DstackClient', () => {
-  it('should able to derive key', async () => {
-    const client = new DstackClient()
+  it('should able to derive key in TappdClient', async () => {
+    const client = new TappdClient()
     const result = await client.deriveKey('/', 'test')
     expect(result).toHaveProperty('key')
     expect(result).toHaveProperty('certificate_chain')
+  })
+
+  it('should throws error in DstackClient', async () => {
+    const client = new DstackClient()
+    await expect(() => client.deriveKey('/', 'test')).rejects.toThrow('deriveKey is deprecated, please use getKey instead.')
   })
 
   it('should able to get key', async () => {
@@ -141,9 +146,9 @@ describe('DstackClient', () => {
     expect(typeof isReachable).toBe('boolean')
   })
 
-  describe('deprecated methods', () => {
+  describe('deprecated methods with TappdClient', () => {
     it('should support deprecated deriveKey method with warning', async () => {
-      const client = new DstackClient()
+      const client = new TappdClient()
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       const result = await client.deriveKey('/', 'test')
@@ -155,7 +160,7 @@ describe('DstackClient', () => {
     })
 
     it('should support deprecated tdxQuote method with warning', async () => {
-      const client = new DstackClient()
+      const client = new TappdClient()
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       const result = await client.tdxQuote('test data')
@@ -167,13 +172,63 @@ describe('DstackClient', () => {
     })
 
     it('should support tdxQuote with hash algorithm parameter', async () => {
-      const client = new DstackClient()
+      const client = new TappdClient()
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       const result = await client.tdxQuote('test data', 'sha256')
       expect(result).toHaveProperty('quote')
       expect(result).toHaveProperty('event_log')
       expect(consoleSpy).toHaveBeenCalledWith('tdxQuote is deprecated, please use getQuote instead')
+      
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('deprecated methods with DstackClient', () => {
+    it('should throws error in deriveKey method', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      await expect(() => client.deriveKey('/', 'test')).rejects.toThrow('deriveKey is deprecated, please use getKey instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should throws error in tdxQuote method without hash algorithm parameter', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      await expect(() => client.tdxQuote('test data')).rejects.toThrow('tdxQuote only supports raw hash algorithm.')
+
+      consoleSpy.mockRestore()
+    })
+
+    it("should throws error in tdxQuote method with hash algorithm parameter other than raw", async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      await expect(() => client.tdxQuote('test data', 'sha256')).rejects.toThrow('tdxQuote only supports raw hash algorithm.')
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should able to get quote with plain report_data in tdxQuote method with warning', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.tdxQuote('test data', "raw")
+      expect(result).toHaveProperty('quote')
+      expect(result).toHaveProperty('event_log')
+      expect(consoleSpy).toHaveBeenCalledWith('tdxQuote is deprecated, please use getQuote instead')
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should throws error in tdxQuote with hash algorithm parameter', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      await expect(() => client.tdxQuote('test data', 'sha256')).rejects.toThrow('tdxQuote only supports raw hash algorithm.')
       
       consoleSpy.mockRestore()
     })

--- a/sdk/js/src/__tests__/index.test.ts
+++ b/sdk/js/src/__tests__/index.test.ts
@@ -4,6 +4,13 @@ import { DstackClient } from '../index'
 describe('DstackClient', () => {
   it('should able to derive key', async () => {
     const client = new DstackClient()
+    const result = await client.deriveKey('/', 'test')
+    expect(result).toHaveProperty('key')
+    expect(result).toHaveProperty('certificate_chain')
+  })
+
+  it('should able to get key', async () => {
+    const client = new DstackClient()
     const result = await client.getKey('/', 'test')
     expect(result).toHaveProperty('key')
     expect(result).toHaveProperty('signature_chain')
@@ -141,7 +148,7 @@ describe('DstackClient', () => {
       
       const result = await client.deriveKey('/', 'test')
       expect(result).toHaveProperty('key')
-      expect(result).toHaveProperty('signature_chain')
+      expect(result).toHaveProperty('certificate_chain')
       expect(consoleSpy).toHaveBeenCalledWith('deriveKey is deprecated, please use getKey instead')
       
       consoleSpy.mockRestore()

--- a/sdk/js/src/__tests__/solana.test.ts
+++ b/sdk/js/src/__tests__/solana.test.ts
@@ -1,15 +1,96 @@
-import { expect, describe, it } from 'vitest'
+import crypto from 'crypto'
+import { expect, describe, it, vi } from 'vitest'
 import { Keypair } from '@solana/web3.js'
 
-import { DstackClient } from '../index'
-import { toKeypair } from '../solana'
+import { DstackClient, TappdClient } from '../index'
+import { toKeypair, toKeypairSecure } from '../solana'
 
 describe('solana support', () => {
-  it('should able to get keypair from deriveKey', async () => {
-    const client = new DstackClient()
-    const result = await client.getKey('/', 'test')
-    const keypair = toKeypair(result)
-    expect(keypair).toBeInstanceOf(Keypair)
-    console.log(keypair.publicKey.toBase58())
+  describe('toKeypair (legacy)', () => {
+    it('should able to get keypair from getKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const result = await client.getKey('/', 'test')
+      const keypair = toKeypair(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+    })
+
+    it('should able to get keypair from deriveKey with TappdClient', async () => {
+      const client = new TappdClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.deriveKey('/', 'test')
+      const keypair = toKeypair(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+      expect(consoleSpy).toHaveBeenCalledWith('toKeypair: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should able to get keypair from getTlsKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.getTlsKey()
+      const keypair = toKeypair(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+      expect(consoleSpy).toHaveBeenCalledWith('toKeypair: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('toKeypairSecure', () => {
+    it('should able to get keypair from getKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const result = await client.getKey('/', 'test')
+      const keypair = toKeypairSecure(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+    })
+
+    it('should able to get keypair from deriveKey with TappdClient', async () => {
+      const client = new TappdClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.deriveKey('/', 'test')
+      const keypair = toKeypairSecure(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+      expect(consoleSpy).toHaveBeenCalledWith('toKeypairSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should able to get keypair from getTlsKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.getTlsKey()
+      const keypair = toKeypairSecure(result)
+      expect(keypair).toBeInstanceOf(Keypair)
+      expect(keypair.secretKey.length).toBe(64)
+      expect(consoleSpy).toHaveBeenCalledWith('toKeypairSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should throw error when sha256 is not supported', async () => {
+      const client = new DstackClient()
+      const result = await client.getTlsKey()
+      
+      // Mock crypto.createHash to simulate missing sha256 support
+      const originalCreateHash = crypto.createHash
+      crypto.createHash = () => {
+        throw new Error('sha256 not supported')
+      }
+      
+      expect(() => toKeypairSecure(result)).toThrow('toKeypairSecure: missing sha256 support')
+      
+      // Restore original createHash
+      crypto.createHash = originalCreateHash
+    })
   })
 })

--- a/sdk/js/src/__tests__/viem.test.ts
+++ b/sdk/js/src/__tests__/viem.test.ts
@@ -1,15 +1,106 @@
-import { expect, describe, it } from 'vitest'
-import { DstackClient } from '../index'
-import { toViemAccount } from '../viem'
+import crypto from 'crypto'
+import { expect, describe, it, vi } from 'vitest'
+import { DstackClient, TappdClient } from '../index'
+import { toViemAccount, toViemAccountSecure } from '../viem'
 
 describe('viem support', () => {
-  it('should able to get account from getKey', async () => {
-    const client = new DstackClient()
-    const result = await client.getKey('/', 'test')
-    const account = toViemAccount(result)
+  describe('toViemAccount (legacy)', () => {
+    it('should able to get account from getKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const result = await client.getKey('/', 'test')
+      const account = toViemAccount(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+    })
 
-    expect(account.source).toBe('privateKey')
-    expect(typeof account.sign).toBe('function')
-    expect(typeof account.signMessage).toBe('function')
+    it('should able to get account from deriveKey with TappdClient', async () => {
+      const client = new TappdClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.deriveKey('/', 'test')
+      const account = toViemAccount(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+      expect(consoleSpy).toHaveBeenCalledWith('toViemAccount: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should able to get account from getTlsKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.getTlsKey()
+      const account = toViemAccount(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+      expect(consoleSpy).toHaveBeenCalledWith('toViemAccount: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('toViemAccountSecure', () => {
+    it('should able to get account from getKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const result = await client.getKey('/', 'test')
+      const account = toViemAccountSecure(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+    })
+
+    it('should able to get account from deriveKey with TappdClient', async () => {
+      const client = new TappdClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.deriveKey('/', 'test')
+      const account = toViemAccountSecure(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+      expect(consoleSpy).toHaveBeenCalledWith('toViemAccountSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should able to get account from getTlsKey with DstackClient', async () => {
+      const client = new DstackClient()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const result = await client.getTlsKey()
+      const account = toViemAccountSecure(result)
+  
+      expect(account.source).toBe('privateKey')
+      expect(typeof account.sign).toBe('function')
+      expect(typeof account.signMessage).toBe('function')
+      expect(consoleSpy).toHaveBeenCalledWith('toViemAccountSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('should throw error when sha256 is not supported', async () => {
+      const client = new DstackClient()
+      const result = await client.getTlsKey()
+      
+      // Mock crypto.createHash to simulate missing sha256 support
+      const originalCreateHash = crypto.createHash
+      crypto.createHash = () => {
+        throw new Error('sha256 not supported')
+      }
+      
+      expect(() => toViemAccountSecure(result)).toThrow('toViemAccountSecure: missing sha256 support')
+      
+      // Restore original createHash
+      crypto.createHash = originalCreateHash
+    })
   })
 })

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -5,6 +5,8 @@ export { getComposeHash } from './get-compose-hash'
 export { verifyEnvEncryptPublicKey } from './verify-env-encrypt-public-key'
 
 export interface GetTlsKeyResponse {
+  __name__: Readonly<'GetTlsKeyResponse'>
+
   key: string
   certificate_chain: string[]
 
@@ -12,6 +14,8 @@ export interface GetTlsKeyResponse {
 }
 
 export interface GetKeyResponse {
+  __name__: Readonly<'GetKeyResponse'>
+
   key: Uint8Array
   signature_chain: Uint8Array[]
 }
@@ -150,7 +154,8 @@ export class DstackClient {
     const result = await send_rpc_request<{ key: string, signature_chain: string[] }>(this.endpoint, '/GetKey', payload)
     return Object.freeze({
       key: new Uint8Array(Buffer.from(result.key, 'hex')),
-      signature_chain: result.signature_chain.map(sig => new Uint8Array(Buffer.from(sig, 'hex')))
+      signature_chain: result.signature_chain.map(sig => new Uint8Array(Buffer.from(sig, 'hex'))),
+      __name__: 'GetKeyResponse',
     })
   }
 
@@ -174,12 +179,12 @@ export class DstackClient {
     }
     const payload = JSON.stringify(raw)
     const result = await send_rpc_request<GetTlsKeyResponse>(this.endpoint, '/GetTlsKey', payload)
-    Object.defineProperty(result, 'asUint8Array', {
-      get: () => (length?: number) => x509key_to_uint8array(result.key, length),
-      enumerable: true,
-      configurable: false,
+    const asUint8Array = (length?: number) => x509key_to_uint8array(result.key, length)
+    return Object.freeze({
+      ...result,
+      asUint8Array,
+      __name__: 'GetTlsKeyResponse',
     })
-    return Object.freeze(result)
   }
 
   async getQuote(report_data: string | Buffer | Uint8Array): Promise<GetQuoteResponse> {
@@ -303,12 +308,12 @@ export class TappdClient extends DstackClient {
     }
     const payload = JSON.stringify(raw)
     const result = await send_rpc_request<GetTlsKeyResponse>(this.endpoint, '/prpc/Tappd.DeriveKey', payload)
-    Object.defineProperty(result, 'asUint8Array', {
-      get: () => (length?: number) => x509key_to_uint8array(result.key, length),
-      enumerable: true,
-      configurable: false,
+    const asUint8Array = (length?: number) => x509key_to_uint8array(result.key, length)
+    return Object.freeze({
+      ...result,
+      asUint8Array,
+      __name__: 'GetTlsKeyResponse',
     })
-    return Object.freeze(result)
   }
 
   /**

--- a/sdk/js/src/solana.ts
+++ b/sdk/js/src/solana.ts
@@ -1,6 +1,37 @@
-import { type GetKeyResponse } from './index'
+import crypto from 'crypto'
+import { type GetKeyResponse, type GetTlsKeyResponse } from './index'
 import { Keypair } from '@solana/web3.js'
 
-export function toKeypair(keyResponse: GetKeyResponse) {
+/**
+ * @deprecated use toKeypairSecure instead. This method has security concerns.
+ * Current implementation uses raw key material without proper hashing.
+ */
+export function toKeypair(keyResponse: GetTlsKeyResponse | GetKeyResponse) {
+  // Keep legacy behavior for GetTlsKeyResponse, but with warning.
+  if (keyResponse.__name__ === 'GetTlsKeyResponse') {
+    console.warn('toKeypair: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+    // Restored original behavior: using first 32 bytes directly
+    const bytes = keyResponse.asUint8Array(32)
+    return Keypair.fromSeed(bytes)
+  }
+  return Keypair.fromSeed(keyResponse.key)
+}
+
+/**
+ * Creates a Solana Keypair from DeriveKeyResponse using secure key derivation.
+ * This method applies SHA256 hashing to the complete key material for enhanced security.
+ */
+export function toKeypairSecure(keyResponse: GetTlsKeyResponse | GetKeyResponse) {
+  // Keep legacy behavior for GetTlsKeyResponse, but with warning.
+  if (keyResponse.__name__ === 'GetTlsKeyResponse') {
+    try {
+      console.warn('toKeypairSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+      // Get supported hash algorithm by `openssl list -digest-algorithms`, but it's not guaranteed to be supported by node.js
+      const buf = crypto.createHash('sha256').update(keyResponse.asUint8Array()).digest()
+      return Keypair.fromSeed(buf)
+    } catch (err) {
+      throw new Error('toKeypairSecure: missing sha256 support, please upgrade your openssl and node.js')
+    }
+  }
   return Keypair.fromSeed(keyResponse.key)
 }

--- a/sdk/js/src/viem.ts
+++ b/sdk/js/src/viem.ts
@@ -1,7 +1,38 @@
-import { type GetKeyResponse } from './index'
+import crypto from 'crypto'
+import { type GetKeyResponse, type GetTlsKeyResponse } from './index'
 import { privateKeyToAccount } from 'viem/accounts'
 
-export function toViemAccount(keyResponse: GetKeyResponse) {
+/**
+ * @deprecated use toViemAccountSecure instead. This method has security concerns.
+ * Current implementation uses raw key material without proper hashing.
+ */
+export function toViemAccount(keyResponse: GetKeyResponse | GetTlsKeyResponse) {
+  // Keep legacy behavior for GetTlsKeyResponse, but with warning.
+  if (keyResponse.__name__ === 'GetTlsKeyResponse') {
+    console.warn('toViemAccount: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+    const hex = Array.from(keyResponse.asUint8Array(32)).map(b => b.toString(16).padStart(2, '0')).join('')
+    return privateKeyToAccount(`0x${hex}`)
+  }
+  const hex = Array.from(keyResponse.key).map(b => b.toString(16).padStart(2, '0')).join('')
+  return privateKeyToAccount(`0x${hex}`)
+}
+
+/**
+ * Creates a Viem account from DeriveKeyResponse using secure key derivation.
+ * This method applies SHA256 hashing to the complete key material for enhanced security.
+ */
+export function toViemAccountSecure(keyResponse: GetKeyResponse | GetTlsKeyResponse) {
+  // Keep legacy behavior for GetTlsKeyResponse, but with warning.
+  if (keyResponse.__name__ === 'GetTlsKeyResponse') {
+    console.warn('toViemAccountSecure: Please don\'t use `deriveKey` method to get key, use `getKey` instead.')
+    try {
+      // Get supported hash algorithm by `openssl list -digest-algorithms`, but it's not guaranteed to be supported by node.js
+      const hex = crypto.createHash('sha256').update(keyResponse.asUint8Array()).digest('hex')
+      return privateKeyToAccount(`0x${hex}`)
+    } catch (err) {
+      throw new Error('toViemAccountSecure: missing sha256 support, please upgrade your openssl and node.js')
+    }
+  }
   const hex = Array.from(keyResponse.key).map(b => b.toString(16).padStart(2, '0')).join('')
   return privateKeyToAccount(`0x${hex}`)
 }


### PR DESCRIPTION
This PR adds backward compatibility with the refreshed TappdClient implementation by accessing the old tappd.sock in the JS SDK. It also ensures smooth migration from v0.1.x and v0.2.x of the JS SDK.

To use the compatible APIs, the app needs to mount both `/var/run/tappd.sock` and `/var/run/dstack.sock` into the container simultaneously.

Example docker-compose file:
```yaml
services:
  jupyter:
    image: quay.io/jupyter/base-notebook
    volumes:
      - /var/run/tappd.sock:/var/run/tappd.sock
      - /var/run/dstack.sock:/var/run/dstack.sock
```

JS usage:
```js
const client = new TappdClient();
const key = await client.deriveKey("key/path");
const privateKey = await webcrypto.subtle.importKey(
  "pkcs8",
  key.asUint8Array(),
  {
    name: "ECDH",
    namedCurve: "P-256"
  },
  true,
  ["deriveKey"]
);
```