### PR TITLE
Retry create state app RPC on failure with exponential backoff

### DIFF
--- a/guest-agent/src/main.rs
+++ b/guest-agent/src/main.rs
@@ -66,6 +66,16 @@ async fn run_internal_v0(
         .map_err(|err| anyhow!("Failed to ignite rocket: {err}"))?;
     let endpoint = DefaultListener::bind_endpoint(&ignite)
         .map_err(|err| anyhow!("Failed to get endpoint: {err}"))?;
+    // Clean up existing socket file or directory if it exists
+    if let Some(path) = endpoint.unix() {
+        if path.exists() {
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).ok();
+            } else {
+                std::fs::remove_file(path).ok();
+            }
+        }
+    }
     let listener = DefaultListener::bind(&ignite)
         .await
         .map_err(|err| anyhow!("Failed to bind on {endpoint}: {err}"))?;
@@ -95,6 +105,16 @@ async fn run_internal(
         .map_err(|err| anyhow!("Failed to ignite rocket: {err}"))?;
     let endpoint = DefaultListener::bind_endpoint(&ignite)
         .map_err(|err| anyhow!("Failed to get endpoint: {err}"))?;
+    // Clean up existing socket file or directory if it exists
+    if let Some(path) = endpoint.unix() {
+        if path.exists() {
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).ok();
+            } else {
+                std::fs::remove_file(path).ok();
+            }
+        }
+    }
     let listener = DefaultListener::bind(&ignite)
         .await
         .map_err(|err| anyhow!("Failed to bind on {endpoint}: {err}"))?;


### PR DESCRIPTION
This pull request introduces reliability improvements to certificate handling and socket file management in the guest agent. The main changes are the addition of exponential backoff retry logic for certificate requests and cleanup of existing Unix socket files or directories before binding. These updates help prevent startup failures due to transient certificate service errors or leftover socket files.

**Certificate Request Reliability:**

* Added exponential backoff retry logic (up to 5 attempts) for certificate requests in `AppState`, `DstackGuestRpc`, and `TappdRpc` implementations to handle transient failures gracefully. Retries are logged with warnings and delays increase exponentially. [[1]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L60-R67) [[2]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L74-R99) [[3]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L170-R222) [[4]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L308-R382)
* Improved error handling for certificate requests, returning a contextual error if all retries fail. [[1]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L74-R99) [[2]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L170-R222) [[3]](diffhunk://#diff-ab2f74912d79add3fde6fd222f8c264f065ef9c2d34a52015abdc308db73ce13L308-R382)

**Socket File Management:**

* Added cleanup logic to remove existing Unix socket files or directories before binding the listener in both `run_internal_v0` and `run_internal` functions, preventing binding errors due to leftover files. [[1]](diffhunk://#diff-44c77a11c8d066525eb5abcced4d98af5527f50a0e8f7adecb3b1923e02ab68cR69-R78) [[2]](diffhunk://#diff-44c77a11c8d066525eb5abcced4d98af5527f50a0e8f7adecb3b1923e02ab68cR108-R117)
