### PR TITLE
rust-sdk: Add support for legacy TappdClient

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -1,4 +1,6 @@
 name: SDK tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -1,0 +1,24 @@
+name: SDK tests
+
+on:
+  push:
+    branches: [ master, next, dev-* ]
+  pull_request:
+    branches: [ master, next, dev-* ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sdk-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@1.86
+      with:
+        components: clippy, rustfmt
+
+    - name: SDK tests
+      run: cd sdk && ./run-tests.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,6 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
- "base64",
  "bon",
  "dcap-qvl",
  "hex",
@@ -2187,6 +2186,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "base64",
  "bon",
  "dcap-qvl",
  "hex",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,16 +6,15 @@ set -e
 pushd sdk/simulator
 ./dstack-simulator &
 SIMULATOR_PID=$!
+trap "kill $SIMULATOR_PID 2>/dev/null || true" EXIT
 echo "Simulator process (PID: $SIMULATOR_PID) started."
 popd
 
 export DSTACK_SIMULATOR_ENDPOINT=$(realpath sdk/simulator/dstack.sock)
+export TAPPD_SIMULATOR_ENDPOINT=$(realpath sdk/simulator/tappd.sock)
 
 echo "DSTACK_SIMULATOR_ENDPOINT: $DSTACK_SIMULATOR_ENDPOINT"
+echo "TAPPD_SIMULATOR_ENDPOINT: $TAPPD_SIMULATOR_ENDPOINT"
 
 # Run the tests
 cargo test
-
-# Kill the simulator after tests finish
-kill $SIMULATOR_PID
-echo "Simulator process (PID: $SIMULATOR_PID) terminated."

--- a/sdk/run-tests.sh
+++ b/sdk/run-tests.sh
@@ -13,7 +13,7 @@ trap "kill $SIMULATOR_PID 2>/dev/null || true" EXIT
 popd
 
 pushd rust/
-cargo test
+cargo test -- --show-output
 popd
 
 pushd go/

--- a/sdk/run-tests.sh
+++ b/sdk/run-tests.sh
@@ -14,6 +14,8 @@ popd
 
 pushd rust/
 cargo test -- --show-output
+cargo run --example tappd_client_usage
+cargo run --example dstack_client_usage
 popd
 
 pushd go/

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Encifher <encifher@rizelabs.io>"]
 [dependencies]
 alloy = { workspace = true, features = ["signers", "signer-local"] }
 anyhow.workspace = true
+base64.workspace = true
 bon.workspace = true
 hex.workspace = true 
 http.workspace = true 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -9,15 +9,15 @@ authors = ["Encifher <encifher@rizelabs.io>"]
 [dependencies]
 alloy = { workspace = true, features = ["signers", "signer-local"] }
 anyhow.workspace = true
-base64.workspace = true
 bon.workspace = true
-hex.workspace = true 
-http.workspace = true 
+hex.workspace = true
+http.workspace = true
 http-client-unix-domain-socket = "0.1.1"
 reqwest = { workspace = true, features = ["json"] }
-serde.workspace = true 
-serde_json.workspace = true 
-sha2.workspace = true 
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+x509-parser.workspace = true
 
 [dev-dependencies]
 dcap-qvl.workspace = true

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,6 +1,6 @@
 # Dstack Crate
 
-This crate provides a rust client for communicating with the dstack server, which is available inside dstack.
+This crate provides rust clients for communicating with both the current dstack server and the legacy tappd service, which are available inside dstack.
 
 ## Installation
 
@@ -11,8 +11,10 @@ dstack-rust = { git = "https://github.com/Dstack-TEE/dstack.git", package = "dst
 
 ## Basic Usage
 
+### DstackClient (Current API)
+
 ```rust
-use dstack_sdk::DstackClient;
+use dstack_sdk::dstack_client::DstackClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -40,45 +42,112 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### TappdClient (Legacy API)
+
+```rust
+use dstack_sdk::tappd_client::{TappdClient, QuoteHashAlgorithm};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TappdClient::new(None); // Uses env var or default to Unix socket
+
+    // Get system info
+    let info = client.info().await?;
+    println!("Instance ID: {}", info.instance_id);
+    println!("App Name: {}", info.app_name);
+
+    // Derive a key
+    let key_resp = client.derive_key("my-app").await?;
+    println!("Key: {}", key_resp.key);
+    println!("Certificate Chain: {:?}", key_resp.certificate_chain);
+
+    // Generate TDX quote with default SHA512
+    let quote_resp = client.tdx_quote(b"test-data".to_vec()).await?;
+    println!("Quote: {}", quote_resp.quote);
+    let rtmrs = quote_resp.replay_rtmrs()?;
+    println!("Replayed RTMRs: {:?}", rtmrs);
+
+    // Generate TDX quote with specific hash algorithm
+    let quote_resp = client.tdx_quote_with_hash_algorithm(
+        b"test-data".to_vec(),
+        QuoteHashAlgorithm::Sha256
+    ).await?;
+
+    // Generate raw quote (exactly 64 bytes)
+    let raw_data = vec![0u8; 64];
+    let raw_quote = client.raw_quote(raw_data).await?;
+
+    Ok(())
+}
+```
+
 ## Features
-### Initialization
+
+### DstackClient Initialization
 
 ```rust
 let client = DstackClient::new(Some("http://localhost:8000"));
 ```
 - `endpoint`: Optional HTTP URL or Unix socket path (`/var/run/dstack.sock` by default)
-
 - Will use the `DSTACK_SIMULATOR_ENDPOINT` environment variable if set
 
-## Methods
+### TappdClient Initialization (Legacy API)
 
-### `info(): InfoResponse`
+```rust
+let client = TappdClient::new(Some("/var/run/tappd.sock"));
+```
+- `endpoint`: Optional HTTP URL or Unix socket path (`/var/run/tappd.sock` by default)
+- Will use the `TAPPD_SIMULATOR_ENDPOINT` environment variable if set
+- Supports the legacy tappd.sock API for backwards compatibility
 
+## API Methods
+
+### DstackClient Methods
+
+#### `info(): InfoResponse`
 Fetches metadata and measurements about the CVM instance.
 
-### `get_key(path: Option<String>, purpose: Option<String>) -> GetKeyResponse`
-
+#### `get_key(path: Option<String>, purpose: Option<String>) -> GetKeyResponse`
 Derives a key for a specified path and optional purpose.
-
 - `key`: Private key in hex format
-
 - `signature_chain`: Vec of X.509 certificate chain entries
 
-### `get_quote(report_data: Vec<u8>) -> GetQuoteResponse`
-
+#### `get_quote(report_data: Vec<u8>) -> GetQuoteResponse`
 Generates a TDX quote with a custom 64-byte payload.
-
 - `quote`: Hex-encoded quote
-
 - `event_log`: Serialized list of events
-
 - `replay_rtmrs()`: Reconstructs RTMR values from the event log
 
-### `emit_event(event: String, payload: Vec<u8>)`
+#### `emit_event(event: String, payload: Vec<u8>)`
 Sends an event log with associated binary payload to the runtime.
 
-### `get_tls_key(...) -> GetTlsKeyResponse`
+#### `get_tls_key(...) -> GetTlsKeyResponse`
 Requests a key and X.509 certificate chain for RA-TLS or server/client authentication.
+
+### TappdClient Methods (Legacy API)
+
+#### `info(): TappdInfoResponse`
+Fetches metadata and measurements about the CVM instance.
+
+#### `derive_key(path: &str) -> DeriveKeyResponse`
+Derives a key for a specified path.
+- `key`: Private key (PEM or hex format)
+- `certificate_chain`: Vec of X.509 certificate chain entries
+
+#### `derive_key_with_subject(path: &str, subject: &str) -> DeriveKeyResponse`
+Derives a key with a custom certificate subject.
+
+#### `derive_key_with_subject_and_alt_names(path: &str, subject: Option<&str>, alt_names: Option<Vec<String>>) -> DeriveKeyResponse`
+Derives a key with full certificate customization.
+
+#### `tdx_quote(report_data: Vec<u8>) -> TdxQuoteResponse`
+Generates a TDX quote using SHA512 hash algorithm.
+
+#### `tdx_quote_with_hash_algorithm(report_data: Vec<u8>, algorithm: QuoteHashAlgorithm) -> TdxQuoteResponse`
+Generates a TDX quote with a specific hash algorithm (SHA256, SHA384, SHA512, etc.).
+
+#### `raw_quote(report_data: Vec<u8>) -> TdxQuoteResponse`
+Generates a TDX quote with exactly 64 bytes of raw report data.
 
 ### Structures
 - `GetKeyResponse`: Holds derived key and signature chain
@@ -104,7 +173,20 @@ cd dstack/sdk/simulator
 Set the endpoint in your environment:
 
 ```
-export DSTACK_SIMULATOR_ENDPOINT=http://localhost:8000
+export DSTACK_SIMULATOR_ENDPOINT=/path/to/dstack-simulator/dstack.sock
+```
+
+## Examples
+
+See the `examples/` directory for comprehensive usage examples:
+
+- `examples/dstack_client_usage.rs` - Complete example using the current DstackClient API
+- `examples/tappd_client_usage.rs` - Complete example using the legacy TappdClient API
+
+Run examples with:
+```bash
+cargo run --example dstack_client_usage
+cargo run --example tappd_client_usage
 ```
 
 ## License

--- a/sdk/rust/examples/dstack_client_usage.rs
+++ b/sdk/rust/examples/dstack_client_usage.rs
@@ -1,0 +1,179 @@
+use dstack_sdk::dstack_client::{DstackClient, TlsKeyConfig};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create a DstackClient with default endpoint (/var/run/dstack.sock)
+    let client = DstackClient::new(None);
+
+    // Or create with a custom endpoint
+    // let client = DstackClient::new(Some("/custom/path/dstack.sock"));
+
+    // Or create with HTTP endpoint for simulator
+    // let client = DstackClient::new(Some("http://localhost:8000"));
+
+    println!("DstackClient created successfully!");
+
+    // Example usage (these will fail without a running dstack service):
+
+    // 1. Get system info
+    match client.info().await {
+        Ok(info) => {
+            println!("System info retrieved successfully!");
+            println!("  App ID: {}", info.app_id);
+            println!("  Instance ID: {}", info.instance_id);
+            println!("  App Name: {}", info.app_name);
+            println!("  Device ID: {}", info.device_id);
+            println!("  Compose Hash: {}", info.compose_hash);
+            println!("  TCB Info - MRTD: {}", info.tcb_info.mrtd);
+            println!("  TCB Info - RTMR0: {}", info.tcb_info.rtmr0);
+        }
+        Err(e) => {
+            println!("Failed to get system info: {}", e);
+        }
+    }
+
+    // 2. Derive a key
+    match client
+        .get_key(Some("my-app".to_string()), Some("encryption".to_string()))
+        .await
+    {
+        Ok(response) => {
+            println!("Key derived successfully!");
+            println!("  Key length: {}", response.key.len());
+            println!(
+                "  Signature chain length: {}",
+                response.signature_chain.len()
+            );
+
+            // Decode the key
+            match response.decode_key() {
+                Ok(key_bytes) => {
+                    println!("  Decoded key bytes length: {}", key_bytes.len());
+                }
+                Err(e) => {
+                    println!("  Key decode error: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("Failed to derive key: {}", e);
+        }
+    }
+
+    // 3. Generate TDX quote
+    let report_data = b"Hello, dstack world!".to_vec();
+    match client.get_quote(report_data).await {
+        Ok(response) => {
+            println!("TDX quote generated successfully!");
+            println!("  Quote length: {}", response.quote.len());
+            println!("  Event log length: {}", response.event_log.len());
+
+            // Decode the quote
+            match response.decode_quote() {
+                Ok(quote_bytes) => {
+                    println!("  Decoded quote bytes length: {}", quote_bytes.len());
+                }
+                Err(e) => {
+                    println!("  Quote decode error: {}", e);
+                }
+            }
+
+            // Replay RTMRs from event log
+            match response.replay_rtmrs() {
+                Ok(rtmrs) => {
+                    println!("  Replayed RTMRs: {} entries", rtmrs.len());
+                    for (idx, rtmr) in rtmrs.iter() {
+                        println!("    RTMR{}: {}", idx, rtmr);
+                    }
+                }
+                Err(e) => {
+                    println!("  RTMR replay error: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("Failed to get TDX quote: {}", e);
+        }
+    }
+
+    // 4. Emit an event
+    let event_payload = b"Application started successfully".to_vec();
+    match client
+        .emit_event("AppStart".to_string(), event_payload)
+        .await
+    {
+        Ok(()) => {
+            println!("Event emitted successfully!");
+        }
+        Err(e) => {
+            println!("Failed to emit event: {}", e);
+        }
+    }
+
+    // 5. Get TLS key for server authentication
+    let tls_config = TlsKeyConfig::builder()
+        .subject("my-app.example.com")
+        .alt_names(vec![
+            "www.my-app.com".to_string(),
+            "api.my-app.com".to_string(),
+        ])
+        .usage_server_auth(true)
+        .usage_client_auth(false)
+        .usage_ra_tls(true)
+        .build();
+
+    match client.get_tls_key(tls_config).await {
+        Ok(response) => {
+            println!("TLS key generated successfully!");
+            println!("  Key length: {}", response.key.len());
+            println!(
+                "  Certificate chain length: {}",
+                response.certificate_chain.len()
+            );
+        }
+        Err(e) => {
+            println!("Failed to get TLS key: {}", e);
+        }
+    }
+
+    // 6. Get a simple key without purpose
+    match client.get_key(Some("simple-key".to_string()), None).await {
+        Ok(response) => {
+            println!("Simple key derived successfully!");
+            println!("  Key: {}", response.key);
+        }
+        Err(e) => {
+            println!("Failed to derive simple key: {}", e);
+        }
+    }
+
+    // 7. Generate quote with minimal report data
+    let minimal_data = vec![0x01, 0x02, 0x03, 0x04];
+    match client.get_quote(minimal_data).await {
+        Ok(response) => {
+            println!("Minimal quote generated successfully!");
+
+            // Parse and display event log
+            match response.decode_event_log() {
+                Ok(events) => {
+                    println!("  Event log contains {} events", events.len());
+                    for (i, event) in events.iter().enumerate().take(3) {
+                        // Show first 3 events
+                        println!(
+                            "    Event {}: IMR={}, Type={}, Event='{}'",
+                            i, event.imr, event.event_type, event.event
+                        );
+                    }
+                }
+                Err(e) => {
+                    println!("  Failed to parse event log: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("Failed to get minimal quote: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/sdk/rust/examples/dstack_client_usage.rs
+++ b/sdk/rust/examples/dstack_client_usage.rs
@@ -16,99 +16,55 @@ async fn main() -> anyhow::Result<()> {
     // Example usage (these will fail without a running dstack service):
 
     // 1. Get system info
-    match client.info().await {
-        Ok(info) => {
-            println!("System info retrieved successfully!");
-            println!("  App ID: {}", info.app_id);
-            println!("  Instance ID: {}", info.instance_id);
-            println!("  App Name: {}", info.app_name);
-            println!("  Device ID: {}", info.device_id);
-            println!("  Compose Hash: {}", info.compose_hash);
-            println!("  TCB Info - MRTD: {}", info.tcb_info.mrtd);
-            println!("  TCB Info - RTMR0: {}", info.tcb_info.rtmr0);
-        }
-        Err(e) => {
-            println!("Failed to get system info: {}", e);
-        }
-    }
+    let info = client.info().await?;
+    println!("System info retrieved successfully!");
+    println!("  App ID: {}", info.app_id);
+    println!("  Instance ID: {}", info.instance_id);
+    println!("  App Name: {}", info.app_name);
+    println!("  Device ID: {}", info.device_id);
+    println!("  Compose Hash: {}", info.compose_hash);
+    println!("  TCB Info - MRTD: {}", info.tcb_info.mrtd);
+    println!("  TCB Info - RTMR0: {}", info.tcb_info.rtmr0);
 
     // 2. Derive a key
-    match client
+    let response = client
         .get_key(Some("my-app".to_string()), Some("encryption".to_string()))
-        .await
-    {
-        Ok(response) => {
-            println!("Key derived successfully!");
-            println!("  Key length: {}", response.key.len());
-            println!(
-                "  Signature chain length: {}",
-                response.signature_chain.len()
-            );
+        .await?;
+    println!("Key derived successfully!");
+    println!("  Key length: {}", response.key.len());
+    println!(
+        "  Signature chain length: {}",
+        response.signature_chain.len()
+    );
 
-            // Decode the key
-            match response.decode_key() {
-                Ok(key_bytes) => {
-                    println!("  Decoded key bytes length: {}", key_bytes.len());
-                }
-                Err(e) => {
-                    println!("  Key decode error: {}", e);
-                }
-            }
-        }
-        Err(e) => {
-            println!("Failed to derive key: {}", e);
-        }
-    }
+    // Decode the key
+    let key_bytes = response.decode_key()?;
+    println!("  Decoded key bytes length: {}", key_bytes.len());
 
     // 3. Generate TDX quote
     let report_data = b"Hello, dstack world!".to_vec();
-    match client.get_quote(report_data).await {
-        Ok(response) => {
-            println!("TDX quote generated successfully!");
-            println!("  Quote length: {}", response.quote.len());
-            println!("  Event log length: {}", response.event_log.len());
+    let response = client.get_quote(report_data).await?;
+    println!("TDX quote generated successfully!");
+    println!("  Quote length: {}", response.quote.len());
+    println!("  Event log length: {}", response.event_log.len());
 
-            // Decode the quote
-            match response.decode_quote() {
-                Ok(quote_bytes) => {
-                    println!("  Decoded quote bytes length: {}", quote_bytes.len());
-                }
-                Err(e) => {
-                    println!("  Quote decode error: {}", e);
-                }
-            }
+    // Decode the quote
+    let quote_bytes = response.decode_quote()?;
+    println!("  Decoded quote bytes length: {}", quote_bytes.len());
 
-            // Replay RTMRs from event log
-            match response.replay_rtmrs() {
-                Ok(rtmrs) => {
-                    println!("  Replayed RTMRs: {} entries", rtmrs.len());
-                    for (idx, rtmr) in rtmrs.iter() {
-                        println!("    RTMR{}: {}", idx, rtmr);
-                    }
-                }
-                Err(e) => {
-                    println!("  RTMR replay error: {}", e);
-                }
-            }
-        }
-        Err(e) => {
-            println!("Failed to get TDX quote: {}", e);
-        }
+    // Replay RTMRs from event log
+    let rtmrs = response.replay_rtmrs()?;
+    println!("  Replayed RTMRs: {} entries", rtmrs.len());
+    for (idx, rtmr) in rtmrs.iter() {
+        println!("    RTMR{}: {}", idx, rtmr);
     }
 
     // 4. Emit an event
     let event_payload = b"Application started successfully".to_vec();
-    match client
+    client
         .emit_event("AppStart".to_string(), event_payload)
-        .await
-    {
-        Ok(()) => {
-            println!("Event emitted successfully!");
-        }
-        Err(e) => {
-            println!("Failed to emit event: {}", e);
-        }
-    }
+        .await?;
+    println!("Event emitted successfully!");
 
     // 5. Get TLS key for server authentication
     let tls_config = TlsKeyConfig::builder()
@@ -122,57 +78,35 @@ async fn main() -> anyhow::Result<()> {
         .usage_ra_tls(true)
         .build();
 
-    match client.get_tls_key(tls_config).await {
-        Ok(response) => {
-            println!("TLS key generated successfully!");
-            println!("  Key length: {}", response.key.len());
-            println!(
-                "  Certificate chain length: {}",
-                response.certificate_chain.len()
-            );
-        }
-        Err(e) => {
-            println!("Failed to get TLS key: {}", e);
-        }
-    }
+    let response = client.get_tls_key(tls_config).await?;
+    println!("TLS key generated successfully!");
+    println!("  Key length: {}", response.key.len());
+    println!(
+        "  Certificate chain length: {}",
+        response.certificate_chain.len()
+    );
 
     // 6. Get a simple key without purpose
-    match client.get_key(Some("simple-key".to_string()), None).await {
-        Ok(response) => {
-            println!("Simple key derived successfully!");
-            println!("  Key: {}", response.key);
-        }
-        Err(e) => {
-            println!("Failed to derive simple key: {}", e);
-        }
-    }
+    let response = client.get_key(Some("simple-key".to_string()), None).await?;
+    println!("Simple key derived successfully!");
+    println!("  Key: {}", response.key);
 
     // 7. Generate quote with minimal report data
     let minimal_data = vec![0x01, 0x02, 0x03, 0x04];
-    match client.get_quote(minimal_data).await {
-        Ok(response) => {
-            println!("Minimal quote generated successfully!");
+    let response = client.get_quote(minimal_data).await?;
+    println!("Minimal quote generated successfully!");
+    println!("  Quote length: {}", response.quote.len());
+    println!("  Event log length: {}", response.event_log.len());
 
-            // Parse and display event log
-            match response.decode_event_log() {
-                Ok(events) => {
-                    println!("  Event log contains {} events", events.len());
-                    for (i, event) in events.iter().enumerate().take(3) {
-                        // Show first 3 events
-                        println!(
-                            "    Event {}: IMR={}, Type={}, Event='{}'",
-                            i, event.imr, event.event_type, event.event
-                        );
-                    }
-                }
-                Err(e) => {
-                    println!("  Failed to parse event log: {}", e);
-                }
-            }
-        }
-        Err(e) => {
-            println!("Failed to get minimal quote: {}", e);
-        }
+    // Parse and display event log
+    let events = response.decode_event_log()?;
+    println!("  Event log contains {} events", events.len());
+    for (i, event) in events.iter().enumerate().take(3) {
+        // Show first 3 events
+        println!(
+            "    Event {}: IMR={}, Type={}, Event='{}'",
+            i, event.imr, event.event_type, event.event
+        );
     }
 
     Ok(())

--- a/sdk/rust/examples/tappd_client_usage.rs
+++ b/sdk/rust/examples/tappd_client_usage.rs
@@ -1,4 +1,4 @@
-use dstack_sdk::tappd_client::{QuoteHashAlgorithm, TappdClient};
+use dstack_sdk::tappd_client::TappdClient;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -29,34 +29,21 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // 2. Get a TDX quote
-    let report_data = b"Hello, world!".to_vec();
-    match client.tdx_quote(report_data).await {
+    // 2. Get a quote with 64 bytes of report data
+    let mut report_data = b"Hello, world!".to_vec();
+    // Pad to exactly 64 bytes for get_quote
+    report_data.resize(64, 0);
+    match client.get_quote(report_data).await {
         Ok(response) => {
-            println!("TDX quote generated successfully!");
+            println!("Quote generated successfully!");
             println!("Quote length: {}", response.quote.len());
         }
         Err(e) => {
-            println!("Failed to get TDX quote: {}", e);
+            println!("Failed to get quote: {}", e);
         }
     }
 
-    // 3. Get a TDX quote with specific hash algorithm
-    let report_data = b"Hello, world!".to_vec();
-    match client
-        .tdx_quote_with_hash_algorithm(report_data, QuoteHashAlgorithm::Sha256)
-        .await
-    {
-        Ok(response) => {
-            println!("TDX quote with SHA256 generated successfully!");
-            println!("Quote length: {}", response.quote.len());
-        }
-        Err(e) => {
-            println!("Failed to get TDX quote with SHA256: {}", e);
-        }
-    }
-
-    // 4. Get instance info
+    // 3. Get instance info
     match client.info().await {
         Ok(info) => {
             println!("Instance info retrieved successfully!");

--- a/sdk/rust/examples/tappd_client_usage.rs
+++ b/sdk/rust/examples/tappd_client_usage.rs
@@ -1,0 +1,73 @@
+use dstack_sdk::tappd_client::{QuoteHashAlgorithm, TappdClient};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create a TappdClient with default endpoint (/var/run/tappd.sock)
+    let client = TappdClient::new(None);
+
+    // Or create with a custom endpoint
+    // let client = TappdClient::new(Some("/custom/path/tappd.sock"));
+
+    // Or create with HTTP endpoint for simulator
+    // let client = TappdClient::new(Some("http://localhost:8080"));
+
+    println!("TappdClient created successfully!");
+
+    // Example usage (these will fail without a running tappd service):
+
+    // 1. Derive a key
+    match client.derive_key("my/key/path").await {
+        Ok(response) => {
+            println!("Key derived successfully!");
+            println!(
+                "Certificate chain length: {}",
+                response.certificate_chain.len()
+            );
+        }
+        Err(e) => {
+            println!("Failed to derive key: {}", e);
+        }
+    }
+
+    // 2. Get a TDX quote
+    let report_data = b"Hello, world!".to_vec();
+    match client.tdx_quote(report_data).await {
+        Ok(response) => {
+            println!("TDX quote generated successfully!");
+            println!("Quote length: {}", response.quote.len());
+        }
+        Err(e) => {
+            println!("Failed to get TDX quote: {}", e);
+        }
+    }
+
+    // 3. Get a TDX quote with specific hash algorithm
+    let report_data = b"Hello, world!".to_vec();
+    match client
+        .tdx_quote_with_hash_algorithm(report_data, QuoteHashAlgorithm::Sha256)
+        .await
+    {
+        Ok(response) => {
+            println!("TDX quote with SHA256 generated successfully!");
+            println!("Quote length: {}", response.quote.len());
+        }
+        Err(e) => {
+            println!("Failed to get TDX quote with SHA256: {}", e);
+        }
+    }
+
+    // 4. Get instance info
+    match client.info().await {
+        Ok(info) => {
+            println!("Instance info retrieved successfully!");
+            println!("App ID: {}", info.app_id);
+            println!("Instance ID: {}", info.instance_id);
+            println!("App Name: {}", info.app_name);
+        }
+        Err(e) => {
+            println!("Failed to get instance info: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/sdk/rust/examples/tappd_client_usage.rs
+++ b/sdk/rust/examples/tappd_client_usage.rs
@@ -16,45 +16,29 @@ async fn main() -> anyhow::Result<()> {
     // Example usage (these will fail without a running tappd service):
 
     // 1. Derive a key
-    match client.derive_key("my/key/path").await {
-        Ok(response) => {
-            println!("Key derived successfully!");
-            println!(
-                "Certificate chain length: {}",
-                response.certificate_chain.len()
-            );
-        }
-        Err(e) => {
-            println!("Failed to derive key: {}", e);
-        }
-    }
+    let response = client.derive_key("my/key/path").await?;
+    println!("Key derived successfully!");
+    println!(
+        "Certificate chain length: {}",
+        response.certificate_chain.len()
+    );
+    let ecdsa_p256_key = response.decode_key().unwrap();
+    println!("ECDSA P-256 key length: {}", ecdsa_p256_key.len());
 
     // 2. Get a quote with 64 bytes of report data
     let mut report_data = b"Hello, world!".to_vec();
     // Pad to exactly 64 bytes for get_quote
     report_data.resize(64, 0);
-    match client.get_quote(report_data).await {
-        Ok(response) => {
-            println!("Quote generated successfully!");
-            println!("Quote length: {}", response.quote.len());
-        }
-        Err(e) => {
-            println!("Failed to get quote: {}", e);
-        }
-    }
+    let response = client.get_quote(report_data).await?;
+    println!("Quote generated successfully!");
+    println!("Quote length: {}", response.quote.len());
 
     // 3. Get instance info
-    match client.info().await {
-        Ok(info) => {
-            println!("Instance info retrieved successfully!");
-            println!("App ID: {}", info.app_id);
-            println!("Instance ID: {}", info.instance_id);
-            println!("App Name: {}", info.app_name);
-        }
-        Err(e) => {
-            println!("Failed to get instance info: {}", e);
-        }
-    }
+    let response = client.info().await?;
+    println!("Instance info retrieved successfully!");
+    println!("App ID: {}", response.app_id);
+    println!("Instance ID: {}", response.instance_id);
+    println!("App Name: {}", response.app_name);
 
     Ok(())
 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod dstack_client;
 pub mod ethereum;
+pub mod tappd_client;

--- a/sdk/rust/src/tappd_client.rs
+++ b/sdk/rust/src/tappd_client.rs
@@ -1,0 +1,400 @@
+use anyhow::Result;
+use hex::{encode as hex_encode, FromHexError};
+use http_client_unix_domain_socket::{ClientUnix, Method};
+use reqwest::Client;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::Digest;
+use std::collections::HashMap;
+use std::env;
+
+use crate::dstack_client::{BaseClient, EventLog};
+
+const INIT_MR: &str = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+/// Hash algorithms supported by the TDX quote generation
+#[derive(Debug, Clone)]
+pub enum QuoteHashAlgorithm {
+    Sha256,
+    Sha384,
+    Sha512,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+    Keccak256,
+    Keccak384,
+    Keccak512,
+    Raw,
+}
+
+impl QuoteHashAlgorithm {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha384 => "sha384",
+            Self::Sha512 => "sha512",
+            Self::Sha3_256 => "sha3-256",
+            Self::Sha3_384 => "sha3-384",
+            Self::Sha3_512 => "sha3-512",
+            Self::Keccak256 => "keccak256",
+            Self::Keccak384 => "keccak384",
+            Self::Keccak512 => "keccak512",
+            Self::Raw => "raw",
+        }
+    }
+}
+
+fn replay_rtmr(history: Vec<String>) -> Result<String, FromHexError> {
+    if history.is_empty() {
+        return Ok(INIT_MR.to_string());
+    }
+    let mut mr = hex::decode(INIT_MR)?;
+    for content in history {
+        let mut content_bytes = hex::decode(content)?;
+        if content_bytes.len() < 48 {
+            content_bytes.resize(48, 0);
+        }
+        mr.extend_from_slice(&content_bytes);
+        mr = sha2::Sha384::digest(&mr).to_vec();
+    }
+    Ok(hex_encode(mr))
+}
+
+fn get_tappd_endpoint(endpoint: Option<&str>) -> String {
+    if let Some(e) = endpoint {
+        return e.to_string();
+    }
+    if let Ok(sim_endpoint) = env::var("TAPPD_SIMULATOR_ENDPOINT") {
+        return sim_endpoint;
+    }
+    "/var/run/tappd.sock".to_string()
+}
+
+#[derive(Debug)]
+pub enum TappdClientKind {
+    Http,
+    Unix,
+}
+
+/// Response from a key derivation request
+#[derive(Serialize, Deserialize)]
+pub struct DeriveKeyResponse {
+    /// The derived key (PEM format for certificates, hex for raw keys)
+    pub key: String,
+    /// The certificate chain
+    pub certificate_chain: Vec<String>,
+}
+
+impl DeriveKeyResponse {
+    /// Decodes the key from PEM/base64 format to bytes, optionally truncating to max_length
+    pub fn to_bytes(&self, max_length: Option<usize>) -> Result<Vec<u8>, anyhow::Error> {
+        let mut content = self.key.clone();
+
+        // Remove PEM headers if present
+        content = content.replace("-----BEGIN PRIVATE KEY-----", "");
+        content = content.replace("-----END PRIVATE KEY-----", "");
+        content = content.replace('\n', "");
+
+        let binary = if content.chars().all(|c| c.is_ascii_hexdigit()) {
+            // Handle hex-encoded content
+            hex::decode(content)?
+        } else {
+            // Handle base64-encoded content
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(content)
+                .map_err(|e| anyhow::anyhow!("Failed to decode base64: {}", e))?
+        };
+
+        if let Some(max_len) = max_length {
+            if binary.len() > max_len {
+                return Ok(binary[..max_len].to_vec());
+            }
+        }
+        Ok(binary)
+    }
+}
+
+/// Response from a TDX quote request
+#[derive(Serialize, Deserialize)]
+pub struct TdxQuoteResponse {
+    /// The TDX quote in hexadecimal format
+    pub quote: String,
+    /// The event log associated with the quote
+    pub event_log: String,
+    /// The hash algorithm used (if returned by server)
+    #[serde(default)]
+    pub hash_algorithm: Option<String>,
+    /// The prefix used (if returned by server)
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+impl TdxQuoteResponse {
+    pub fn decode_quote(&self) -> Result<Vec<u8>, FromHexError> {
+        hex::decode(&self.quote)
+    }
+
+    pub fn decode_event_log(&self) -> Result<Vec<EventLog>, serde_json::Error> {
+        serde_json::from_str(&self.event_log)
+    }
+
+    /// Replays RTMR history to calculate final RTMR values
+    pub fn replay_rtmrs(&self) -> Result<HashMap<u8, String>> {
+        let parsed_event_log: Vec<EventLog> = self.decode_event_log()?;
+        let mut rtmrs = HashMap::new();
+        for idx in 0..4 {
+            let mut history = vec![];
+            for event in &parsed_event_log {
+                if event.imr == idx {
+                    history.push(event.digest.clone());
+                }
+            }
+            rtmrs.insert(idx as u8, replay_rtmr(history)?);
+        }
+        Ok(rtmrs)
+    }
+}
+
+/// TCB (Trusted Computing Base) information
+#[derive(Serialize, Deserialize)]
+pub struct TappdTcbInfo {
+    /// The measurement root of trust
+    pub mrtd: String,
+    /// The value of RTMR0 (Runtime Measurement Register 0)
+    pub rtmr0: String,
+    /// The value of RTMR1 (Runtime Measurement Register 1)
+    pub rtmr1: String,
+    /// The value of RTMR2 (Runtime Measurement Register 2)
+    pub rtmr2: String,
+    /// The value of RTMR3 (Runtime Measurement Register 3)
+    pub rtmr3: String,
+    /// The event log entries
+    pub event_log: Vec<EventLog>,
+    /// The application compose file
+    pub app_compose: String,
+}
+
+/// Response from a Tappd info request
+#[derive(Serialize, Deserialize)]
+pub struct TappdInfoResponse {
+    /// The application identifier
+    pub app_id: String,
+    /// The instance identifier
+    pub instance_id: String,
+    /// The application certificate
+    pub app_cert: String,
+    /// Trusted Computing Base information
+    pub tcb_info: TappdTcbInfo,
+    /// The name of the application
+    pub app_name: String,
+}
+
+/// The main client for interacting with the legacy Tappd service
+pub struct TappdClient {
+    /// The base URL for HTTP requests
+    base_url: String,
+    /// The endpoint for Unix domain socket communication
+    endpoint: String,
+    /// The type of client (HTTP or Unix domain socket)
+    client: TappdClientKind,
+}
+
+impl BaseClient for TappdClient {}
+
+impl TappdClient {
+    pub fn new(endpoint: Option<&str>) -> Self {
+        let endpoint = get_tappd_endpoint(endpoint);
+        let (base_url, client) = match endpoint {
+            ref e if e.starts_with("http://") || e.starts_with("https://") => {
+                (e.to_string(), TappdClientKind::Http)
+            }
+            _ => ("http://localhost".to_string(), TappdClientKind::Unix),
+        };
+
+        TappdClient {
+            base_url,
+            endpoint,
+            client,
+        }
+    }
+
+    async fn send_rpc_request<S: Serialize, D: DeserializeOwned>(
+        &self,
+        path: &str,
+        payload: &S,
+    ) -> anyhow::Result<D> {
+        match &self.client {
+            TappdClientKind::Http => {
+                let client = Client::new();
+                let url = format!(
+                    "{}/{}",
+                    self.base_url.trim_end_matches('/'),
+                    path.trim_start_matches('/')
+                );
+                let res = client
+                    .post(&url)
+                    .json(payload)
+                    .header("Content-Type", "application/json")
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                Ok(res.json().await?)
+            }
+            TappdClientKind::Unix => {
+                let mut unix_client = ClientUnix::try_new(&self.endpoint).await?;
+                let res = unix_client
+                    .send_request_json::<_, _, Value>(
+                        path,
+                        Method::POST,
+                        &[("Content-Type", "application/json")],
+                        Some(&payload),
+                    )
+                    .await?;
+                Ok(res.1)
+            }
+        }
+    }
+
+    /// Derives a key from the Tappd service using the path as both path and subject
+    pub async fn derive_key(&self, path: &str) -> Result<DeriveKeyResponse> {
+        self.derive_key_with_subject_and_alt_names(path, Some(path), None)
+            .await
+    }
+
+    /// Derives a key from the Tappd service with a specific subject
+    pub async fn derive_key_with_subject(
+        &self,
+        path: &str,
+        subject: &str,
+    ) -> Result<DeriveKeyResponse> {
+        self.derive_key_with_subject_and_alt_names(path, Some(subject), None)
+            .await
+    }
+
+    /// Derives a key from the Tappd service with full configuration
+    pub async fn derive_key_with_subject_and_alt_names(
+        &self,
+        path: &str,
+        subject: Option<&str>,
+        alt_names: Option<Vec<String>>,
+    ) -> Result<DeriveKeyResponse> {
+        let subject = subject.unwrap_or(path);
+
+        let mut payload = json!({
+            "path": path,
+            "subject": subject,
+        });
+
+        if let Some(alt_names) = alt_names {
+            if !alt_names.is_empty() {
+                payload["alt_names"] = json!(alt_names);
+            }
+        }
+
+        let response = self
+            .send_rpc_request("/prpc/Tappd.DeriveKey", &payload)
+            .await?;
+        Ok(response)
+    }
+
+    /// Sends a TDX quote request using SHA512 as the default hash algorithm
+    pub async fn tdx_quote(&self, report_data: Vec<u8>) -> Result<TdxQuoteResponse> {
+        self.tdx_quote_with_hash_algorithm(report_data, QuoteHashAlgorithm::Sha512)
+            .await
+    }
+
+    /// Sends a TDX quote request with a specific hash algorithm
+    pub async fn tdx_quote_with_hash_algorithm(
+        &self,
+        mut report_data: Vec<u8>,
+        hash_algorithm: QuoteHashAlgorithm,
+    ) -> Result<TdxQuoteResponse> {
+        // For RAW algorithm, ensure report_data is exactly 64 bytes
+        if matches!(hash_algorithm, QuoteHashAlgorithm::Raw) {
+            if report_data.len() > 64 {
+                anyhow::bail!("Report data is too large, it should be at most 64 bytes when hash_algorithm is RAW");
+            }
+            if report_data.len() < 64 {
+                // Left-pad with zeros
+                let mut padded = vec![0u8; 64 - report_data.len()];
+                padded.extend_from_slice(&report_data);
+                report_data = padded;
+            }
+        }
+
+        let payload = json!({
+            "report_data": hex_encode(report_data),
+            "hash_algorithm": hash_algorithm.as_str(),
+        });
+
+        let response = self
+            .send_rpc_request("/prpc/Tappd.TdxQuote", &payload)
+            .await?;
+        Ok(response)
+    }
+
+    /// Sends a TDX quote request with custom prefix and hash algorithm
+    pub async fn tdx_quote_with_prefix(
+        &self,
+        report_data: Vec<u8>,
+        hash_algorithm: QuoteHashAlgorithm,
+        prefix: Option<&str>,
+    ) -> Result<TdxQuoteResponse> {
+        let mut payload = json!({
+            "report_data": hex_encode(report_data),
+            "hash_algorithm": hash_algorithm.as_str(),
+        });
+
+        if let Some(prefix) = prefix {
+            payload["prefix"] = json!(prefix);
+        }
+
+        let response = self
+            .send_rpc_request("/prpc/Tappd.TdxQuote", &payload)
+            .await?;
+        Ok(response)
+    }
+
+    /// Sends a raw quote request with 64 bytes of report data
+    pub async fn raw_quote(&self, report_data: Vec<u8>) -> Result<TdxQuoteResponse> {
+        if report_data.len() != 64 {
+            anyhow::bail!("Report data must be exactly 64 bytes for raw quote");
+        }
+
+        let payload = json!({
+            "report_data": hex_encode(report_data),
+        });
+
+        let response = self
+            .send_rpc_request("/prpc/Tappd.RawQuote", &payload)
+            .await?;
+        Ok(response)
+    }
+
+    /// Retrieves information about the Tappd instance
+    pub async fn info(&self) -> Result<TappdInfoResponse> {
+        #[derive(Deserialize)]
+        struct RawInfoResponse {
+            app_id: String,
+            instance_id: String,
+            app_cert: String,
+            tcb_info: String,
+            app_name: String,
+        }
+
+        let raw_response: RawInfoResponse = self
+            .send_rpc_request("/prpc/Tappd.Info", &json!({}))
+            .await?;
+
+        let tcb_info: TappdTcbInfo = serde_json::from_str(&raw_response.tcb_info)?;
+
+        Ok(TappdInfoResponse {
+            app_id: raw_response.app_id,
+            instance_id: raw_response.instance_id,
+            app_cert: raw_response.app_cert,
+            tcb_info,
+            app_name: raw_response.app_name,
+        })
+    }
+}

--- a/sdk/rust/src/tappd_client.rs
+++ b/sdk/rust/src/tappd_client.rs
@@ -87,7 +87,7 @@ pub struct DeriveKeyResponse {
 
 impl DeriveKeyResponse {
     /// Decodes the key from PEM format and extracts the raw ECDSA P-256 private key bytes
-    pub fn to_bytes(&self) -> Result<Vec<u8>, anyhow::Error> {
+    pub fn decode_key(&self) -> Result<Vec<u8>, anyhow::Error> {
         use x509_parser::der_parser::der::parse_der;
         use x509_parser::pem::parse_x509_pem;
 

--- a/sdk/rust/tests/test_tappd_client.rs
+++ b/sdk/rust/tests/test_tappd_client.rs
@@ -70,15 +70,9 @@ async fn test_tappd_client_derive_key_integration() {
     assert!(!response.key.is_empty());
 
     // Test key decoding
-    match response.to_bytes() {
-        Ok(key_bytes) => {
-            println!("  Decoded key bytes length: {}", key_bytes.len());
-            assert!(!key_bytes.is_empty());
-        }
-        Err(e) => {
-            println!("  Key decode error: {}", e);
-        }
-    }
+    let key_bytes = response.decode_key().unwrap();
+    println!("✓ Decoded key bytes length: {}", key_bytes.len());
+    assert_eq!(key_bytes.len(), 32);
 }
 
 #[tokio::test]
@@ -167,7 +161,6 @@ async fn test_tappd_client_get_quote_integration() {
     }
 }
 
-
 // Helper function to get a test client
 fn get_test_client() -> TappdClient {
     // Check for simulator endpoint first
@@ -187,7 +180,6 @@ fn get_test_client() -> TappdClient {
     TappdClient::new(None)
 }
 
-
 #[test]
 fn test_derive_key_response_decode() {
     use dstack_sdk::tappd_client::DeriveKeyResponse;
@@ -200,12 +192,9 @@ fn test_derive_key_response_decode() {
     };
 
     // The implementation should return the decoded ECDSA P-256 private key bytes
-    let bytes = response.to_bytes().unwrap();
+    let bytes = response.decode_key().unwrap();
     assert!(!bytes.is_empty());
     // For a valid ECDSA P-256 key, we should get either 32 bytes (the private key)
     // or fall back to the full DER contents if parsing fails
-    assert!(bytes.len() == 32 || bytes.len() > 32);
+    assert_eq!(bytes.len(), 32);
 }
-
-
-

--- a/sdk/rust/tests/test_tappd_client.rs
+++ b/sdk/rust/tests/test_tappd_client.rs
@@ -1,0 +1,283 @@
+use dstack_sdk::tappd_client::{QuoteHashAlgorithm, TappdClient};
+use std::env;
+
+#[tokio::test]
+async fn test_tappd_client_creation() {
+    // Test client creation with default endpoint
+    let _client = TappdClient::new(None);
+
+    // This should succeed without panicking
+    assert!(true);
+}
+
+#[tokio::test]
+async fn test_tappd_client_with_custom_endpoint() {
+    // Test client creation with custom endpoint
+    let _client = TappdClient::new(Some("/custom/path/tappd.sock"));
+
+    // This should succeed without panicking
+    assert!(true);
+}
+
+#[tokio::test]
+async fn test_tappd_client_with_http_endpoint() {
+    // Test client creation with HTTP endpoint
+    let _client = TappdClient::new(Some("http://localhost:8080"));
+
+    // This should succeed without panicking
+    assert!(true);
+}
+
+// Integration tests that require a running tappd service
+// These tests will be skipped if no tappd service is available
+
+#[tokio::test]
+async fn test_tappd_client_info_integration() {
+    let client = get_test_client();
+    let info = client.info().await.unwrap();
+
+    println!("✓ Info request successful");
+    println!("  App ID: {}", info.app_id);
+    println!("  Instance ID: {}", info.instance_id);
+    println!("  App Name: {}", info.app_name);
+
+    // Validate response structure
+    assert!(!info.app_id.is_empty());
+    assert!(!info.instance_id.is_empty());
+    assert!(!info.app_name.is_empty());
+    assert!(!info.tcb_info.app_compose.is_empty());
+    assert!(!info.tcb_info.mrtd.is_empty());
+    assert!(!info.tcb_info.rtmr0.is_empty());
+    assert!(!info.tcb_info.rtmr1.is_empty());
+    assert!(!info.tcb_info.rtmr2.is_empty());
+    assert!(!info.tcb_info.rtmr3.is_empty());
+    assert!(!info.tcb_info.event_log.is_empty());
+}
+
+#[tokio::test]
+async fn test_tappd_client_derive_key_integration() {
+    let client = get_test_client();
+
+    let response = client.derive_key("test/key/path").await.unwrap();
+    println!("✓ Derive key request successful");
+    println!("  Key length: {}", response.key.len());
+    println!(
+        "  Certificate chain length: {}",
+        response.certificate_chain.len()
+    );
+
+    // Validate response structure
+    assert!(!response.key.is_empty());
+
+    // Test key decoding
+    match response.to_bytes(None) {
+        Ok(key_bytes) => {
+            println!("  Decoded key bytes length: {}", key_bytes.len());
+            assert!(!key_bytes.is_empty());
+        }
+        Err(e) => {
+            println!("  Key decode error: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_tappd_client_derive_key_with_subject_integration() {
+    let client = get_test_client();
+
+    let response = client
+        .derive_key_with_subject("test/key/path", "example.com")
+        .await
+        .unwrap();
+
+    println!("✓ Derive key with subject request successful");
+    println!("  Key length: {}", response.key.len());
+    println!(
+        "  Certificate chain length: {}",
+        response.certificate_chain.len()
+    );
+
+    // Validate response structure
+    assert!(!response.key.is_empty());
+}
+
+#[tokio::test]
+async fn test_tappd_client_derive_key_with_alt_names_integration() {
+    let client = get_test_client();
+
+    let alt_names = vec!["www.example.com".to_string(), "api.example.com".to_string()];
+    let response = client
+        .derive_key_with_subject_and_alt_names(
+            "test/key/path",
+            Some("example.com"),
+            Some(alt_names),
+        )
+        .await
+        .unwrap();
+    println!("✓ Derive key with alt names request successful");
+    println!("  Key length: {}", response.key.len());
+    println!(
+        "  Certificate chain length: {}",
+        response.certificate_chain.len()
+    );
+
+    // Validate response structure
+    assert!(!response.key.is_empty());
+}
+
+#[tokio::test]
+async fn test_tappd_client_tdx_quote_integration() {
+    let client = get_test_client();
+
+    let report_data = b"test report data for quote".to_vec();
+
+    let response = client.tdx_quote(report_data).await.unwrap();
+    println!("✓ TDX quote request successful");
+    println!("  Quote length: {}", response.quote.len());
+    println!("  Event log length: {}", response.event_log.len());
+
+    // Validate response structure
+    assert!(!response.quote.is_empty());
+    assert!(!response.event_log.is_empty());
+
+    // Test quote decoding
+    match response.decode_quote() {
+        Ok(quote_bytes) => {
+            println!("  Decoded quote bytes length: {}", quote_bytes.len());
+            assert!(!quote_bytes.is_empty());
+        }
+        Err(e) => {
+            println!("  Quote decode error: {}", e);
+        }
+    }
+
+    // Test RTMR replay
+    match response.replay_rtmrs() {
+        Ok(rtmrs) => {
+            println!("  Replayed RTMRs: {} entries", rtmrs.len());
+            for (idx, rtmr) in rtmrs.iter() {
+                println!("    RTMR{}: {}", idx, rtmr);
+            }
+        }
+        Err(e) => {
+            println!("  RTMR replay error: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_tappd_client_tdx_quote_with_hash_algorithm_integration() {
+    let client = get_test_client();
+
+    let report_data = b"test report data for sha256 quote".to_vec();
+
+    let response = client
+        .tdx_quote_with_hash_algorithm(report_data, QuoteHashAlgorithm::Sha256)
+        .await
+        .unwrap();
+    println!("✓ TDX quote with SHA256 request successful");
+    println!("  Quote length: {}", response.quote.len());
+    println!("  Event log length: {}", response.event_log.len());
+
+    // Validate response structure
+    assert!(!response.quote.is_empty());
+    assert!(!response.event_log.is_empty());
+}
+
+#[tokio::test]
+async fn test_tappd_client_raw_quote_integration() {
+    let client = get_test_client();
+
+    let report_data = vec![0x42u8; 64]; // 64 bytes of test data
+
+    let response = client.raw_quote(report_data).await.unwrap();
+    println!("✓ Raw quote request successful");
+    println!("  Quote length: {}", response.quote.len());
+    println!("  Event log length: {}", response.event_log.len());
+
+    // Validate response structure
+    assert!(!response.quote.is_empty());
+    assert!(!response.event_log.is_empty());
+}
+
+// Helper function to get a test client
+fn get_test_client() -> TappdClient {
+    // Check for simulator endpoint first
+    if let Ok(endpoint) = env::var("TAPPD_SIMULATOR_ENDPOINT") {
+        println!("Using TAPPD_SIMULATOR_ENDPOINT: {}", endpoint);
+        return TappdClient::new(Some(&endpoint));
+    }
+
+    // Check for DSTACK_SIMULATOR_ENDPOINT as fallback
+    if let Ok(endpoint) = env::var("DSTACK_SIMULATOR_ENDPOINT") {
+        println!("Using DSTACK_SIMULATOR_ENDPOINT as fallback: {}", endpoint);
+        return TappdClient::new(Some(&endpoint));
+    }
+
+    // Use default endpoint
+    println!("Using default tappd endpoint: /var/run/tappd.sock");
+    TappdClient::new(None)
+}
+
+#[test]
+fn test_quote_hash_algorithm_conversion() {
+    // Test QuoteHashAlgorithm string conversion
+    assert_eq!(QuoteHashAlgorithm::Sha256.as_str(), "sha256");
+    assert_eq!(QuoteHashAlgorithm::Sha384.as_str(), "sha384");
+    assert_eq!(QuoteHashAlgorithm::Sha512.as_str(), "sha512");
+    assert_eq!(QuoteHashAlgorithm::Raw.as_str(), "raw");
+}
+
+#[test]
+fn test_derive_key_response_hex_decode() {
+    use dstack_sdk::tappd_client::DeriveKeyResponse;
+
+    let response = DeriveKeyResponse {
+        key: "deadbeef".to_string(),
+        certificate_chain: vec![],
+    };
+
+    let bytes = response.to_bytes(None).unwrap();
+    assert_eq!(bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+}
+
+#[test]
+fn test_derive_key_response_base64_decode() {
+    use dstack_sdk::tappd_client::DeriveKeyResponse;
+
+    // "hello" in base64 is "aGVsbG8="
+    let response = DeriveKeyResponse {
+        key: "aGVsbG8=".to_string(),
+        certificate_chain: vec![],
+    };
+
+    let bytes = response.to_bytes(None).unwrap();
+    assert_eq!(bytes, b"hello");
+}
+
+#[test]
+fn test_derive_key_response_pem_strip() {
+    use dstack_sdk::tappd_client::DeriveKeyResponse;
+
+    let pem_key = "-----BEGIN PRIVATE KEY-----\naGVsbG8=\n-----END PRIVATE KEY-----";
+    let response = DeriveKeyResponse {
+        key: pem_key.to_string(),
+        certificate_chain: vec![],
+    };
+
+    let bytes = response.to_bytes(None).unwrap();
+    assert_eq!(bytes, b"hello");
+}
+
+#[test]
+fn test_derive_key_response_truncate() {
+    use dstack_sdk::tappd_client::DeriveKeyResponse;
+
+    let response = DeriveKeyResponse {
+        key: "deadbeefcafe".to_string(),
+        certificate_chain: vec![],
+    };
+
+    let bytes = response.to_bytes(Some(4)).unwrap();
+    assert_eq!(bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+}


### PR DESCRIPTION
The compatible API resides in `TappdClient`, maintaining consistency with the js-sdk.