### PR TITLE
Remove passt networking mode support

### DIFF
--- a/vmm/rpc/proto/vmm_rpc.proto
+++ b/vmm/rpc/proto/vmm_rpc.proto
@@ -105,7 +105,7 @@ message VmConfiguration {
 
 // Per-VM networking configuration.
 message NetworkingConfig {
-  // Networking mode: "passt", "bridge", "user"
+  // Networking mode: "bridge", "user"
   string mode = 1;
 }
 

--- a/vmm/src/app/qemu.rs
+++ b/vmm/src/app/qemu.rs
@@ -5,7 +5,7 @@
 //! QEMU related code
 use crate::{
     app::Manifest,
-    config::{CvmConfig, GatewayConfig, Networking, NetworkingMode, ProcessAnnotation, Protocol},
+    config::{CvmConfig, GatewayConfig, Networking, NetworkingMode, ProcessAnnotation},
 };
 use std::{collections::HashMap, os::unix::fs::PermissionsExt};
 use std::{
@@ -63,7 +63,7 @@ fn networking_to_proto(n: &Networking) -> pb::NetworkingConfig {
     let mode = match n.mode {
         NetworkingMode::Bridge => "bridge",
         NetworkingMode::User => "user",
-        NetworkingMode::Passt => "passt",
+
         NetworkingMode::Custom => "custom",
     };
     pb::NetworkingConfig { mode: mode.into() }
@@ -351,113 +351,6 @@ impl VmState {
 }
 
 impl VmConfig {
-    fn config_passt(&self, workdir: &VmWorkDir, netcfg: &Networking) -> Result<ProcessConfig> {
-        let Networking {
-            passt_exec,
-            interface,
-            address,
-            netmask,
-            gateway,
-            dns,
-            map_host_loopback,
-            map_guest_addr,
-            no_map_gw,
-            ipv4_only,
-            ..
-        } = netcfg;
-
-        let passt_socket = workdir.passt_socket();
-        if passt_socket.exists() {
-            fs_err::remove_file(&passt_socket).context("Failed to remove passt socket")?;
-        }
-        let passt_exec = if passt_exec.is_empty() {
-            "passt"
-        } else {
-            passt_exec
-        };
-
-        let passt_log = workdir.passt_log();
-
-        let mut passt_cmd = Command::new(passt_exec);
-        passt_cmd.arg("--socket").arg(&passt_socket);
-        passt_cmd.arg("--log-file").arg(&passt_log);
-
-        if !interface.is_empty() {
-            passt_cmd.arg("--interface").arg(interface);
-        }
-        if !address.is_empty() {
-            passt_cmd.arg("--address").arg(address);
-        }
-        if !netmask.is_empty() {
-            passt_cmd.arg("--netmask").arg(netmask);
-        }
-        if !gateway.is_empty() {
-            passt_cmd.arg("--gateway").arg(gateway);
-        }
-        for dns in dns {
-            passt_cmd.arg("--dns").arg(dns);
-        }
-        if !map_host_loopback.is_empty() {
-            passt_cmd.arg("--map-host-loopback").arg(map_host_loopback);
-        }
-        if !map_guest_addr.is_empty() {
-            passt_cmd.arg("--map-guest-addr").arg(map_guest_addr);
-        }
-        if *no_map_gw {
-            passt_cmd.arg("--no-map-gw");
-        }
-        if *ipv4_only {
-            passt_cmd.arg("--ipv4-only");
-        }
-        // Group port mappings by protocol
-        let mut tcp_ports = Vec::new();
-        let mut udp_ports = Vec::new();
-
-        for pm in &self.manifest.port_map {
-            let port_spec = format!("{}/{}:{}", pm.address, pm.from, pm.to);
-            match pm.protocol {
-                Protocol::Tcp => tcp_ports.push(port_spec),
-                Protocol::Udp => udp_ports.push(port_spec),
-            }
-        }
-        // Add TCP port forwarding — one --tcp-ports per spec to avoid
-        // exceeding passt's single-argument parser limit.
-        for spec in &tcp_ports {
-            passt_cmd.arg("--tcp-ports").arg(spec);
-        }
-        // Add UDP port forwarding
-        for spec in &udp_ports {
-            passt_cmd.arg("--udp-ports").arg(spec);
-        }
-        passt_cmd.arg("-f").arg("-1");
-
-        let args = passt_cmd
-            .get_args()
-            .map(|arg| arg.to_string_lossy().to_string())
-            .collect::<Vec<_>>();
-        let stdout_path = workdir.passt_stdout();
-        let stderr_path = workdir.passt_stderr();
-        let note = ProcessAnnotation {
-            kind: "passt".to_string(),
-            live_for: Some(self.manifest.id.clone()),
-        };
-        let note = serde_json::to_string(&note)?;
-        let process_config = ProcessConfig {
-            id: format!("passt-{}", self.manifest.id),
-            args,
-            name: format!("passt-{}", self.manifest.name),
-            command: passt_exec.to_string(),
-            env: Default::default(),
-            cwd: workdir.to_string_lossy().to_string(),
-            stdout: stdout_path.to_string_lossy().to_string(),
-            stderr: stderr_path.to_string_lossy().to_string(),
-            pidfile: Default::default(),
-            cid: None,
-            note,
-        };
-        Ok(process_config)
-    }
-
     pub fn config_qemu(
         &self,
         workdir: impl AsRef<Path>,
@@ -591,16 +484,6 @@ impl VmConfig {
                     ));
                 }
                 netdev
-            }
-            NetworkingMode::Passt => {
-                processes.push(
-                    self.config_passt(&workdir, networking)
-                        .context("Failed to configure passt")?,
-                );
-                format!(
-                    "stream,id=net0,server=off,addr.type=unix,addr.path={}",
-                    workdir.passt_socket().display()
-                )
             }
             NetworkingMode::Bridge => {
                 tracing::info!("bridge networking: mac={mac} bridge={}", networking.bridge);
@@ -1181,22 +1064,6 @@ impl VmWorkDir {
 
     pub fn qmp_socket(&self) -> PathBuf {
         self.workdir.join("qmp.sock")
-    }
-
-    pub fn passt_socket(&self) -> PathBuf {
-        self.workdir.join("passt.sock")
-    }
-
-    pub fn passt_stdout(&self) -> PathBuf {
-        self.workdir.join("passt.stdout")
-    }
-
-    pub fn passt_stderr(&self) -> PathBuf {
-        self.workdir.join("passt.stderr")
-    }
-
-    pub fn passt_log(&self) -> PathBuf {
-        self.workdir.join("passt.log")
     }
 
     pub fn path(&self) -> &Path {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -367,7 +367,6 @@ impl Config {
 #[serde(rename_all = "lowercase")]
 pub enum NetworkingMode {
     User,
-    Passt,
     Bridge,
     Custom,
 }
@@ -401,38 +400,12 @@ pub struct Networking {
     #[serde(default)]
     pub restrict: bool,
 
-    // ── Passt fields ───────────────────────────────────────────────
-    #[serde(default)]
-    pub passt_exec: String,
-    #[serde(default)]
-    pub interface: String,
-    #[serde(default)]
-    pub address: String,
-    #[serde(default)]
-    pub netmask: String,
-    #[serde(default)]
-    pub gateway: String,
-    #[serde(default)]
-    pub dns: Vec<String>,
-    #[serde(default)]
-    pub map_host_loopback: String,
-    #[serde(default)]
-    pub map_guest_addr: String,
-    #[serde(default)]
-    pub no_map_gw: bool,
-    #[serde(default)]
-    pub ipv4_only: bool,
-
     // ── Custom fields ──────────────────────────────────────────────
     #[serde(default)]
     pub netdev: String,
 }
 
 impl Networking {
-    pub fn is_passt(&self) -> bool {
-        self.mode == NetworkingMode::Passt
-    }
-
     pub fn is_bridge(&self) -> bool {
         self.mode == NetworkingMode::Bridge
     }

--- a/vmm/src/main_service.rs
+++ b/vmm/src/main_service.rs
@@ -201,7 +201,7 @@ fn networking_from_proto(proto: &rpc::NetworkingConfig) -> Option<crate::config:
     use crate::config::NetworkingMode;
     let mode = match proto.mode.as_str() {
         "bridge" => NetworkingMode::Bridge,
-        "passt" => NetworkingMode::Passt,
+
         "user" => NetworkingMode::User,
         "custom" => NetworkingMode::Custom,
         "" => return None, // not set, use global default
@@ -218,16 +218,6 @@ fn networking_from_proto(proto: &rpc::NetworkingConfig) -> Option<crate::config:
         net: String::new(),
         dhcp_start: String::new(),
         restrict: false,
-        passt_exec: String::new(),
-        interface: String::new(),
-        address: String::new(),
-        netmask: String::new(),
-        gateway: String::new(),
-        dns: vec![],
-        map_host_loopback: String::new(),
-        map_guest_addr: String::new(),
-        no_map_gw: false,
-        ipv4_only: false,
         netdev: String::new(),
         forward_service_enabled: false,
     })

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -1390,7 +1390,7 @@ def main():
     deploy_parser.add_argument('--tee', dest='no_tee', action='store_false',
                                help='Force-enable Intel TDX (default)')
     deploy_parser.set_defaults(no_tee=False)
-    deploy_parser.add_argument('--net', choices=['bridge', 'passt', 'user'],
+    deploy_parser.add_argument('--net', choices=['bridge', 'user'],
                                help='Networking mode (default: use global config)')
 
 

--- a/vmm/vmm.toml
+++ b/vmm/vmm.toml
@@ -85,18 +85,6 @@ net = "10.0.2.0/24"
 dhcp_start = "10.0.2.10"
 restrict = false
 
-# for mode = "passt"
-passt_exec = ""
-interface = ""
-address = "10.0.2.10"
-netmask = "255.255.255.0"
-gateway = "10.0.2.2"
-dns = ["1.1.1.1", "1.0.0.1"]
-map_host_loopback = "none"
-map_guest_addr = "none"
-no_map_gw = true
-ipv4_only = true
-
 # for mode = "bridge"
 # bridge = "virbr0"
 forward_service_enabled = false


### PR DESCRIPTION
## Summary
- Completely remove passt networking mode from VMM
- Remove passt-related config fields, CLI options, qemu config generation, and process lifecycle management
- Passt processes were leaking in supervisor because `stop_vm` and `remove_vm` didn't clean them up; removing the mode entirely eliminates this class of bugs

## Changed files
- `vmm/src/config.rs` — Remove `NetworkingMode::Passt`, passt struct fields, `is_passt()`
- `vmm/src/app.rs` — Remove passt stop/remove logic from `start_vm` and `remove_vm`
- `vmm/src/app/qemu.rs` — Remove `config_passt()`, `Passt` match arm, passt workdir methods
- `vmm/src/main_service.rs` — Remove passt from proto conversion
- `vmm/src/vmm-cli.py` — Remove 'passt' from `--net` choices
- `vmm/src/console_v1.html` — Remove Passt option from UI dropdown
- `vmm/vmm.toml` — Remove passt config section
- `vmm/rpc/proto/vmm_rpc.proto` — Update comment

## Test plan
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Verify existing VMs with `user` and `bridge` networking modes still work