### PR TITLE
feat: customize site name for VMM

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -265,6 +265,10 @@ pub struct Config {
     /// The URL of the KMS server
     pub kms_url: String,
 
+    /// Node name (optional, used as prefix in UI title)
+    #[serde(default)]
+    pub node_name: String,
+
     /// CVM configuration
     pub cvm: CvmConfig,
     /// Gateway configuration

--- a/vmm/src/console.html
+++ b/vmm/src/console.html
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>dstack VM Management Console</title>
+    <title>{{TITLE}}</title>
     <script src="https://unpkg.com/vue@3.0.0/dist/vue.global.js"></script>
     <script src="/res/x25519.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"

--- a/vmm/src/main_routes.rs
+++ b/vmm/src/main_routes.rs
@@ -28,8 +28,15 @@ macro_rules! file_or_include_str {
 }
 
 #[get("/")]
-async fn index() -> (ContentType, String) {
-    (ContentType::HTML, file_or_include_str!("console.html"))
+async fn index(app: &State<App>) -> (ContentType, String) {
+    let html = file_or_include_str!("console.html");
+    let title = if app.config.node_name.is_empty() {
+        "dstack VM Management Console".to_string()
+    } else {
+        format!("{} - dstack VM Management Console", app.config.node_name)
+    };
+    let html = html.replace("{{TITLE}}", &title);
+    (ContentType::HTML, html)
 }
 
 #[get("/res/<path>")]


### PR DESCRIPTION
This PR lets us customize the site name in the built-in VMM console UI, so we can find the right one quickly when we have multiple pages open from different dstack instances.