### PR TITLE
dstack-mr: Add qemu_version in VmConfig

### DIFF
--- a/dstack-mr/src/acpi.rs
+++ b/dstack-mr/src/acpi.rs
@@ -85,7 +85,12 @@ impl Machine<'_> {
         } else {
             machine.push_str(",smm=off");
         }
-        if self.pic {
+
+        let vopt = self
+            .versioned_options()
+            .context("Failed to get versioned options")?;
+
+        if vopt.pic {
             machine.push_str(",pic=on");
         } else {
             machine.push_str(",pic=off");
@@ -148,8 +153,13 @@ impl Machine<'_> {
 
         debug!("qemu command: {cmd:?}");
 
+        let ver = vopt.version;
         // Execute the command and capture output
         let output = cmd
+            .env(
+                "QEMU_ACPI_COMPAT_VER",
+                format!("{}.{}.{}", ver.0, ver.1, ver.2),
+            )
             .output()
             .context("failed to execute dstack-acpi-tables")?;
 

--- a/dstack-mr/src/machine.rs
+++ b/dstack-mr/src/machine.rs
@@ -6,7 +6,7 @@ use crate::tdvf::Tdvf;
 use crate::util::debug_print_log;
 use crate::{kernel, TdxMeasurements};
 use crate::{measure_log, measure_sha384};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use fs_err as fs;
 use log::debug;
 
@@ -18,8 +18,9 @@ pub struct Machine<'a> {
     pub kernel: &'a str,
     pub initrd: &'a str,
     pub kernel_cmdline: &'a str,
-    pub two_pass_add_pages: bool,
-    pub pic: bool,
+    pub two_pass_add_pages: Option<bool>,
+    pub pic: Option<bool>,
+    pub qemu_version: Option<String>,
     #[builder(default = false)]
     pub smm: bool,
     pub pci_hole64_size: Option<u64>,
@@ -28,6 +29,53 @@ pub struct Machine<'a> {
     pub num_nvswitches: u32,
     pub hotplug_off: bool,
     pub root_verity: bool,
+}
+
+fn parse_version_tuple(v: &str) -> Result<(u32, u32, u32)> {
+    let parts: Vec<u32> = v
+        .split('.')
+        .map(|p| p.parse::<u32>().context("Invalid version number"))
+        .collect::<Result<Vec<_>, _>>()?;
+    if parts.len() != 3 {
+        bail!(
+            "Version string must have exactly 3 parts (major.minor.patch), got {}",
+            parts.len()
+        );
+    }
+    Ok((parts[0], parts[1], parts[2]))
+}
+
+impl Machine<'_> {
+    pub fn versioned_options(&self) -> Result<VersionedOptions> {
+        let version = match &self.qemu_version {
+            Some(v) => Some(parse_version_tuple(v).context("Failed to parse QEMU version")?),
+            None => None,
+        };
+        let default_pic;
+        let default_two_pass;
+        let version = version.unwrap_or((9, 1, 0));
+        if version < (8, 0, 0) {
+            bail!("Unsupported QEMU version: {version:?}");
+        }
+        if ((8, 0, 0)..(9, 0, 0)).contains(&version) {
+            default_pic = true;
+            default_two_pass = true;
+        } else {
+            default_pic = false;
+            default_two_pass = false;
+        };
+        Ok(VersionedOptions {
+            version,
+            pic: self.pic.unwrap_or(default_pic),
+            two_pass_add_pages: self.two_pass_add_pages.unwrap_or(default_two_pass),
+        })
+    }
+}
+
+pub struct VersionedOptions {
+    pub version: (u32, u32, u32),
+    pub pic: bool,
+    pub two_pass_add_pages: bool,
 }
 
 impl Machine<'_> {

--- a/dstack-mr/src/tdvf.rs
+++ b/dstack-mr/src/tdvf.rs
@@ -223,7 +223,10 @@ impl<'a> Tdvf<'a> {
     }
 
     pub fn mrtd(&self, machine: &Machine) -> Result<Vec<u8>> {
-        self.compute_mrtd(if machine.two_pass_add_pages {
+        let opts = machine
+            .versioned_options()
+            .context("Failed to get versioned options")?;
+        self.compute_mrtd(if opts.two_pass_add_pages {
             PageAddOrder::TwoPass
         } else {
             PageAddOrder::SinglePass

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -151,6 +151,7 @@ pub struct VmConfig {
     pub num_nvswitches: u32,
     #[serde(default)]
     pub hotplug_off: bool,
+    pub image: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -138,10 +138,9 @@ pub struct VmConfig {
     pub cpu_count: u32,
     pub memory_size: u64,
     // https://github.com/intel-staging/qemu-tdx/issues/1
-    #[serde(default)]
-    pub qemu_single_pass_add_pages: bool,
-    #[serde(default)]
-    pub pic: bool,
+    pub qemu_single_pass_add_pages: Option<bool>,
+    pub pic: Option<bool>,
+    pub qemu_version: Option<String>,
     #[serde(default)]
     pub pci_hole64_size: u64,
     #[serde(default)]

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -268,8 +268,9 @@ impl RpcHandler {
             .kernel_cmdline(&kernel_cmdline)
             .root_verity(true)
             .hotplug_off(vm_config.hotplug_off)
-            .two_pass_add_pages(vm_config.qemu_single_pass_add_pages)
-            .pic(vm_config.pic)
+            .maybe_two_pass_add_pages(vm_config.qemu_single_pass_add_pages)
+            .maybe_pic(vm_config.pic)
+            .maybe_qemu_version(vm_config.qemu_version.clone())
             .maybe_pci_hole64_size(if vm_config.pci_hole64_size > 0 {
                 Some(vm_config.pci_hole64_size)
             } else {

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -519,6 +519,7 @@ impl App {
                 num_gpus: gpus.gpus.len() as u32,
                 num_nvswitches: gpus.bridges.len() as u32,
                 hotplug_off: cfg.cvm.qemu_hotplug_off,
+                image: Some(manifest.image.clone()),
             })?;
             json!({
                 "kms_urls": kms_urls,

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -513,6 +513,7 @@ impl App {
                 memory_size: manifest.memory as u64 * 1024 * 1024,
                 qemu_single_pass_add_pages: cfg.cvm.qemu_single_pass_add_pages,
                 pic: cfg.cvm.qemu_pic,
+                qemu_version: cfg.cvm.qemu_version.clone(),
                 pci_hole64_size: cfg.cvm.qemu_pci_hole64_size,
                 hugepages: manifest.hugepages,
                 num_gpus: gpus.gpus.len() as u32,

--- a/vmm/src/one_shot.rs
+++ b/vmm/src/one_shot.rs
@@ -267,6 +267,7 @@ Compose file content (first 200 chars):
             num_gpus: manifest.gpus.as_ref().map_or(0, |g| g.gpus.len() as u32),
             num_nvswitches: manifest.gpus.as_ref().map_or(0, |g| g.bridges.len() as u32),
             hotplug_off: config.cvm.qemu_hotplug_off,
+            image: Some(manifest.image.clone()),
         })?
     });
     let sys_config_path = vm_work_dir.shared_dir().join(".sys-config.json");

--- a/vmm/src/one_shot.rs
+++ b/vmm/src/one_shot.rs
@@ -261,6 +261,7 @@ Compose file content (first 200 chars):
             memory_size: manifest.memory as u64 * 1024 * 1024,
             qemu_single_pass_add_pages: config.cvm.qemu_single_pass_add_pages,
             pic: config.cvm.qemu_pic,
+            qemu_version: config.cvm.qemu_version.clone(),
             pci_hole64_size: config.cvm.qemu_pci_hole64_size,
             hugepages: manifest.hugepages,
             num_gpus: manifest.gpus.as_ref().map_or(0, |g| g.gpus.len() as u32),

--- a/vmm/vmm.toml
+++ b/vmm/vmm.toml
@@ -30,8 +30,9 @@ user = ""
 use_mrconfigid = true
 
 # QEMU flags
-qemu_single_pass_add_pages = false
-qemu_pic = true
+#qemu_single_pass_add_pages = false
+#qemu_pic = true
+#qemu_version = ""
 qemu_pci_hole64_size = 0
 qemu_hotplug_off = false
 


### PR DESCRIPTION
Enabling dstack-mr to generate version-specific ACPI tables for QEMU.
image name is also added by the way.