### PR TITLE
fix(verifier): remove pccs_url from public API to prevent SSRF

### DIFF
--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -69,6 +69,7 @@ impl KmsState {
             config.image.cache_dir.display().to_string(),
             config.image.download_url.clone(),
             config.image.download_timeout,
+            config.pccs_url.clone(),
         );
         Ok(Self {
             inner: Arc::new(KmsStateInner {

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -78,7 +78,7 @@ You usually don't need to edit the config file. Just using the default is fine, 
 - `image_cache_dir`: Directory for cached OS images (default: "/tmp/dstack-verifier/cache")
 - `image_download_url`: URL template for downloading OS images (default: dstack official releases URL)
 - `image_download_timeout_secs`: Download timeout in seconds (default: 300)
-- `pccs_url`: Optional PCCS URL for quote verification
+- `pccs_url`: PCCS URL for quote verification (default: uses Intel's public PCCS)
 
 ### Example Configuration File
 
@@ -88,7 +88,7 @@ port = 8080
 image_cache_dir = "/tmp/dstack-verifier/cache"
 image_download_url = "https://download.dstack.org/os-images/mr_{OS_IMAGE_HASH}.tar.gz"
 image_download_timeout_secs = 300
-pccs_url = "https://pccs.phala.network"
+# pccs_url = "https://pccs.phala.network"
 ```
 
 ## Usage

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -85,17 +85,15 @@ async fn run_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to read file {}: {}", file_path, e))?;
 
     // Parse as VerificationRequest
-    let mut request: VerificationRequest = serde_json::from_str(&content)
+    let request: VerificationRequest = serde_json::from_str(&content)
         .map_err(|e| anyhow::anyhow!("Failed to parse JSON: {}", e))?;
-
-    // Ensure PCCS URL is populated from config when the report omits it
-    request.pccs_url = request.pccs_url.or_else(|| config.pccs_url.clone());
 
     // Create verifier
     let verifier = CvmVerifier::new(
         config.image_cache_dir.clone(),
         config.image_download_url.clone(),
         std::time::Duration::from_secs(config.image_download_timeout_secs),
+        config.pccs_url.clone(),
     );
 
     // Run verification
@@ -187,6 +185,7 @@ async fn main() -> Result<()> {
         config.image_cache_dir.clone(),
         config.image_download_url.clone(),
         std::time::Duration::from_secs(config.image_download_timeout_secs),
+        config.pccs_url.clone(),
     ));
 
     rocket::custom(figment)

--- a/verifier/src/types.rs
+++ b/verifier/src/types.rs
@@ -15,7 +15,6 @@ pub struct VerificationRequest {
     pub vm_config: Option<String>,
     #[serde(with = "serde_bytes")]
     pub attestation: Option<Vec<u8>>,
-    pub pccs_url: Option<String>,
     pub debug: Option<bool>,
 }
 

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -137,14 +137,21 @@ pub struct CvmVerifier {
     pub image_cache_dir: String,
     pub download_url: String,
     pub download_timeout: Duration,
+    pub pccs_url: Option<String>,
 }
 
 impl CvmVerifier {
-    pub fn new(image_cache_dir: String, download_url: String, download_timeout: Duration) -> Self {
+    pub fn new(
+        image_cache_dir: String,
+        download_url: String,
+        download_timeout: Duration,
+        pccs_url: Option<String>,
+    ) -> Self {
         Self {
             image_cache_dir,
             download_url,
             download_timeout,
+            pccs_url,
         }
     }
 
@@ -408,7 +415,7 @@ impl CvmVerifier {
 
         let attestation = attestation.into_inner();
         let debug = request.debug.unwrap_or(false);
-        let verified = attestation.verify(request.pccs_url.as_deref()).await;
+        let verified = attestation.verify(self.pccs_url.as_deref()).await;
         let verified_attestation = match verified {
             Ok(att) => {
                 details.quote_verified = true;


### PR DESCRIPTION
Remove the pccs_url parameter from the VerificationRequest struct to prevent potential SSRF attacks where a malicious client could specify an arbitrary URL. The PCCS URL is now only configurable via the server configuration file.

Changes:
- Remove pccs_url field from VerificationRequest in types.rs
- Add pccs_url to CvmVerifier struct instead of passing per-request
- Update all CvmVerifier::new() calls to pass pccs_url from config
- Update README to reflect the configuration-only approach