### PR TITLE
chore: pin Rust toolchain to 1.92

### DIFF
--- a/key-provider-build/Dockerfile.key-provider
+++ b/key-provider-build/Dockerfile.key-provider
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     build-essential=12.8ubuntu1.1 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.80 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.92 -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Set environment variables

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.92"
+components = ["rustfmt", "clippy", "rust-analyzer"]
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-musl"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,4 +5,4 @@
 [toolchain]
 channel = "1.92"
 components = ["rustfmt", "clippy", "rust-analyzer"]
-targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-musl"]
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-musl", "thumbv6m-none-eabi"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [toolchain]
 channel = "1.92"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` to pin Rust version to 1.92
- Includes components: rustfmt, clippy, rust-analyzer
- Includes targets: wasm32-unknown-unknown, x86_64-unknown-linux-musl
- Bump key-provider Dockerfile Rust version to 1.92 to match

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets` passes (no new warnings)
- [x] CI reuse-lint passes