### PR TITLE
gw: Add 0.3.x compatibility custom domain dns prefix

### DIFF
--- a/gateway/gateway.toml
+++ b/gateway/gateway.toml
@@ -60,6 +60,7 @@ buffer_size = 8192
 connect_top_n = 3
 localhost_enabled = false
 app_address_ns_prefix = "_dstack-app-address"
+app_address_ns_compat = true
 workers = 32
 external_port = 443
 

--- a/gateway/rpc/proto/gateway_rpc.proto
+++ b/gateway/rpc/proto/gateway_rpc.proto
@@ -41,8 +41,10 @@ message GuestAgentConfig {
   uint32 external_port = 1;
   // The in CVM port of the guest agent.
   uint32 internal_port = 2;
-  // The domain of the guest agent.
+  // The base domain of the zt-https
   string domain = 3;
+  // The app address namespace prefix
+  string app_address_ns_prefix = 4;
 }
 
 // StatusResponse is the response for Status.
@@ -145,6 +147,8 @@ message InfoResponse {
   string base_domain = 1;
   // The external port of the ZT-HTTPS
   uint32 external_port = 2;
+  // The app address namespace prefix
+  string app_address_ns_prefix = 3;
 }
 
 service Gateway {

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -80,6 +80,7 @@ pub struct ProxyConfig {
     pub localhost_enabled: bool,
     pub workers: usize,
     pub app_address_ns_prefix: String,
+    pub app_address_ns_compat: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -735,9 +735,10 @@ impl GatewayRpc for RpcHandler {
                 servers,
             }),
             agent: Some(GuestAgentConfig {
-                external_port: state.config.proxy.listen_port as u32,
+                external_port: state.config.proxy.external_port as u32,
                 internal_port: state.config.proxy.agent_port as u32,
                 domain: state.config.proxy.base_domain.clone(),
+                app_address_ns_prefix: state.config.proxy.app_address_ns_prefix.clone(),
             }),
         };
         self.state.notify_state_updated.notify_one();
@@ -786,6 +787,7 @@ impl GatewayRpc for RpcHandler {
         Ok(InfoResponse {
             base_domain: state.config.proxy.base_domain.clone(),
             external_port: state.config.proxy.external_port as u32,
+            app_address_ns_prefix: state.config.proxy.app_address_ns_prefix.clone(),
         })
     }
 }


### PR DESCRIPTION
This PR adds optional support for `TXT` prefix `_tapp-address`, which is compatible with dstack 0.3.x.