### PR TITLE
Make KMS configurable

### DIFF
--- a/kms/dstack-app/compose-dev.yaml
+++ b/kms/dstack-app/compose-dev.yaml
@@ -7,7 +7,7 @@ services:
         WORKDIR /app
 
         RUN apk add --no-cache git
-        RUN git clone https://github.com/Dstack-TEE/dstack.git && \
+        RUN git clone ${GIT_REPOSITORY} && \
             cd dstack && \
             git checkout ${GIT_REV}
         WORKDIR /app/dstack/kms/auth-eth

--- a/kms/dstack-app/deploy-to-vmm.sh
+++ b/kms/dstack-app/deploy-to-vmm.sh
@@ -32,8 +32,14 @@ else
 # The URL of the dstack app image download URL
 # IMAGE_DOWNLOAD_URL=https://files.kvin.wang/images/mr_{OS_IMAGE_HASH}.tar.gz
 
+# Image hash verification feature flag
+# VERIFY_IMAGE=true
+
 # The URL of the Ethereum RPC service
 ETH_RPC_URL=https://rpc.phala.network
+
+# The Git repository to deploy
+# GIT_REPOSITORY=https://github.com/Dstack-TEE/dstack.git
 
 # The Git revision to deploy
 GIT_REV=HEAD
@@ -56,6 +62,8 @@ required_env_vars=(
   "KMS_CONTRACT_ADDR"
   "ETH_RPC_URL"
   "IMAGE_DOWNLOAD_URL"
+  "VERIFY_IMAGE"
+  "GIT_REPOSITORY"
 )
 
 for var in "${required_env_vars[@]}"; do
@@ -85,6 +93,8 @@ subvar KMS_CONTRACT_ADDR
 subvar GIT_REV
 subvar IMAGE_DOWNLOAD_URL
 subvar ADMIN_TOKEN_HASH
+subvar VERIFY_IMAGE
+subvar GIT_REPOSITORY
 
 echo "Docker compose file:"
 cat "$COMPOSE_TMP"

--- a/kms/dstack-app/deploy-to-vmm.sh
+++ b/kms/dstack-app/deploy-to-vmm.sh
@@ -33,13 +33,13 @@ else
 # IMAGE_DOWNLOAD_URL=https://files.kvin.wang/images/mr_{OS_IMAGE_HASH}.tar.gz
 
 # Image hash verification feature flag
-# VERIFY_IMAGE=true
+VERIFY_IMAGE=true
 
 # The URL of the Ethereum RPC service
 ETH_RPC_URL=https://rpc.phala.network
 
 # The Git repository to deploy
-# GIT_REPOSITORY=https://github.com/Dstack-TEE/dstack.git
+GIT_REPOSITORY=https://github.com/Dstack-TEE/dstack.git
 
 # The Git revision to deploy
 GIT_REV=HEAD

--- a/kms/dstack-app/entrypoint.sh
+++ b/kms/dstack-app/entrypoint.sh
@@ -6,7 +6,7 @@ cat <<EOF > ./kms.toml
 admin_token_hash = "${ADMIN_TOKEN_HASH}"
 
 [core.image]
-verify = true
+verify = ${VERIFY_IMAGE}
 cache_dir = "./images"
 download_url = "${IMAGE_DOWNLOAD_URL}"
 download_timeout = "2m"


### PR DESCRIPTION
Hi! I'm Tei from Sunnyside Labs.

This PR adds configuration options for running KMS using docker compose and run script.
- `VERIFY_IMAGE`: Allow disabling image hash verification feature to use custom dstack OS image.
- `GIT_REPOSITORY`: Allow to compile and run KMS from forked repository.

I had to disable `verify` option to run my custom dstack OS image. And to apply & test this change, I needed to specify my forked repository in the docker compose file.
This change is backward compatible and does not affect existing behavior unless configured explicitly.