### PR TITLE
kdf: rename derive_ecdsa_* functions to more accurate names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,6 +2590,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "which 7.0.3",
 ]

--- a/dstack-util/src/main.rs
+++ b/dstack-util/src/main.rs
@@ -14,7 +14,7 @@ use ra_rpc::Attestation;
 use ra_tls::{
     attestation::QuoteContentType,
     cert::generate_ra_cert,
-    kdf::{derive_ecdsa_key, derive_ecdsa_key_pair_from_bytes},
+    kdf::{derive_key, derive_p256_key_pair_from_bytes},
     rcgen::KeyPair,
 };
 use std::{
@@ -378,9 +378,9 @@ fn gen_app_keys_from_seed(
     provider: KeyProviderKind,
     mr: Option<Vec<u8>>,
 ) -> Result<AppKeys> {
-    let key = derive_ecdsa_key_pair_from_bytes(seed, &["app-key".as_bytes()])?;
-    let disk_key = derive_ecdsa_key_pair_from_bytes(seed, &["app-disk-key".as_bytes()])?;
-    let k256_key = derive_ecdsa_key(seed, &["app-k256-key".as_bytes()], 32)?;
+    let key = derive_p256_key_pair_from_bytes(seed, &["app-key".as_bytes()])?;
+    let disk_key = derive_p256_key_pair_from_bytes(seed, &["app-disk-key".as_bytes()])?;
+    let k256_key = derive_key(seed, &["app-k256-key".as_bytes()], 32)?;
     let k256_key = SigningKey::from_bytes(&k256_key).context("Failed to parse k256 key")?;
     let key_provider = match provider {
         KeyProviderKind::None => KeyProvider::None {

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -30,7 +30,7 @@ use ra_rpc::{Attestation, CallContext, RpcCall};
 use ra_tls::{
     attestation::{QuoteContentType, VersionedAttestation, DEFAULT_HASH_ALGORITHM},
     cert::CertConfigV2,
-    kdf::{derive_ecdsa_key, derive_ecdsa_key_pair_from_bytes},
+    kdf::{derive_key, derive_p256_key_pair_from_bytes},
 };
 use rcgen::KeyPair;
 use ring::rand::{SecureRandom, SystemRandom};
@@ -235,7 +235,7 @@ impl DstackGuestRpc for InternalRpcHandler {
             .fill(&mut seed)
             .context("Failed to generate secure seed")?;
         let derived_key =
-            derive_ecdsa_key_pair_from_bytes(&seed, &[]).context("Failed to derive key")?;
+            derive_p256_key_pair_from_bytes(&seed, &[]).context("Failed to derive key")?;
         let config = CertConfigV2 {
             org_name: None,
             subject: request.subject,
@@ -270,7 +270,7 @@ impl DstackGuestRpc for InternalRpcHandler {
 
         let (key, pubkey_hex) = match request.algorithm.as_str() {
             "ed25519" => {
-                let derived_key = derive_ecdsa_key(k256_app_key, &[request.path.as_bytes()], 32)
+                let derived_key = derive_key(k256_app_key, &[request.path.as_bytes()], 32)
                     .context("Failed to derive ed25519 key")?;
                 let signing_key = Ed25519SigningKey::from_bytes(
                     &derived_key
@@ -282,7 +282,7 @@ impl DstackGuestRpc for InternalRpcHandler {
                 (derived_key, pubkey_hex)
             }
             "secp256k1" | "secp256k1_prehashed" | "" => {
-                let derived_key = derive_ecdsa_key(k256_app_key, &[request.path.as_bytes()], 32)
+                let derived_key = derive_key(k256_app_key, &[request.path.as_bytes()], 32)
                     .context("Failed to derive k256 key")?;
 
                 let signing_key =
@@ -497,7 +497,7 @@ impl TappdRpc for InternalRpcHandlerV0 {
         } else {
             &self.state.inner.keys.k256_key
         };
-        let derived_key = derive_ecdsa_key_pair_from_bytes(seed, &[request.path.as_bytes()])
+        let derived_key = derive_p256_key_pair_from_bytes(seed, &[request.path.as_bytes()])
             .context("Failed to derive key")?;
         let config = CertConfigV2 {
             org_name: None,

--- a/kms/src/crypto.rs
+++ b/kms/src/crypto.rs
@@ -13,11 +13,10 @@ pub(crate) fn derive_k256_key(
     app_id: &[u8],
 ) -> Result<(SigningKey, Vec<u8>)> {
     let context_data = [app_id, b"app-key"];
-    let derived_key_bytes: [u8; 32] =
-        kdf::derive_ecdsa_key(&parent_key.to_bytes(), &context_data, 32)?
-            .try_into()
-            .ok()
-            .context("Invalid derived key len")?;
+    let derived_key_bytes: [u8; 32] = kdf::derive_key(&parent_key.to_bytes(), &context_data, 32)?
+        .try_into()
+        .ok()
+        .context("Invalid derived key len")?;
     let derived_signing_key = SigningKey::from_bytes(&derived_key_bytes.into())?;
     let pubkey = derived_signing_key.verifying_key();
 

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -215,7 +215,7 @@ impl RpcHandler {
 
     fn derive_app_ca(&self, app_id: &[u8]) -> Result<CaCert> {
         let context_data = vec![app_id, b"app-ca"];
-        let app_key = kdf::derive_ecdsa_key_pair(&self.state.root_ca.key, &context_data)
+        let app_key = kdf::derive_p256_key_pair(&self.state.root_ca.key, &context_data)
             .context("Failed to derive app disk key")?;
         let req = CertRequest::builder()
             .key(&app_key)


### PR DESCRIPTION
## Summary

Rename KDF functions to better reflect their actual purpose:

| Old Name | New Name |
|----------|----------|
| `derive_ecdsa_key` | `derive_key` |
| `derive_ecdsa_key_pair` | `derive_p256_key_pair` |
| `derive_ecdsa_key_pair_from_bytes` | `derive_p256_key_pair_from_bytes` |

## Rationale

- `derive_ecdsa_key` was misleading - it's a generic HKDF-SHA256 key derivation that can produce keys for any algorithm (ed25519, secp256k1, etc.), not specifically ECDSA
- `derive_ecdsa_key_pair` and `derive_ecdsa_key_pair_from_bytes` specifically produce P-256 key pairs, so the new names make this explicit

## Test plan

- [x] All existing tests pass
- [x] No external users of ra-tls::kdf module