### PR TITLE
feat(sdk): Add /run socket paths for compatibility

### DIFF
--- a/sdk/go/dstack/client.go
+++ b/sdk/go/dstack/client.go
@@ -240,10 +240,12 @@ func (c *DstackClient) getEndpoint() string {
 		c.logger.Info("using simulator endpoint", "endpoint", simEndpoint)
 		return simEndpoint
 	}
-	// Try new path first, fall back to old path for backward compatibility
+	// Try paths in order: legacy paths first, then namespaced paths
 	socketPaths := []string{
-		"/var/run/dstack/dstack.sock",
 		"/var/run/dstack.sock",
+		"/run/dstack.sock",
+		"/var/run/dstack/dstack.sock",
+		"/run/dstack/dstack.sock",
 	}
 	for _, path := range socketPaths {
 		if _, err := os.Stat(path); err == nil {

--- a/sdk/go/tappd/client.go
+++ b/sdk/go/tappd/client.go
@@ -230,10 +230,12 @@ func (c *TappdClient) getEndpoint() string {
 		c.logger.Info("using simulator endpoint", "endpoint", simEndpoint)
 		return simEndpoint
 	}
-	// Try new path first, fall back to old path for backward compatibility
+	// Try paths in order: legacy paths first, then namespaced paths
 	socketPaths := []string{
-		"/var/run/dstack/tappd.sock",
 		"/var/run/tappd.sock",
+		"/run/tappd.sock",
+		"/var/run/dstack/tappd.sock",
+		"/run/dstack/tappd.sock",
 	}
 	for _, path := range socketPaths {
 		if _, err := os.Stat(path); err == nil {

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -179,10 +179,12 @@ export class DstackClient<T extends TcbInfo = TcbInfoV05x> {
         console.warn(`Using simulator endpoint: ${process.env.DSTACK_SIMULATOR_ENDPOINT}`)
         endpoint = process.env.DSTACK_SIMULATOR_ENDPOINT
       } else {
-        // Try new path first, fall back to old path for backward compatibility
+        // Try paths in order: legacy paths first, then namespaced paths
         const socketPaths = [
-          '/var/run/dstack/dstack.sock',
           '/var/run/dstack.sock',
+          '/run/dstack.sock',
+          '/var/run/dstack/dstack.sock',
+          '/run/dstack/dstack.sock',
         ]
         endpoint = socketPaths.find(p => fs.existsSync(p)) ?? socketPaths[0]
       }
@@ -407,10 +409,12 @@ export class TappdClient extends DstackClient<TcbInfoV03x> {
         console.warn(`Using tappd endpoint: ${process.env.TAPPD_SIMULATOR_ENDPOINT}`)
         endpoint = process.env.TAPPD_SIMULATOR_ENDPOINT
       } else {
-        // Try new path first, fall back to old path for backward compatibility
+        // Try paths in order: legacy paths first, then namespaced paths
         const socketPaths = [
-          '/var/run/dstack/tappd.sock',
           '/var/run/tappd.sock',
+          '/run/tappd.sock',
+          '/var/run/dstack/tappd.sock',
+          '/run/dstack/tappd.sock',
         ]
         endpoint = socketPaths.find(p => fs.existsSync(p)) ?? socketPaths[0]
       }

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -51,10 +51,12 @@ def get_endpoint(endpoint: str | None = None) -> str:
             f"Using simulator endpoint: {os.environ['DSTACK_SIMULATOR_ENDPOINT']}"
         )
         return os.environ["DSTACK_SIMULATOR_ENDPOINT"]
-    # Try new path first, fall back to old path for backward compatibility
+    # Try paths in order: legacy paths first, then namespaced paths
     socket_paths = [
-        "/var/run/dstack/dstack.sock",
         "/var/run/dstack.sock",
+        "/run/dstack.sock",
+        "/var/run/dstack/dstack.sock",
+        "/run/dstack/dstack.sock",
     ]
     for path in socket_paths:
         if os.path.exists(path):
@@ -69,10 +71,12 @@ def get_tappd_endpoint(endpoint: str | None = None) -> str:
     if "TAPPD_SIMULATOR_ENDPOINT" in os.environ:
         logger.info(f"Using tappd endpoint: {os.environ['TAPPD_SIMULATOR_ENDPOINT']}")
         return os.environ["TAPPD_SIMULATOR_ENDPOINT"]
-    # Try new path first, fall back to old path for backward compatibility
+    # Try paths in order: legacy paths first, then namespaced paths
     socket_paths = [
-        "/var/run/dstack/tappd.sock",
         "/var/run/tappd.sock",
+        "/run/tappd.sock",
+        "/var/run/dstack/tappd.sock",
+        "/run/dstack/tappd.sock",
     ]
     for path in socket_paths:
         if os.path.exists(path):

--- a/sdk/rust/src/dstack_client.rs
+++ b/sdk/rust/src/dstack_client.rs
@@ -36,8 +36,13 @@ fn get_endpoint(endpoint: Option<&str>) -> String {
     if let Ok(sim_endpoint) = env::var("DSTACK_SIMULATOR_ENDPOINT") {
         return sim_endpoint;
     }
-    // Try new path first, fall back to old path for backward compatibility
-    const SOCKET_PATHS: &[&str] = &["/var/run/dstack/dstack.sock", "/var/run/dstack.sock"];
+    // Try paths in order: legacy paths first, then namespaced paths
+    const SOCKET_PATHS: &[&str] = &[
+        "/var/run/dstack.sock",
+        "/run/dstack.sock",
+        "/var/run/dstack/dstack.sock",
+        "/run/dstack/dstack.sock",
+    ];
     for path in SOCKET_PATHS {
         if std::path::Path::new(path).exists() {
             return path.to_string();

--- a/sdk/rust/src/tappd_client.rs
+++ b/sdk/rust/src/tappd_client.rs
@@ -21,8 +21,13 @@ fn get_tappd_endpoint(endpoint: Option<&str>) -> String {
     if let Ok(sim_endpoint) = env::var("TAPPD_SIMULATOR_ENDPOINT") {
         return sim_endpoint;
     }
-    // Try new path first, fall back to old path for backward compatibility
-    const SOCKET_PATHS: &[&str] = &["/var/run/dstack/tappd.sock", "/var/run/tappd.sock"];
+    // Try paths in order: legacy paths first, then namespaced paths
+    const SOCKET_PATHS: &[&str] = &[
+        "/var/run/tappd.sock",
+        "/run/tappd.sock",
+        "/var/run/dstack/tappd.sock",
+        "/run/dstack/tappd.sock",
+    ];
     for path in SOCKET_PATHS {
         if std::path::Path::new(path).exists() {
             return path.to_string();


### PR DESCRIPTION
## Summary
Add `/run/*.sock` and `/run/dstack/*.sock` to the socket path search list in all SDKs. This ensures compatibility with systemd socket activation which uses `/run` instead of `/var/run`.

## Background
PR #478 introduced systemd socket activation for dstack-guest-agent, which creates sockets at `/run/dstack.sock` and `/run/tappd.sock` (using the modern `/run` path instead of legacy `/var/run`).

While `/var/run` is typically a symlink to `/run` on modern Linux systems, some container environments may not have this symlink configured. Adding explicit `/run` paths ensures SDKs work correctly in all environments.

## Changes
Updated socket path search order in all SDKs:
- **Rust**: `sdk/rust/src/dstack_client.rs`, `sdk/rust/src/tappd_client.rs`
- **Python**: `sdk/python/src/dstack_sdk/dstack_client.py`
- **JavaScript**: `sdk/js/src/index.ts`
- **Go**: `sdk/go/dstack/client.go`, `sdk/go/tappd/client.go`

## Search Order (legacy paths first for backward compatibility)
1. `/var/run/*.sock` (legacy path)
2. `/run/*.sock` (modern systemd path)
3. `/var/run/dstack/*.sock` (namespaced legacy)
4. `/run/dstack/*.sock` (namespaced modern)