### PR TITLE
fix: correct kms:add-device success message

### DIFF
--- a/kms/auth-eth/hardhat.config.ts
+++ b/kms/auth-eth/hardhat.config.ts
@@ -196,7 +196,7 @@ task("kms:add-device", "Add a device ID of an KMS instance")
     const kmsContract = await getKmsContract(ethers);
     const tx = await kmsContract.addKmsDevice(deviceId);
     await waitTx(tx);
-    console.log("Device compose hash added successfully");
+    console.log("Device ID added successfully");
   });
 
 task("kms:remove-device", "Remove a device ID")


### PR DESCRIPTION
## Summary
- Fix incorrect success message in `kms:add-device` hardhat task: "Device compose hash added successfully" → "Device ID added successfully"

## Context
The `kms:remove-device` task already correctly prints "Device ID removed successfully", but the `kms:add-device` task had a copy-paste error saying "Device compose hash" instead of "Device ID".