### PR TITLE
fix(tdx-attest): align dummy.rs API with linux.rs for musl builds

### DIFF
--- a/tdx-attest/src/dummy.rs
+++ b/tdx-attest/src/dummy.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cc_eventlog::TdxEventLog;
 use num_enum::FromPrimitive;
 use thiserror::Error;
 
@@ -48,11 +47,7 @@ pub fn extend_rtmr(_index: u32, _event_type: u32, _digest: [u8; 48]) -> Result<(
 pub fn get_report(_report_data: &TdxReportData) -> Result<TdxReport> {
     Err(TdxAttestError::NotSupported)
 }
-pub fn get_quote(
-    _report_data: &TdxReportData,
-    _att_key_id_list: Option<&[TdxUuid]>,
-) -> Result<(TdxUuid, Vec<u8>)> {
-    let _ = _report_data;
+pub fn get_quote(_report_data: &TdxReportData) -> Result<Vec<u8>> {
     Err(TdxAttestError::NotSupported)
 }
 pub fn get_supported_att_key_ids() -> Result<Vec<TdxUuid>> {


### PR DESCRIPTION
## Summary
- Fix dummy.rs `get_quote` signature to match linux.rs
- Remove unused `cc_eventlog::TdxEventLog` import

## Problem
When building for `x86_64-unknown-linux-musl` target, the code fails to compile because:

1. `dummy.rs` is selected (since `target_env != "gnu"`)
2. The `get_quote` function signature in `dummy.rs` doesn't match `linux.rs`
3. `dstack-attest` calls `tdx_attest::get_quote(report_data)` with 1 argument, but `dummy.rs` expects 2

Error:
```
error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> vendor/dstack/dstack-attest/src/attestation.rs:608:29
    |
608 |                 let quote = tdx_attest::get_quote(report_data).context("Failed to get quote")?;
```

## Solution
Align `dummy.rs` API signatures with `linux.rs`:
- `get_quote(report_data: &TdxReportData) -> Result<Vec<u8>>`

## Use Case
This enables building static binaries with musl for better cross-distro compatibility. For example, binaries built on Ubuntu with glibc 2.39 don't work on RockyLinux 9 which has glibc 2.34. Static musl builds solve this.