### PR TITLE
Make simulator certs more realistic

### DIFF
--- a/cert-client/src/lib.rs
+++ b/cert-client/src/lib.rs
@@ -102,7 +102,10 @@ impl CertRequestClient {
         let pubkey = key.public_key_der();
         let report_data = QuoteContentType::RaTlsCert.to_report_data(&pubkey);
         let attestation = match attestation_override {
-            Some(attestation) => attestation,
+            Some(mut attestation) => {
+                attestation.set_report_data(report_data);
+                attestation
+            }
             None => ra_rpc::Attestation::quote(&report_data)
                 .context("Failed to get quote for cert pubkey")?
                 .into_versioned(),

--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -267,6 +267,19 @@ impl VersionedAttestation {
         }
     }
 
+    /// Set the report_data field in the attestation and in the raw TDX quote bytes (offset 568..632).
+    /// This is used by the simulator to patch a canned attestation with the correct report_data
+    /// that binds to the actual TLS public key.
+    pub fn set_report_data(&mut self, report_data: [u8; 64]) {
+        let VersionedAttestation::V0 { attestation } = self;
+        attestation.report_data = report_data;
+        if let Some(tdx_quote) = attestation.tdx_quote_mut() {
+            if tdx_quote.quote.len() >= 632 {
+                tdx_quote.quote[568..632].copy_from_slice(&report_data);
+            }
+        }
+    }
+
     /// Strip data for certificate embedding (e.g. keep RTMR3 event logs only).
     pub fn into_stripped(mut self) -> Self {
         let VersionedAttestation::V0 { attestation } = &mut self;


### PR DESCRIPTION
The simulator's get_tls_key RPC produced RA-TLS certificates with a canned attestation whose report_data didn't match the actual TLS public key. Clients verifying report_data == SHA-512("ratls-cert:" || leaf_pubkey) would reject these certs. Fix by adding VersionedAttestation::set_report_data() and calling it in request_cert() when an attestation override is provided.