### PR TITLE
Update README to clarify app-id definition

### DIFF
--- a/kms/README.md
+++ b/kms/README.md
@@ -28,7 +28,7 @@ CVMs running in dstack support three boot modes:
 - Supports application upgrades
 - Requires control contract configuration
 - `key-provider` in RTMR: `{"type": "kms", "id": "<kms-root-pubkey>"}`
-- `app-id` is derived from the deployer's eth address + salt
+- `app-id` is equal to the address of the deployed App Smart Contract.
 
 ## KMS Implementation
 


### PR DESCRIPTION
Clarified the definition of `app-id` in the README.