### PR TITLE
fix(kms): auto-append /prpc to onboard source_url

### DIFF
--- a/kms/src/onboard_service.rs
+++ b/kms/src/onboard_service.rs
@@ -77,8 +77,14 @@ impl OnboardRpc for OnboardHandler {
     }
 
     async fn onboard(self, request: OnboardRequest) -> Result<OnboardResponse> {
+        let source_url = request.source_url.trim_end_matches('/').to_string();
+        let source_url = if source_url.ends_with("/prpc") {
+            source_url
+        } else {
+            format!("{source_url}/prpc")
+        };
         let keys = Keys::onboard(
-            &request.source_url,
+            &source_url,
             &request.domain,
             self.state.config.onboard.quote_enabled,
             self.state.config.pccs_url.clone(),


### PR DESCRIPTION
## Summary
- Normalize `source_url` in the Onboard RPC handler by auto-appending `/prpc` when missing
- Matches the existing pattern in `dstack-util` (`main.rs`) and `system_setup.rs`
- Allows callers to pass just the base URL (e.g. `https://kms.example.com:9201`) without knowing the internal `/prpc` path prefix

## Context
Currently `source_url` is passed verbatim to `RaClient::new()`, which constructs URLs as `{source_url}/{method}?json`. Without the `/prpc` suffix, requests hit the wrong path and get 404s.

The web UI (`onboard.html`) works around this by appending `/prpc` in JavaScript, but direct API callers (e.g. `curl`) must know to include it.

Same fix already merged into Phala-Network/dstack-cloud master.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -D warnings` passes
- [ ] Onboard with `source_url = "https://host:9201/prpc"` still works (no double `/prpc`)
- [ ] Onboard with `source_url = "https://host:9201"` now works (auto-appended)
- [ ] Onboard with `source_url = "https://host:9201/"` now works (trailing slash trimmed)