### PR TITLE
Add init_script in app-compose.json

### DIFF
--- a/basefiles/dstack-prepare.sh
+++ b/basefiles/dstack-prepare.sh
@@ -45,3 +45,11 @@ mkdir -p $DATA_MNT/var/lib/docker
 mount --rbind $DATA_MNT/var/lib/docker /var/lib/docker
 mount --rbind $WORK_DIR /dstack
 mount_overlay /etc/users $OVERLAY_PERSIST
+
+cd /dstack
+
+if [ $(jq 'has("init_script")' app-compose.json) == true ]; then
+    echo "Running init script"
+    dstack-util notify-host -e "boot.progress" -d "init-script" || true
+    source <(jq -r '.init_script' app-compose.json)
+fi

--- a/docs/security-guide/cvm-boundaries.md
+++ b/docs/security-guide/cvm-boundaries.md
@@ -39,7 +39,9 @@ This is the main configuration file for the application in JSON format:
 | allowed_envs | array of string | List of allowed environment variable names |
 | no_instance_id | boolean | Disable instance ID generation |
 | secure_time | boolean | Whether secure time is enabled |
-| pre_launch_script | string | Prelaunch bash script that runs before starting containers |
+| pre_launch_script | string | Prelaunch bash script that runs before execute `docker compose up` |
+| init_script | string | Bash script that executed prior to dockerd startup |
+
 
 The hash of this file content is extended to RTMR3 as event name `compose-hash`. Remote verifier can extract the compose-hash during remote attestation.
 


### PR DESCRIPTION
The pre_launch_script is executed after dockerd has started, so that it can use the `docker` command. However, the drawback is that app containers may start before pre_launch_script execution after a system reboot. This PR adds `init_script` which is guaranteed to be executed before dockerd starts.