### PR TITLE
gateway: gRPC proxy support

### DIFF
--- a/docs/dstack-gateway.md
+++ b/docs/dstack-gateway.md
@@ -41,6 +41,27 @@ Focus on these five fields in the `core.proxy` section:
 
 For example, if your base domain is `gateway.example.com`, app ID is `<app_id>`, listening on `80`, and dstack-gateway is on port 7777, the URL would be `https://<app_id>-80.gateway.example.com:7777`
 
+### URL Format
+
+The gateway supports the following URL format:
+- `<app_id>[-<port>][<suffix>].<base_domain>`
+
+Where:
+- `<app_id>`: The application identifier
+- `<port>`: Optional port number (defaults to 80 for HTTP, 443 for HTTPS)
+- `<suffix>`: Optional suffix flags:
+  - `s`: Enable TLS passthrough (proxy passes encrypted traffic directly to backend)
+  - `g`: Enable HTTP/2 (gRPC) support (proxy advertises h2 via ALPN)
+
+Examples:
+- `<app_id>.gateway.example.com` - Default HTTP on port 80
+- `<app_id>-8080.gateway.example.com` - HTTP on port 8080
+- `<app_id>-s.gateway.example.com` - TLS passthrough on port 443
+- `<app_id>-443s.gateway.example.com` - TLS passthrough on port 443
+- `<app_id>-50051g.gateway.example.com` - HTTP/2/gRPC on port 50051
+
+Note: The `s` and `g` suffixes cannot be used together
+
 ## Step 5: Adjust Configuration in `vmm.toml`
 
 Open `vmm.toml` and adjust dstack-gateway configuration in the `gateway` section:

--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -60,6 +60,7 @@ pub struct ProxyInner {
     notify_state_updated: Notify,
     auth_client: AuthClient,
     pub(crate) acceptor: RwLock<TlsAcceptor>,
+    pub(crate) h2_acceptor: RwLock<TlsAcceptor>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,8 +142,11 @@ impl ProxyInner {
             }
             false => None,
         };
-        let acceptor =
-            RwLock::new(create_acceptor(&config.proxy).context("Failed to create acceptor")?);
+        let acceptor = RwLock::new(
+            create_acceptor(&config.proxy, false).context("Failed to create acceptor")?,
+        );
+        let h2_acceptor =
+            RwLock::new(create_acceptor(&config.proxy, true).context("Failed to create acceptor")?);
         Ok(Self {
             config,
             state,
@@ -150,6 +154,7 @@ impl ProxyInner {
             my_app_id,
             auth_client,
             acceptor,
+            h2_acceptor,
             certbot,
         })
     }

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -65,6 +65,7 @@ struct DstInfo {
     app_id: String,
     port: u16,
     is_tls: bool,
+    is_h2: bool,
 }
 
 fn parse_destination(sni: &str, dotted_base_domain: &str) -> Result<DstInfo> {
@@ -83,22 +84,28 @@ fn parse_destination(sni: &str, dotted_base_domain: &str) -> Result<DstInfo> {
     let last_part = parts.next();
     let is_tls;
     let port;
+    let is_h2;
     match last_part {
         None => {
             is_tls = false;
+            is_h2 = false;
             port = None;
         }
         Some(last_part) => {
-            let port_str = match last_part.strip_suffix('s') {
-                None => {
-                    is_tls = false;
-                    last_part
-                }
-                Some(last_part) => {
-                    is_tls = true;
-                    last_part
-                }
+            let (port_str, has_g) = match last_part.strip_suffix('g') {
+                Some(without_g) => (without_g, true),
+                None => (last_part, false),
             };
+
+            let (port_str, has_s) = match port_str.strip_suffix('s') {
+                Some(without_s) => (without_s, true),
+                None => (port_str, false),
+            };
+            if has_g && has_s {
+                bail!("invalid sni format: `gs` is not allowed");
+            }
+            is_h2 = has_g;
+            is_tls = has_s;
             port = if port_str.is_empty() {
                 None
             } else {
@@ -114,6 +121,7 @@ fn parse_destination(sni: &str, dotted_base_domain: &str) -> Result<DstInfo> {
         app_id,
         port,
         is_tls,
+        is_h2,
     })
 }
 
@@ -138,7 +146,9 @@ async fn handle_connection(
         if dst.is_tls {
             tls_passthough::proxy_to_app(state, inbound, buffer, &dst.app_id, dst.port).await
         } else {
-            state.proxy(inbound, buffer, &dst.app_id, dst.port).await
+            state
+                .proxy(inbound, buffer, &dst.app_id, dst.port, dst.is_h2)
+                .await
         }
     } else {
         tls_passthough::proxy_with_sni(state, inbound, buffer, &sni).await


### PR DESCRIPTION
This PR adds a new prefix `g` to the port part which means the backend is serving on HTTP/2.

### URL Format

The gateway supports the following URL format:
- `<app_id>[-<port>][<suffix>].<base_domain>`

Where:
- `<app_id>`: The application identifier
- `<port>`: Optional port number (defaults to 80 for HTTP, 443 for HTTPS)
- `<suffix>`: Optional suffix flags:
  - `s`: Enable TLS passthrough (proxy passes encrypted traffic directly to backend)
  - `g`: Enable HTTP/2 (gRPC) support (proxy advertises h2 via ALPN)

Examples:
- `<app_id>.gateway.example.com` - Default HTTP on port 80
- `<app_id>-8080.gateway.example.com` - HTTP on port 8080
- `<app_id>-s.gateway.example.com` - TLS passthrough on port 443
- `<app_id>-443s.gateway.example.com` - TLS passthrough on port 443
- `<app_id>-50051g.gateway.example.com` - HTTP/2/gRPC on port 50051

Note: The `s` and `g` suffixes cannot be used together