### PR TITLE
feat(rust-sdk): implement `borsh` serialization for rust sdk types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2250,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bon",
+ "borsh",
  "dcap-qvl",
  "hex",
  "pkcs8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ sd-notify = "0.4.5"
 jemallocator = "0.5.4"
 
 # Serialization/Parsing
+borsh = { version = "1.5.7", features = ["derive"] }
 bon = { version = "3.4.0", default-features = false }
 base64 = "0.22.1"
 hex = { version = "0.4.3", default-features = false }

--- a/sdk/rust/types/Cargo.toml
+++ b/sdk/rust/types/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Encifher <encifher@rizelabs.io>"]
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true
+borsh = { workspace = true, optional = true }
 hex = { workspace = true, features = ["alloc"] }
 pkcs8 = { workspace = true, features = ["pem"] }
 serde.workspace = true
@@ -21,6 +22,7 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["std"]
+borsh = ["dep:borsh"]
 std = [
     "anyhow/std",
     "bon/std",

--- a/sdk/rust/types/src/dstack.rs
+++ b/sdk/rust/types/src/dstack.rs
@@ -9,6 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_str, Value};
 use sha2::Digest;
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
+
 const INIT_MR: &str = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 fn replay_rtmr(history: Vec<String>) -> Result<String, FromHexError> {
@@ -29,6 +32,7 @@ fn replay_rtmr(history: Vec<String>) -> Result<String, FromHexError> {
 
 /// Represents an event log entry in the system
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct EventLog {
     /// The index of the IMR (Integrity Measurement Register)
     pub imr: u32,
@@ -43,7 +47,8 @@ pub struct EventLog {
 }
 
 /// Configuration for TLS key generation
-#[derive(Debug, bon::Builder, Serialize)]
+#[derive(Debug, bon::Builder, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TlsKeyConfig {
     /// The subject name for the certificate
     #[builder(into, default = String::new())]
@@ -64,6 +69,7 @@ pub struct TlsKeyConfig {
 
 /// Response containing a key and its signature chain
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct GetKeyResponse {
     /// The key in hexadecimal format
     pub key: String,
@@ -83,6 +89,7 @@ impl GetKeyResponse {
 
 /// Response containing a quote and associated event log
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct GetQuoteResponse {
     /// The attestation quote in hexadecimal format
     pub quote: String,
@@ -122,6 +129,7 @@ impl GetQuoteResponse {
 
 /// Response containing instance information and attestation data
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct InfoResponse {
     /// The application identifier
     pub app_id: String,
@@ -157,6 +165,7 @@ impl InfoResponse {
 
 /// Trusted Computing Base information structure
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TcbInfo {
     /// The measurement root of trust
     pub mrtd: String,
@@ -183,6 +192,7 @@ pub struct TcbInfo {
 
 /// Response containing TLS key and certificate chain
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct GetTlsKeyResponse {
     /// The TLS key in hexadecimal format
     pub key: String,

--- a/sdk/rust/types/src/tappd.rs
+++ b/sdk/rust/types/src/tappd.rs
@@ -4,6 +4,7 @@ use alloc::{
     vec::Vec,
 };
 use anyhow::{bail, Context as _, Result};
+use borsh::{BorshDeserialize, BorshSerialize};
 use hex::{encode as hex_encode, FromHexError};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
@@ -13,7 +14,8 @@ use crate::dstack::EventLog;
 const INIT_MR: &str = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 /// Hash algorithms supported by the TDX quote generation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub enum QuoteHashAlgorithm {
     Sha256,
     Sha384,
@@ -62,6 +64,7 @@ fn replay_rtmr(history: Vec<String>) -> Result<String, FromHexError> {
 
 /// Response from a key derivation request
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct DeriveKeyResponse {
     /// The derived key (PEM format for certificates, hex for raw keys)
     pub key: String,
@@ -132,6 +135,7 @@ impl DeriveKeyResponse {
 
 /// Response from a TDX quote request
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TdxQuoteResponse {
     /// The TDX quote in hexadecimal format
     pub quote: String,
@@ -178,6 +182,7 @@ impl TdxQuoteResponse {
 
 /// TCB (Trusted Computing Base) information
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TappdTcbInfo {
     /// The measurement root of trust
     pub mrtd: String,
@@ -197,6 +202,7 @@ pub struct TappdTcbInfo {
 
 /// Response from a Tappd info request
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct TappdInfoResponse {
     /// The application identifier
     pub app_id: String,

--- a/sdk/rust/types/src/tappd.rs
+++ b/sdk/rust/types/src/tappd.rs
@@ -4,10 +4,12 @@ use alloc::{
     vec::Vec,
 };
 use anyhow::{bail, Context as _, Result};
-use borsh::{BorshDeserialize, BorshSerialize};
 use hex::{encode as hex_encode, FromHexError};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
+
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::dstack::EventLog;
 


### PR DESCRIPTION
This PR adds optional [Borsh](https://borsh.io/) (Binary Object Representation Serializer for Hashing) serialization support to the Rust SDK types, complementing the existing Serde serialization capabilities.

Borsh is a highly efficient serializer and commonly used for smart contract development.