### PR TITLE
fix(event-log): strip RTMR[0-2] payloads and document semantics

### DIFF
--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -339,10 +339,13 @@ impl<T> Attestation<T> {
             .map(|q| serde_json::to_vec(&q.event_log).unwrap_or_default())
     }
 
-    /// Get TDX event log string
+    /// Get TDX event log string with RTMR[0-2] payloads stripped to reduce size.
+    /// Only digests are kept for boot-time events; runtime events (RTMR3) retain full payload.
     pub fn get_tdx_event_log_string(&self) -> Option<String> {
-        self.tdx_quote()
-            .map(|q| serde_json::to_string(&q.event_log).unwrap_or_default())
+        self.tdx_quote().map(|q| {
+            let stripped: Vec<_> = q.event_log.iter().map(|e| e.stripped()).collect();
+            serde_json::to_string(&stripped).unwrap_or_default()
+        })
     }
 
     pub fn get_td10_report(&self) -> Option<TDReport10> {

--- a/sdk/curl/api-tappd.md
+++ b/sdk/curl/api-tappd.md
@@ -128,11 +128,14 @@ curl --unix-socket /var/run/tappd.sock -X POST \
 ```json
 {
   "quote": "<hex-encoded-quote>",
-  "event_log": "quote generation log",
+  "event_log": "<json-event-log>",
   "hash_algorithm": "sha512",
   "prefix": "app-data:"
 }
 ```
+
+**Note on Event Log:**
+The `event_log` field contains a JSON array of TDX event log entries. For RTMR 0-2 (boot-time measurements), only the digest is included; the payload is stripped to reduce response size. For RTMR3 (runtime measurements), both digest and payload are included.
 
 ### 4. Raw Quote
 
@@ -166,9 +169,12 @@ curl --unix-socket /var/run/tappd.sock http://localhost/prpc/Tappd.RawQuote?repo
 ```json
 {
   "quote": "<hex-encoded-quote>",
-  "event_log": "quote generation log"
+  "event_log": "<json-event-log>"
 }
 ```
+
+**Note on Event Log:**
+The `event_log` field contains a JSON array of TDX event log entries. For RTMR 0-2 (boot-time measurements), only the digest is included; the payload is stripped to reduce response size. For RTMR3 (runtime measurements), both digest and payload are included.
 
 ### 5. Info
 

--- a/sdk/curl/api.md
+++ b/sdk/curl/api.md
@@ -132,11 +132,14 @@ curl --unix-socket /var/run/dstack.sock http://dstack/GetQuote?report_data=00000
 ```json
 {
   "quote": "<hex-encoded-quote>",
-  "event_log": "quote generation log",
+  "event_log": "<json-event-log>",
   "report_data": "<hex-encoded-report-data>",
   "vm_config": "<json-vm-config-string>"
 }
 ```
+
+**Note on Event Log:**
+The `event_log` field contains a JSON array of TDX event log entries. For RTMR 0-2 (boot-time measurements), only the digest is included; the payload is stripped to reduce response size. For RTMR3 (runtime measurements), both digest and payload are included. To verify the event log, submit it along with the quote to the [verifier service](../../verifier/README.md).
 
 ### 4. Get Info
 

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -31,7 +31,7 @@ or
   "is_valid": true,
   "details": {
     "quote_verified": true,
-    "event_log_verified": true,
+    "event_log_verified": true,  // See "Verification Process" for semantics
     "os_image_hash_verified": true,
     "report_data": "hex-encoded-64-byte-report-data",
     "tcb_status": "UpToDate",
@@ -178,7 +178,7 @@ $ curl -s -d @quote.json localhost:8080/verify | jq
 The verifier performs three main verification steps:
 
 1. **Quote Verification**: Validates the TDX quote using dcap-qvl, checking the quote signature and TCB status
-2. **Event Log Verification**: Replays event logs to ensure RTMR values match and extracts app information
+2. **Event Log Verification**: Replays event logs to ensure RTMR values match and extracts app information. For RTMR3 (runtime measurements), both the digest and payload integrity are verified. For RTMR 0-2 (boot-time measurements), only the digests are verified; the payload content is not validated as dstack does not define semantics for these payloads
 3. **OS Image Hash Verification**:
    - Automatically downloads OS images if not cached locally
    - Uses dstack-mr to compute expected measurements

--- a/verifier/src/types.rs
+++ b/verifier/src/types.rs
@@ -28,6 +28,13 @@ pub struct VerificationResponse {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct VerificationDetails {
     pub quote_verified: bool,
+    /// Indicates that the event log was verified against the quote.
+    ///
+    /// For RTMR3 (runtime measurements), both the digest and payload integrity are verified
+    /// by replaying the event log and comparing against the quote. For RTMR 0-2 (boot-time
+    /// measurements), only the digests are verified through replay comparison with the quote;
+    /// the payload content is not validated. dstack does not define semantics for RTMR 0-2
+    /// event log payloads.
     pub event_log_verified: bool,
     pub os_image_hash_verified: bool,
     pub report_data: Option<String>,


### PR DESCRIPTION
Strip boot-time event log payloads (RTMR 0-2) from GetQuote, Attest, and TdxQuote responses to reduce response size. Only digests are retained for verification purposes; runtime events (RTMR3) keep full payloads.

Add documentation explaining event_log_verified semantics: RTMR3 events have both digest and payload verified, while RTMR 0-2 events only have digests verified through replay comparison.