### PR TITLE
cvm: Remove docker config from app compose

### DIFF
--- a/docs/security-guide/cvm-boundaries.md
+++ b/docs/security-guide/cvm-boundaries.md
@@ -29,7 +29,7 @@ This is the main configuration file for the application in JSON format:
 | name | 0.3.1 | string | Name of the instance |
 | runner | 0.3.1 | string | Name of the runner (currently defaults to "docker-compose") |
 | docker_compose_file | 0.3.1 | string | YAML string representing docker-compose config |
-| docker_config | 0.3.1 | object | Additional docker settings (currently empty) |
+| docker_config | 0.3.1 | object | (Removed since 0.5.5) Additional docker settings (currently empty) |
 | kms_enabled | 0.3.1 | boolean | Enable/disable KMS |
 | gateway_enabled | 0.3.1 | boolean | Enable/disable gateway |
 | local_key_provider_enabled | 0.3.1 | boolean | Use a local key provider |

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -17,8 +17,6 @@ pub struct AppCompose {
     #[serde(default)]
     pub docker_compose_file: Option<String>,
     #[serde(default)]
-    pub docker_config: DockerConfig,
-    #[serde(default)]
     pub public_logs: bool,
     #[serde(default)]
     pub public_sysinfo: bool,


### PR DESCRIPTION
Remove this feature as it has been broken since `0.5.0`, causing CVM boot failures. Use the prelaunch script instead.