### PR TITLE
fix(vmm): Forbid host API listening on non-vsock addresses

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -409,6 +409,22 @@ pub struct HostApiConfig {
     pub port: u32,
 }
 
+impl HostApiConfig {
+    /// Validate that the host API address is a vsock address.
+    /// The host API must only listen on vsock for security reasons.
+    /// TCP/Unix socket listening is not supported.
+    pub fn validate(&self) -> Result<()> {
+        if !self.address.starts_with("vsock:") {
+            anyhow::bail!(
+                "Host API address must be a vsock address (e.g., 'vsock:2'), got: '{}'. \
+                TCP/Unix socket listening is not supported for the host API.",
+                self.address
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct KeyProviderConfig {
     pub enabled: bool,


### PR DESCRIPTION
## Summary
The host API is designed for CVM-to-host communication via vsock only. When users accidentally configure TCP or Unix socket addresses, it silently falls back without proper error, making troubleshooting difficult.

## Changes
- Add validation in `HostApiConfig` to ensure address starts with `vsock:`
- Validate config at startup and fail fast with clear error message
- Remove TCP fallback code from `run_host_api` since only vsock is supported

## Error Message
If a user configures a non-vsock address like `127.0.0.1`:
```
Error: Invalid host_api configuration

Caused by:
    Host API address must be a vsock address (e.g., 'vsock:2'), got: '127.0.0.1'. 
    TCP/Unix socket listening is not supported for the host API.
```

Fixes #417