### PR TITLE
fix: Create mount points before rbind mount

### DIFF
--- a/basefiles/dstack-prepare.sh
+++ b/basefiles/dstack-prepare.sh
@@ -265,6 +265,9 @@ log "Mounting docker dirs to persistent storage"
 # Mount docker dirs to DATA_MNT
 mkdir -p $DATA_MNT/var/lib/docker
 mkdir -p $DATA_MNT/var/lib/containerd
+# Create mount points (containerd may not have started yet to create them)
+mkdir -p /var/lib/docker
+mkdir -p /var/lib/containerd
 mount --rbind $DATA_MNT/var/lib/docker /var/lib/docker
 mount --rbind $DATA_MNT/var/lib/containerd /var/lib/containerd
 mount --rbind $WORK_DIR /dstack


### PR DESCRIPTION
## Summary
- Create `/var/lib/docker` and `/var/lib/containerd` directories before rbind mount

## Problem
When `containerd.service` is configured with a drop-in to start after `dstack-prepare.service`, the `/var/lib/containerd` directory may not exist yet since containerd hasn't started to create it. This causes the rbind mount to fail with:

```
mount: /var/lib/containerd: mount point does not exist.
```

## Solution
Create the mount point directories explicitly in `dstack-prepare.sh` before attempting the rbind mount.

## Test plan
- [x] Boot a CVM with containerd.service configured to start after dstack-prepare.service
- [x] Verify dstack-prepare.service completes successfully
- [x] Verify containerd and docker start normally