### PR TITLE
fix(vmm): use custom gateway URL for dashboard when VM has custom kms/gw endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ tokio = { version = "1.46.1" }
 tokio-vsock = "0.7.0"
 sysinfo = "0.35.2"
 default-net = "0.22.0"
+url = "2.5"
 
 # Cryptography/Security
 aes-gcm = "0.10.3"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -53,6 +53,7 @@ size-parser = { workspace = true, features = ["serde"] }
 fatfs.workspace = true
 fscommon.workspace = true
 or-panic.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 insta.workspace = true


### PR DESCRIPTION
## Summary

When a VM is configured with custom `gateway_urls`, the dashboard URL (`app_url`) now correctly uses the custom gateway's host and port instead of the global gateway config.

## Problem

Previously, VMs with custom kms/gw endpoints would show incorrect dashboard URLs pointing to the default gateway, even though they were configured to use a different gateway.

## Solution

The fix parses the first gateway URL from the VM's custom `gateway_urls` and extracts the host and port to construct the correct dashboard URL:

- If VM has custom `gateway_urls`: use the host/port from the first custom URL
- Otherwise: fall back to the global gateway config

## Test plan

- [x] Deploy a VM with custom `--gateway-url https://custom-gateway.example.com:9202`
- [x] Verify the dashboard URL in the VMM console points to the custom gateway
- [x] Verify VMs without custom gateway_urls still use the default gateway URL