### PR TITLE
refactor: rename hardhat network "test" to "custom"

### DIFF
--- a/kms/auth-eth/hardhat.config.ts
+++ b/kms/auth-eth/hardhat.config.ts
@@ -40,7 +40,7 @@ const config: HardhatUserConfig = {
       url: 'https://mainnet.base.org',
       accounts: [PRIVATE_KEY],
     },
-    test: {
+    custom: {
       url: process.env.RPC_URL || 'http://127.0.0.1:8545/',
       accounts: [PRIVATE_KEY],
     }


### PR DESCRIPTION
## Summary
- Rename the `test` network in hardhat config to `custom`
- The name "test" was misleading as it implied a specific testnet, but the network's RPC URL is entirely user-defined via `RPC_URL` env var

## Test plan
- [x] Verify hardhat compile still works
- [x] Verify `--network custom` resolves correctly with `RPC_URL` set