### PR TITLE
fix: Move `/var/run/dstack.sock` to `/var/run/dstack/dstack.sock` directory

### DIFF
--- a/basefiles/dstack-socket.service
+++ b/basefiles/dstack-socket.service
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Proxy service that forwards connections from /var/run/dstack.sock to /var/run/dstack/dstack.sock.
+# Used for backward compatibility with containers that mount the socket file directly.
+
+[Unit]
+Description=dstack socket proxy for backward compatibility
+Requires=dstack-socket.socket
+After=dstack-guest-agent.service
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-socket-proxyd /var/run/dstack/dstack.sock
+Type=notify

--- a/basefiles/dstack-socket.socket
+++ b/basefiles/dstack-socket.socket
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Backward compatibility socket for containers that mount /var/run/dstack.sock directly.
+# The socket is owned by systemd, so it survives service restarts without inode changes.
+
+[Unit]
+Description=dstack backward compatibility socket (dstack.sock)
+
+[Socket]
+ListenStream=/var/run/dstack.sock
+SocketMode=0777
+
+[Install]
+WantedBy=sockets.target

--- a/basefiles/tappd-socket.service
+++ b/basefiles/tappd-socket.service
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Proxy service that forwards connections from /var/run/tappd.sock to /var/run/dstack/tappd.sock.
+# Used for backward compatibility with containers that mount the socket file directly.
+
+[Unit]
+Description=tappd socket proxy for backward compatibility
+Requires=tappd-socket.socket
+After=dstack-guest-agent.service
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-socket-proxyd /var/run/dstack/tappd.sock
+Type=notify

--- a/basefiles/tappd-socket.socket
+++ b/basefiles/tappd-socket.socket
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Backward compatibility socket for containers that mount /var/run/tappd.sock directly.
+# The socket is owned by systemd, so it survives service restarts without inode changes.
+
+[Unit]
+Description=dstack backward compatibility socket (tappd.sock)
+
+[Socket]
+ListenStream=/var/run/tappd.sock
+SocketMode=0777
+
+[Install]
+WantedBy=sockets.target

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -263,7 +263,14 @@ pub fn dstack_agent_address() -> String {
     if let Ok(address) = std::env::var("DSTACK_AGENT_ADDRESS") {
         return address;
     }
-    "unix:/var/run/dstack.sock".into()
+    // Try new path first, fall back to old path for backward compatibility
+    const SOCKET_PATHS: &[&str] = &["/var/run/dstack/dstack.sock", "/var/run/dstack.sock"];
+    for path in SOCKET_PATHS {
+        if std::path::Path::new(path).exists() {
+            return format!("unix:{}", path);
+        }
+    }
+    format!("unix:{}", SOCKET_PATHS[0])
 }
 
 /// Hardware/Cloud Platform

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1440,6 +1440,7 @@ impl Stage1<'_> {
     async fn setup(&self) -> Result<()> {
         let _envs = self.unseal_env_vars()?;
         self.link_files()?;
+        self.setup_socket_dir()?;
         self.setup_guest_agent_config()?;
         self.vmm
             .notify_q("boot.progress", "setting up dstack-gateway")
@@ -1461,6 +1462,13 @@ impl Stage1<'_> {
             ln -sf ${HOST_SHARED_DIR_NAME}/${APP_COMPOSE};
             ln -sf ${HOST_SHARED_DIR_NAME}/${USER_CONFIG} user_config;
         }?;
+        Ok(())
+    }
+
+    /// Setup socket directory for dstack-guest-agent.
+    fn setup_socket_dir(&self) -> Result<()> {
+        info!("Setting up socket directory");
+        fs::create_dir_all("/var/run/dstack").context("Failed to create socket directory")?;
         Ok(())
     }
 

--- a/guest-agent/dstack.toml
+++ b/guest-agent/dstack.toml
@@ -21,11 +21,11 @@ enabled = false
 attestation_file = "attestation.bin"
 
 [internal-v0]
-address = "unix:/var/run/tappd.sock"
+address = "unix:/var/run/dstack/tappd.sock"
 reuse = true
 
 [internal]
-address = "unix:/var/run/dstack.sock"
+address = "unix:/var/run/dstack/dstack.sock"
 reuse = true
 
 [external]

--- a/sdk/go/tappd/client.go
+++ b/sdk/go/tappd/client.go
@@ -185,7 +185,8 @@ func WithLogger(logger *slog.Logger) TappdClientOption {
 // Creates a new TappdClient instance based on the provided endpoint.
 // If the endpoint is empty, it will use the simulator endpoint if it is
 // set in the environment through DSTACK_SIMULATOR_ENDPOINT. Otherwise, it
-// will use the default endpoint at /var/run/tappd.sock.
+// will try /var/run/dstack/tappd.sock first, falling back to /var/run/tappd.sock
+// for backward compatibility.
 func NewTappdClient(opts ...TappdClientOption) *TappdClient {
 	client := &TappdClient{
 		endpoint:   "",
@@ -218,8 +219,9 @@ func NewTappdClient(opts ...TappdClientOption) *TappdClient {
 
 // Returns the appropriate endpoint based on environment and input. If the
 // endpoint is empty, it will use the simulator endpoint if it is set in the
-// environment through DSTACK_SIMULATOR_ENDPOINT. Otherwise, it will use the
-// default endpoint at /var/run/tappd.sock.
+// environment through DSTACK_SIMULATOR_ENDPOINT. Otherwise, it will try
+// /var/run/dstack/tappd.sock first, falling back to /var/run/tappd.sock
+// for backward compatibility.
 func (c *TappdClient) getEndpoint() string {
 	if c.endpoint != "" {
 		return c.endpoint
@@ -228,7 +230,17 @@ func (c *TappdClient) getEndpoint() string {
 		c.logger.Info("using simulator endpoint", "endpoint", simEndpoint)
 		return simEndpoint
 	}
-	return "/var/run/tappd.sock"
+	// Try new path first, fall back to old path for backward compatibility
+	socketPaths := []string{
+		"/var/run/dstack/tappd.sock",
+		"/var/run/tappd.sock",
+	}
+	for _, path := range socketPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return socketPaths[0]
 }
 
 // Sends an RPC request to the Tappd service.

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -179,7 +179,12 @@ export class DstackClient<T extends TcbInfo = TcbInfoV05x> {
         console.warn(`Using simulator endpoint: ${process.env.DSTACK_SIMULATOR_ENDPOINT}`)
         endpoint = process.env.DSTACK_SIMULATOR_ENDPOINT
       } else {
-        endpoint = '/var/run/dstack.sock'
+        // Try new path first, fall back to old path for backward compatibility
+        const socketPaths = [
+          '/var/run/dstack/dstack.sock',
+          '/var/run/dstack.sock',
+        ]
+        endpoint = socketPaths.find(p => fs.existsSync(p)) ?? socketPaths[0]
       }
     }
     if (endpoint.startsWith('/') && !fs.existsSync(endpoint)) {
@@ -402,7 +407,12 @@ export class TappdClient extends DstackClient<TcbInfoV03x> {
         console.warn(`Using tappd endpoint: ${process.env.TAPPD_SIMULATOR_ENDPOINT}`)
         endpoint = process.env.TAPPD_SIMULATOR_ENDPOINT
       } else {
-        endpoint = '/var/run/tappd.sock'
+        // Try new path first, fall back to old path for backward compatibility
+        const socketPaths = [
+          '/var/run/dstack/tappd.sock',
+          '/var/run/tappd.sock',
+        ]
+        endpoint = socketPaths.find(p => fs.existsSync(p)) ?? socketPaths[0]
       }
     }
     console.warn('TappdClient is deprecated, please use DstackClient instead')

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -51,7 +51,16 @@ def get_endpoint(endpoint: str | None = None) -> str:
             f"Using simulator endpoint: {os.environ['DSTACK_SIMULATOR_ENDPOINT']}"
         )
         return os.environ["DSTACK_SIMULATOR_ENDPOINT"]
-    return "/var/run/dstack.sock"
+    # Try new path first, fall back to old path for backward compatibility
+    socket_paths = [
+        "/var/run/dstack/dstack.sock",
+        "/var/run/dstack.sock",
+    ]
+    for path in socket_paths:
+        if os.path.exists(path):
+            return path
+    # Default to new path even if not exists (will fail with clear error)
+    return socket_paths[0]
 
 
 def get_tappd_endpoint(endpoint: str | None = None) -> str:
@@ -60,7 +69,15 @@ def get_tappd_endpoint(endpoint: str | None = None) -> str:
     if "TAPPD_SIMULATOR_ENDPOINT" in os.environ:
         logger.info(f"Using tappd endpoint: {os.environ['TAPPD_SIMULATOR_ENDPOINT']}")
         return os.environ["TAPPD_SIMULATOR_ENDPOINT"]
-    return "/var/run/tappd.sock"
+    # Try new path first, fall back to old path for backward compatibility
+    socket_paths = [
+        "/var/run/dstack/tappd.sock",
+        "/var/run/tappd.sock",
+    ]
+    for path in socket_paths:
+        if os.path.exists(path):
+            return path
+    return socket_paths[0]
 
 
 def emit_deprecation_warning(message: str, stacklevel: int = 2) -> None:

--- a/sdk/rust/src/dstack_client.rs
+++ b/sdk/rust/src/dstack_client.rs
@@ -36,7 +36,15 @@ fn get_endpoint(endpoint: Option<&str>) -> String {
     if let Ok(sim_endpoint) = env::var("DSTACK_SIMULATOR_ENDPOINT") {
         return sim_endpoint;
     }
-    "/var/run/dstack.sock".to_string()
+    // Try new path first, fall back to old path for backward compatibility
+    const SOCKET_PATHS: &[&str] = &["/var/run/dstack/dstack.sock", "/var/run/dstack.sock"];
+    for path in SOCKET_PATHS {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+    // Default to new path even if not exists (will fail with clear error)
+    SOCKET_PATHS[0].to_string()
 }
 
 #[derive(Debug)]

--- a/sdk/rust/src/tappd_client.rs
+++ b/sdk/rust/src/tappd_client.rs
@@ -21,7 +21,14 @@ fn get_tappd_endpoint(endpoint: Option<&str>) -> String {
     if let Ok(sim_endpoint) = env::var("TAPPD_SIMULATOR_ENDPOINT") {
         return sim_endpoint;
     }
-    "/var/run/tappd.sock".to_string()
+    // Try new path first, fall back to old path for backward compatibility
+    const SOCKET_PATHS: &[&str] = &["/var/run/dstack/tappd.sock", "/var/run/tappd.sock"];
+    for path in SOCKET_PATHS {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+    SOCKET_PATHS[0].to_string()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Problem

When containers mount the socket file directly (e.g., `-v /var/run/dstack.sock:/var/run/dstack.sock`), the socket becomes inaccessible after guest-agent restarts.

### Root Cause

Docker's bind mount locks the **inode** at container start time, not the path. When guest-agent restarts:

1. Rocket's Unix socket handling acquires an exclusive lock on `<path>.lock`
2. If `reuse=true` (default), it **deletes** the existing socket file via `remove_file()`
3. Creates a new socket via `bind()` - this creates a **NEW inode**
4. The container still holds the **old inode**, which no longer has any listener

### Why Rocket Deletes the Socket

Unlike TCP sockets, **Unix Domain Sockets do not support `SO_REUSEADDR`**. The `bind()` syscall requires the path to not exist - if the socket file already exists, `bind()` fails with `EADDRINUSE`.

Rocket's `reuse` option is a workaround that simulates TCP-like behavior by:
1. Acquiring a file lock to prevent races
2. **Deleting** the existing socket file
3. Creating a new socket

This "delete and recreate" approach is necessary for UDS but breaks Docker's file-based mounts.

**Relevant Rocket code** ([unix.rs:32-72](https://github.com/rwf2/Rocket/blob/3a54d079aef060a8f732bd04ea54b0581a604087/core/lib/src/listener/unix.rs#L32-L72)):

```rust
pub async fn bind<P: AsRef<Path>>(path: P, reuse: bool) -> io::Result<Self> {
    let lock = if reuse {
        // ...acquire exclusive lock...
        if path.exists() {
            tokio::fs::remove_file(&path).await?;  // <-- Deletes old socket!
        }
        Some(lock_file)
    };
    let listener = tokio::net::UnixListener::bind(&path);  // <-- Creates new inode
    // ...
}
```

## Solution

### 1. Move guest-agent to listen on new paths

| Old Path | New Path |
|----------|----------|
| `/var/run/dstack.sock` | `/var/run/dstack/dstack.sock` |
| `/var/run/tappd.sock` | `/var/run/dstack/tappd.sock` |

### 2. Systemd socket proxy for backward compatibility

For containers that mount the old paths, we use **systemd socket activation** with `systemd-socket-proxyd`:

```
Container → /var/run/dstack.sock (systemd-owned) → proxy → /var/run/dstack/dstack.sock (guest-agent)
```

**Key insight**: `systemd.socket` creates and owns the socket file, not the service process. This means:
- The socket file **persists across proxy service restarts**
- The **inode never changes**
- Containers mounting `/var/run/dstack.sock` continue to work even after guest-agent restarts

Files added:
- `dstack-socket.socket` + `dstack-socket.service`
- `tappd-socket.socket` + `tappd-socket.service`

### 3. SDK Fallback

All SDKs (Rust, Python, JS, Go) try the new path first, falling back to the old path for compatibility with older guest-agent versions.

## User Impact

**None** - Apps can continue using `/var/run/dstack.sock` and `/var/run/tappd.sock` as before. The systemd socket proxy handles the forwarding transparently.

## Changes

- **guest-agent/dstack.toml**: Updated socket paths to `/var/run/dstack/`
- **dstack-util/src/system_setup.rs**: Create `/var/run/dstack/` directory
- **basefiles/**: Added systemd socket + proxy service files for backward compatibility
- **SDK updates**: Rust, Python, JS, Go clients try new path first with fallback