### PR TITLE
feat(ra-tls): adjust certificate validity periods for security

### DIFF
--- a/dstack-util/src/main.rs
+++ b/dstack-util/src/main.rs
@@ -13,7 +13,7 @@ use k256::schnorr::SigningKey;
 use ra_rpc::Attestation;
 use ra_tls::{
     attestation::QuoteContentType,
-    cert::generate_ra_cert,
+    cert::{generate_ra_cert, server_cert_not_after},
     kdf::{derive_ecdsa_key, derive_ecdsa_key_pair_from_bytes},
     rcgen::KeyPair,
 };
@@ -348,6 +348,7 @@ fn cmd_gen_ca_cert(args: GenCaCertArgs) -> Result<()> {
         .attestation(&attestation)
         .key(&key)
         .ca_level(args.ca_level)
+        .not_after(server_cert_not_after())
         .build();
 
     let cert = req
@@ -419,6 +420,7 @@ fn make_app_keys(
         .attestation(&attestation)
         .key(app_key)
         .ca_level(ca_level)
+        .not_after(server_cert_not_after())
         .build();
     let cert = req
         .self_signed()

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -110,6 +110,7 @@ async fn maybe_gen_certs(config: &Config, tls_config: &TlsConfig) -> Result<()> 
         .subject("dstack-gateway")
         .alt_names(std::slice::from_ref(&config.rpc_domain))
         .usage_server_auth(true)
+        .not_after(ra_tls::cert::server_cert_not_after())
         .build()
         .self_signed()
         .context("Failed to self-sign rpc cert")?;

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -17,7 +17,9 @@ use k256::ecdsa::SigningKey;
 use ra_rpc::{CallContext, RpcCall};
 use ra_tls::{
     attestation::VerifiedAttestation,
-    cert::{CaCert, CertRequest, CertSigningRequestV1, CertSigningRequestV2, Csr},
+    cert::{
+        server_cert_not_after, CaCert, CertRequest, CertSigningRequestV1, CertSigningRequestV2, Csr,
+    },
     kdf,
 };
 use scale::Decode;
@@ -224,6 +226,7 @@ impl RpcHandler {
             .ca_level(0)
             .app_id(app_id)
             .special_usage("app:ca")
+            .not_after(server_cert_not_after())
             .build();
         let app_ca = self
             .state


### PR DESCRIPTION
- Change default certificate validity from 10 years to 1 hour
- Add server_cert_not_after() helper for long-lived server certs (10 years)
- Add client_cert_not_after() helper for short-lived client certs (10 minutes)
- Update KMS CA, RPC and App CA certs to use 10-year validity
- Update Gateway RPC cert to use 10-year validity
- Update dstack-util generated certs to use 10-year validity
- Update RA-TLS temp certs to use 10-minute validity


This is a breaking change. We should reconsider carefully.