### PR TITLE
ra-tls: Add KeyCertSign and CrlSign usages for CA certs

### DIFF
--- a/ra-tls/src/cert.rs
+++ b/ra-tls/src/cert.rs
@@ -258,6 +258,8 @@ impl<Key> CertRequest<'_, Key> {
         }
         if let Some(ca_level) = self.ca_level {
             params.is_ca = IsCa::Ca(BasicConstraints::Constrained(ca_level));
+            params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+            params.key_usages.push(KeyUsagePurpose::CrlSign);
         }
         if let Some(not_before) = self.not_before {
             params.not_before = not_before.into();


### PR DESCRIPTION
This fixes some verifiers complain