### PR TITLE
fix: clippy warning in dstack-types

### DIFF
--- a/dstack-types/src/version.rs
+++ b/dstack-types/src/version.rs
@@ -44,7 +44,7 @@ impl Version {
         // Strip prerelease (-...) and build metadata (+...) suffixes
         // Find the first occurrence of '-' or '+'
         let version = version
-            .split_once(|c| c == '-' || c == '+')
+            .split_once(['-', '+'])
             .map(|(v, _)| v)
             .unwrap_or(version);
 


### PR DESCRIPTION
## Summary

Fix `clippy::manual_pattern_char_comparison` warning by using a char array instead of a closure.

```rust
// Before
.split_once(|c| c == '-' || c == '+')

// After
.split_once(['-', '+'])
```

This fixes the CI failure on master.