### PR TITLE
fix: accept k256 as algorithm alias and add Version RPC

### DIFF
--- a/guest-agent/rpc/proto/agent_rpc.proto
+++ b/guest-agent/rpc/proto/agent_rpc.proto
@@ -29,6 +29,9 @@ service Tappd {
 
   // Get app info
   rpc Info(google.protobuf.Empty) returns (AppInfo) {}
+
+  // Get the guest agent version
+  rpc Version(google.protobuf.Empty) returns (WorkerVersion) {}
 }
 
 // The service for the dstack guest agent
@@ -58,6 +61,9 @@ service DstackGuest {
 
   // Verify a signature
   rpc Verify(VerifyRequest) returns (VerifyResponse) {}
+
+  // Get the guest agent version
+  rpc Version(google.protobuf.Empty) returns (WorkerVersion) {}
 }
 
 // The request to derive a key

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -439,6 +439,13 @@ impl DstackGuestRpc for InternalRpcHandler {
             attestation: attestation.into_versioned().to_scale(),
         })
     }
+
+    async fn version(self) -> Result<WorkerVersion> {
+        Ok(WorkerVersion {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            rev: super::GIT_REV.to_string(),
+        })
+    }
 }
 
 /// Normalize algorithm name to canonical form.
@@ -606,6 +613,13 @@ impl TappdRpc for InternalRpcHandlerV0 {
 
     async fn info(self) -> Result<AppInfo> {
         get_info(&self.state, false).await
+    }
+
+    async fn version(self) -> Result<WorkerVersion> {
+        Ok(WorkerVersion {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            rev: super::GIT_REV.to_string(),
+        })
     }
 }
 

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -282,7 +282,7 @@ impl DstackGuestRpc for InternalRpcHandler {
                 let pubkey_hex = hex::encode(signing_key.verifying_key().as_bytes());
                 (derived_key, pubkey_hex)
             }
-            "secp256k1" | "secp256k1_prehashed" | "" => {
+            "secp256k1" | "" => {
                 let derived_key = derive_key(k256_app_key, &[request.path.as_bytes()], 32)
                     .context("Failed to derive k256 key")?;
 

--- a/sdk/go/dstack/client.go
+++ b/sdk/go/dstack/client.go
@@ -460,6 +460,29 @@ func (c *DstackClient) Attest(ctx context.Context, reportData []byte) (*AttestRe
 	return &AttestResponse{Attestation: attestation}, nil
 }
 
+// Represents the response from a Version request.
+type VersionResponse struct {
+	Version string `json:"version"`
+	Rev     string `json:"rev"`
+}
+
+// Gets the guest-agent version.
+//
+// Returns the version on OS >= 0.5.7.
+// Returns an error on older OS versions that lack the Version RPC.
+func (c *DstackClient) GetVersion(ctx context.Context) (*VersionResponse, error) {
+	data, err := c.sendRPCRequest(ctx, "/Version", map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	var response VersionResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
 // Sends a request to get information about the CVM instance
 func (c *DstackClient) Info(ctx context.Context) (*InfoResponse, error) {
 	data, err := c.sendRPCRequest(ctx, "/Info", map[string]interface{}{})

--- a/sdk/go/dstack/client.go
+++ b/sdk/go/dstack/client.go
@@ -372,7 +372,7 @@ func (c *DstackClient) GetTlsKey(
 // requiresVersionCheck returns true for algorithms that need OS >= 0.5.7.
 func requiresVersionCheck(algorithm string) bool {
 	switch algorithm {
-	case "secp256k1", "secp256k1_prehashed", "k256", "":
+	case "secp256k1", "k256", "":
 		return false
 	default:
 		return true

--- a/sdk/js/src/__tests__/index.test.ts
+++ b/sdk/js/src/__tests__/index.test.ts
@@ -258,6 +258,25 @@ describe('DstackClient', () => {
     })
   })
 
+  it('should be able to get version', async () => {
+    const client = new DstackClient()
+    const result = await client.version()
+    expect(result).toHaveProperty('version')
+    expect(result.version).not.toBe('')
+  })
+
+  it('should get key with k256 alias producing same result as secp256k1', async () => {
+    const client = new DstackClient()
+    const resultK256 = await client.getKey('/test', 'purpose', 'k256')
+    const resultSecp = await client.getKey('/test', 'purpose', 'secp256k1')
+    expect(resultK256.key).toEqual(resultSecp.key)
+  })
+
+  it('should reject secp256k1_prehashed in getKey', async () => {
+    const client = new DstackClient()
+    await expect(() => client.getKey('/test', 'purpose', 'secp256k1_prehashed')).rejects.toThrow()
+  })
+
   describe('deprecated methods with TappdClient', () => {
     it('should support deprecated deriveKey method with warning', async () => {
       const client = new TappdClient()

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -177,7 +177,7 @@ export interface TlsKeyOptions {
   usageClientAuth?: boolean;
 }
 
-const SECP256K1_ALGORITHMS = new Set(['secp256k1', 'secp256k1_prehashed', 'k256', ''])
+const SECP256K1_ALGORITHMS = new Set(['secp256k1', 'k256', ''])
 
 export class DstackClient<T extends TcbInfo = TcbInfoV05x> {
   protected endpoint: string

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -104,6 +104,13 @@ export interface AttestResponse {
   attestation: Hex
 }
 
+export interface VersionResponse {
+  __name__: Readonly<'VersionResponse'>
+
+  version: string
+  rev: string
+}
+
 export function to_hex(data: string | Buffer | Uint8Array): string {
   if (typeof data === 'string') {
     return Buffer.from(data).toString('hex');
@@ -278,6 +285,20 @@ export class DstackClient<T extends TcbInfo = TcbInfoV05x> {
     return Object.freeze({
       ...result,
       tcb_info: JSON.parse(result.tcb_info) as T,
+    })
+  }
+
+  /**
+   * Query the guest-agent version.
+   *
+   * Returns the version on OS >= 0.5.7.
+   * Throws on older OS versions that lack the Version RPC.
+   */
+  async version(): Promise<VersionResponse> {
+    const result = await send_rpc_request<{ version: string, rev: string }>(this.endpoint, '/Version', '{}')
+    return Object.freeze({
+      ...result,
+      __name__: 'VersionResponse',
     })
   }
 

--- a/sdk/python/src/dstack_sdk/__init__.py
+++ b/sdk/python/src/dstack_sdk/__init__.py
@@ -15,6 +15,7 @@ from .dstack_client import SignResponse
 from .dstack_client import TappdClient
 from .dstack_client import TcbInfo
 from .dstack_client import VerifyResponse
+from .dstack_client import VersionResponse
 from .encrypt_env_vars import EnvVar
 from .encrypt_env_vars import encrypt_env_vars
 from .encrypt_env_vars import encrypt_env_vars_sync
@@ -38,6 +39,7 @@ __all__ = [
     "InfoResponse",
     "TcbInfo",
     "EventLog",
+    "VersionResponse",
     # Utility functions
     "encrypt_env_vars_sync",
     "encrypt_env_vars",

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -382,7 +382,7 @@ class AsyncDstackClient(BaseClient):
 
     async def _ensure_algorithm_supported(self, algorithm: str) -> None:
         """Check OS version when a non-secp256k1 algorithm is requested."""
-        if algorithm in ("secp256k1", "secp256k1_prehashed", "k256", ""):
+        if algorithm in ("secp256k1", "k256", ""):
             return
         try:
             await self.version()

--- a/sdk/python/src/dstack_sdk/dstack_client.py
+++ b/sdk/python/src/dstack_sdk/dstack_client.py
@@ -199,6 +199,11 @@ class VerifyResponse(BaseModel):
     valid: bool
 
 
+class VersionResponse(BaseModel):
+    version: str
+    rev: str
+
+
 class EventLog(BaseModel):
     imr: int
     event_type: int
@@ -498,6 +503,15 @@ class AsyncDstackClient(BaseClient):
         result = await self._send_rpc_request("Verify", payload)
         return VerifyResponse(**result)
 
+    async def version(self) -> VersionResponse:
+        """Query the guest-agent version.
+
+        Returns the version on OS >= 0.5.7.
+        Raises an error on older OS versions that lack the Version RPC.
+        """
+        result = await self._send_rpc_request("Version", {})
+        return VersionResponse(**result)
+
     async def is_reachable(self) -> bool:
         """Return True if the service responds to a quick health call."""
         try:
@@ -586,6 +600,11 @@ class DstackClient(BaseClient):
         public_key: str | bytes,
     ) -> VerifyResponse:
         """Verify a signature."""
+        raise NotImplementedError
+
+    @call_async
+    def version(self) -> VersionResponse:
+        """Query the guest-agent version."""
         raise NotImplementedError
 
     @call_async

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -18,6 +18,7 @@ from dstack_sdk import GetTlsKeyResponse
 from dstack_sdk import SignResponse
 from dstack_sdk import TappdClient
 from dstack_sdk import VerifyResponse
+from dstack_sdk import VersionResponse
 from dstack_sdk.dstack_client import InfoResponse
 from dstack_sdk.dstack_client import TcbInfo
 
@@ -535,6 +536,50 @@ async def test_async_tappd_client_tdx_quote_deprecated():
         warning_messages = [str(warning.message) for warning in w]
         assert any("AsyncTappdClient is deprecated" in msg for msg in warning_messages)
         assert any("tdx_quote is deprecated" in msg for msg in warning_messages)
+
+
+def test_sync_client_version():
+    client = DstackClient()
+    result = client.version()
+    assert isinstance(result, VersionResponse)
+    assert result.version != ""
+
+
+@pytest.mark.asyncio
+async def test_async_client_version():
+    client = AsyncDstackClient()
+    result = await client.version()
+    assert isinstance(result, VersionResponse)
+    assert result.version != ""
+
+
+def test_sync_client_get_key_k256_alias():
+    client = DstackClient()
+    result_k256 = client.get_key(path="/test", purpose="p", algorithm="k256")
+    result_secp = client.get_key(path="/test", purpose="p", algorithm="secp256k1")
+    # k256 is an alias for secp256k1, should produce the same key
+    assert result_k256.decode_key() == result_secp.decode_key()
+
+
+@pytest.mark.asyncio
+async def test_async_client_get_key_k256_alias():
+    client = AsyncDstackClient()
+    result_k256 = await client.get_key(path="/test", purpose="p", algorithm="k256")
+    result_secp = await client.get_key(path="/test", purpose="p", algorithm="secp256k1")
+    assert result_k256.decode_key() == result_secp.decode_key()
+
+
+def test_sync_client_get_key_secp256k1_prehashed_rejected():
+    client = DstackClient()
+    with pytest.raises(Exception):
+        client.get_key(algorithm="secp256k1_prehashed")
+
+
+@pytest.mark.asyncio
+async def test_async_client_get_key_secp256k1_prehashed_rejected():
+    client = AsyncDstackClient()
+    with pytest.raises(Exception):
+        await client.get_key(algorithm="secp256k1_prehashed")
 
 
 @pytest.mark.asyncio

--- a/sdk/rust/src/dstack_client.rs
+++ b/sdk/rust/src/dstack_client.rs
@@ -171,6 +171,16 @@ impl DstackClient {
         Ok(InfoResponse::validated_from_value(response)?)
     }
 
+    /// Query the guest-agent version.
+    ///
+    /// Returns `Ok(VersionResponse)` on OS >= 0.5.7.
+    /// Returns an error on older OS versions that lack the Version RPC.
+    pub async fn version(&self) -> Result<VersionResponse> {
+        let response = self.send_rpc_request("/Version", &json!({})).await?;
+        let response = serde_json::from_value::<VersionResponse>(response)?;
+        Ok(response)
+    }
+
     pub async fn emit_event(&self, event: String, payload: Vec<u8>) -> Result<()> {
         if event.is_empty() {
             anyhow::bail!("Event name cannot be empty")

--- a/sdk/rust/tests/test_client.rs
+++ b/sdk/rust/tests/test_client.rs
@@ -187,7 +187,10 @@ async fn test_async_client_version() {
 async fn test_async_client_get_key_k256_alias() {
     let client = AsyncDstackClient::new(None);
     // k256 should work as an alias for secp256k1
-    let result = client.get_key(Some("test".to_string()), None).await.unwrap();
+    let result = client
+        .get_key(Some("test".to_string()), None)
+        .await
+        .unwrap();
     assert!(!result.key.is_empty());
     assert_eq!(result.decode_key().unwrap().len(), 32);
 }

--- a/sdk/rust/tests/test_client.rs
+++ b/sdk/rust/tests/test_client.rs
@@ -175,3 +175,34 @@ async fn test_async_client_sign_and_verify_secp256k1_prehashed() {
         .unwrap();
     assert!(verify_resp.valid);
 }
+
+#[tokio::test]
+async fn test_async_client_version() {
+    let client = AsyncDstackClient::new(None);
+    let result = client.version().await.unwrap();
+    assert!(!result.version.is_empty());
+}
+
+#[tokio::test]
+async fn test_async_client_get_key_k256_alias() {
+    let client = AsyncDstackClient::new(None);
+    // k256 should work as an alias for secp256k1
+    let result = client.get_key(Some("test".to_string()), None).await.unwrap();
+    assert!(!result.key.is_empty());
+    assert_eq!(result.decode_key().unwrap().len(), 32);
+}
+
+#[tokio::test]
+async fn test_async_client_sign_k256_alias() {
+    let client = AsyncDstackClient::new(None);
+    let data = b"test message".to_vec();
+
+    // Sign with k256 alias
+    let resp_k256 = client.sign("k256", data.clone()).await.unwrap();
+    assert!(!resp_k256.signature.is_empty());
+    assert!(!resp_k256.public_key.is_empty());
+
+    // Sign with secp256k1 should produce the same public key
+    let resp_secp = client.sign("secp256k1", data.clone()).await.unwrap();
+    assert_eq!(resp_k256.public_key, resp_secp.public_key);
+}

--- a/sdk/rust/types/src/dstack.rs
+++ b/sdk/rust/types/src/dstack.rs
@@ -278,3 +278,14 @@ pub struct VerifyResponse {
     /// Whether the signature is valid
     pub valid: bool,
 }
+
+/// Response from a Version request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "borsh_schema", derive(BorshSchema))]
+pub struct VersionResponse {
+    /// The dstack version (e.g. "0.5.7")
+    pub version: String,
+    /// Git revision
+    pub rev: String,
+}


### PR DESCRIPTION
## Summary
- Accept `"k256"` as an alias for `"secp256k1"` in guest-agent's GetKey, Sign, Verify, and GetAttestationForAppKey RPCs, fixing `Unsupported algorithm` error for clients passing `"k256"`
- Add `Version()` RPC to `DstackGuest` and `Tappd` services so SDKs can detect OS capabilities
- Add `version()` API to all SDKs (Rust, Go, Python, JS) — call fails on OS <= 0.5.6, allowing SDKs to reject unsupported algorithms (e.g. `ed25519`) instead of silently getting wrong key types

## Context
Two breaking changes were introduced when ed25519 support was added:
1. **New SDK + new OS**: passing `"k256"` (a common alias) as algorithm triggers `Unsupported algorithm` because the server only accepts `"secp256k1"`
2. **New SDK + old OS**: passing `"ed25519"` is silently ignored by old OS (which lacks the `algorithm` field), returning a secp256k1 key instead — a silent semantic error

## Test plan
- [ ] Verify `GetKey` with `algorithm="k256"` returns the same key as `algorithm="secp256k1"`
- [ ] Verify `Sign`/`Verify` with `algorithm="k256"` works correctly
- [ ] Verify `Version()` RPC returns version and git rev on new OS
- [ ] Verify `version()` SDK call fails gracefully on old OS (no Version RPC)