### PR TITLE
dstack-mr: Support for more than 255 CPUs

### DIFF
--- a/dstack-mr/cli/src/main.rs
+++ b/dstack-mr/cli/src/main.rs
@@ -24,7 +24,7 @@ type Bool = bool;
 struct MachineConfig {
     /// Number of CPUs
     #[arg(short, long, default_value = "1")]
-    cpu: u8,
+    cpu: u32,
 
     /// Memory size in bytes
     #[arg(short, long, default_value = "2G", value_parser = parse_memory_size)]

--- a/dstack-mr/src/machine.rs
+++ b/dstack-mr/src/machine.rs
@@ -8,7 +8,7 @@ use log::debug;
 
 #[derive(Debug, bon::Builder)]
 pub struct Machine<'a> {
-    pub cpu_count: u8,
+    pub cpu_count: u32,
     pub memory_size: u64,
     pub firmware: &'a str,
     pub kernel: &'a str,

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -131,7 +131,7 @@ pub struct VmConfig {
     pub spec_version: u32,
     #[serde(with = "hex_bytes")]
     pub os_image_hash: Vec<u8>,
-    pub cpu_count: u8,
+    pub cpu_count: u32,
     pub memory_size: u64,
     // https://github.com/intel-staging/qemu-tdx/issues/1
     #[serde(default)]

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -484,7 +484,7 @@ impl App {
             let vm_config = serde_json::to_string(&dstack_types::VmConfig {
                 spec_version: 1,
                 os_image_hash,
-                cpu_count: manifest.vcpu.try_into().context("Too many vCPUs")?,
+                cpu_count: manifest.vcpu,
                 memory_size: manifest.memory as u64 * 1024 * 1024,
                 qemu_single_pass_add_pages: cfg.cvm.qemu_single_pass_add_pages,
                 pic: cfg.cvm.qemu_pic,


### PR DESCRIPTION
The current u8 representation for CPU cores, inherited from the Go implementation, caps the maximum at 255. With dstack OS now [supporting up to 512 cores](https://github.com/Dstack-TEE/meta-dstack/pull/11), we must update dstack-mr to accommodate this expanded capacity.