### PR TITLE
Fix encrypted ZFS persistence issue

### DIFF
--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1053,11 +1053,12 @@ impl<'a> Stage0<'a> {
             }
         };
 
-        // For encrypted ZFS, need both LUKS header AND zpool to exist
-        let initialized = if opts.storage_encrypted && opts.storage_fs == FsType::Zfs {
-            has_luks && has_fs
+        // For encrypted filesystems, we can only detect the filesystem after LUKS is opened
+        // So we rely on LUKS header presence as the indicator for both ext4 and ZFS
+        let initialized = if opts.storage_encrypted {
+            has_luks
         } else {
-            has_luks || has_fs
+            has_fs
         };
 
         if !initialized {


### PR DESCRIPTION
## Problem
Encrypted ZFS volumes were reformatted on every reboot because initialization checked for both LUKS header and zpool on the raw encrypted device.

## Solution
For encrypted filesystems, only check for LUKS header presence; filesystem detection happens after opening LUKS. Aligns encrypted ZFS with encrypted ext4.

## Testing
- cargo clippy
- Verified encrypted ext4 storage persists correctly with KMS key provider
- Verified encrypted ZFS storage persists correctly