### PR TITLE
feat(gateway): support multi-port TCP listening via port ranges

### DIFF
--- a/gateway/rpc/proto/gateway_rpc.proto
+++ b/gateway/rpc/proto/gateway_rpc.proto
@@ -77,8 +77,6 @@ message HostInfo {
   string app_id = 3;
   // The base domain of the HTTPS endpoint of the host.
   string base_domain = 4;
-  // The external port of the host.
-  uint32 port = 5;
   // The latest handshake time of the host.
   uint64 latest_handshake = 6;
   // The number of connections of the host.

--- a/gateway/src/admin_service.rs
+++ b/gateway/src/admin_service.rs
@@ -35,7 +35,6 @@ impl AdminRpcHandler {
                 ip: instance.ip.to_string(),
                 app_id: instance.app_id.clone(),
                 base_domain: base_domain.clone(),
-                port: state.config.proxy.listen_port as u32,
                 latest_handshake: encode_ts(instance.last_seen),
                 num_connections: instance.num_connections(),
             })
@@ -97,7 +96,6 @@ impl AdminRpc for AdminRpcHandler {
                 ip: instance.ip.to_string(),
                 app_id: instance.app_id.clone(),
                 base_domain: base_domain.clone(),
-                port: state.config.proxy.listen_port as u32,
                 latest_handshake: {
                     let (ts, _) = handshakes
                         .get(&instance.public_key)

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -8,6 +8,7 @@ use std::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
+    task::Poll,
 };
 
 use anyhow::{bail, Context, Result};
@@ -173,21 +174,35 @@ pub async fn proxy_main(config: &ProxyConfig, proxy: Proxy) -> Result<()> {
         let base_domain = base_domain.strip_prefix(".").unwrap_or(base_domain);
         Arc::new(format!(".{base_domain}"))
     };
-    let listener = TcpListener::bind((config.listen_addr, config.listen_port))
-        .await
-        .with_context(|| {
-            format!(
-                "failed to bind {}:{}",
-                config.listen_addr, config.listen_port
-            )
-        })?;
-    info!(
-        "tcp bridge listening on {}:{}",
-        config.listen_addr, config.listen_port
-    );
+    let mut tcp_listeners = Vec::new();
+    for &port in &config.listen_port {
+        let listener = TcpListener::bind((config.listen_addr, port))
+            .await
+            .with_context(|| format!("failed to bind {}:{}", config.listen_addr, port))?;
+        info!("tcp bridge listening on {}:{}", config.listen_addr, port);
+        tcp_listeners.push(listener);
+    }
+    if tcp_listeners.is_empty() {
+        bail!("no tcp listen ports configured");
+    }
 
+    let poll_counter = AtomicUsize::new(0);
     loop {
-        match listener.accept().await {
+        // Accept from any TCP listener via round-robin poll.
+        let poll_start = poll_counter.fetch_add(1, Ordering::Relaxed);
+        let n = tcp_listeners.len();
+        let accepted: std::io::Result<(TcpStream, std::net::SocketAddr)> =
+            std::future::poll_fn(|cx| {
+                for j in 0..n {
+                    let i = (poll_start + j) % n;
+                    if let Poll::Ready(result) = tcp_listeners[i].poll_accept(cx) {
+                        return Poll::Ready(result);
+                    }
+                }
+                Poll::Pending
+            })
+            .await;
+        match accepted {
             Ok((inbound, from)) => {
                 let span = info_span!("conn", id = next_connection_id());
                 let _enter = span.enter();
@@ -210,7 +225,7 @@ pub async fn proxy_main(config: &ProxyConfig, proxy: Proxy) -> Result<()> {
                                 info!("connection closed");
                             }
                             Ok(Err(e)) => {
-                                error!("connection error: {e:?}");
+                                error!("connection error: {e:#}");
                             }
                             Err(_) => {
                                 error!("connection kept too long, force closing");
@@ -245,7 +260,7 @@ pub fn start(config: ProxyConfig, app_state: Proxy) -> Result<()> {
             // Run the proxy_main function in this runtime
             if let Err(err) = rt.block_on(proxy_main(&config, app_state)) {
                 error!(
-                    "error on {}:{}: {err:?}",
+                    "error on {}:{:?}: {err:?}",
                     config.listen_addr, config.listen_port
                 );
             }


### PR DESCRIPTION
## Summary
- Allow `listen_port` to accept either a single port (`8443`) or a range string (`"8443-8543"`) to bind multiple TCP listeners
- Round-robin poll across all listeners to avoid starving any port
- Remove single-port `port` field from `HostInfo` proto (no longer meaningful with port ranges)
- Use `{e:#}` for cleaner connection error logs

## Context
Under high concurrency (>60K connections per port), a single listen port can exhaust its accept queue or cause kernel-level backlog issues. Binding multiple ports distributes incoming connections across more kernel data structures.

Load testing confirmed: 20 ports handled 200K concurrent TLS connections at 100% success rate.

## Config example
```toml
# Single port (backwards compatible)
listen_port = 8443

# Port range
listen_port = "8443-8462"
```

## Test results
- [x] Deployed to gateway CVM with `listen_port = "14100-14110"`
- [x] Gateway bound all 11 ports (14100-14110), confirmed via `/proc/net/tcp`
- [x] TCP connections to non-default ports (e.g., 14105) succeed from host
- [x] Backwards-compatible single port config continues to work