### PR TITLE
refactor: extract TDX quote report_data offset as a named constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "sha3",
  "tdx-attest",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/dstack-attest/Cargo.toml
+++ b/dstack-attest/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 tdx-attest.workspace = true
+tracing.workspace = true
 insta.workspace = true
 errify.workspace = true
 

--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -4,6 +4,11 @@
 
 //! Attestation functions
 
+/// Byte range of the REPORT_DATA field within a TDX quote.
+/// In Intel TDX ECDSA quote format, the TD Report body starts at offset 568
+/// and REPORT_DATA occupies bytes 568..632 (64 bytes).
+pub const TDX_QUOTE_REPORT_DATA_RANGE: std::ops::Range<usize> = 568..632;
+
 use std::{borrow::Cow, time::SystemTime};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -274,8 +279,14 @@ impl VersionedAttestation {
         let VersionedAttestation::V0 { attestation } = self;
         attestation.report_data = report_data;
         if let Some(tdx_quote) = attestation.tdx_quote_mut() {
-            if tdx_quote.quote.len() >= 632 {
-                tdx_quote.quote[568..632].copy_from_slice(&report_data);
+            if tdx_quote.quote.len() >= TDX_QUOTE_REPORT_DATA_RANGE.end {
+                tdx_quote.quote[TDX_QUOTE_REPORT_DATA_RANGE].copy_from_slice(&report_data);
+            } else {
+                tracing::warn!(
+                    "TDX quote too short to patch report_data ({} < {})",
+                    tdx_quote.quote.len(),
+                    TDX_QUOTE_REPORT_DATA_RANGE.end
+                );
             }
         }
     }

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -28,7 +28,10 @@ use k256::ecdsa::SigningKey;
 use or_panic::ResultOrPanic;
 use ra_rpc::{Attestation, CallContext, RpcCall};
 use ra_tls::{
-    attestation::{QuoteContentType, VersionedAttestation, DEFAULT_HASH_ALGORITHM},
+    attestation::{
+        QuoteContentType, VersionedAttestation, DEFAULT_HASH_ALGORITHM,
+        TDX_QUOTE_REPORT_DATA_RANGE,
+    },
     cert::CertConfigV2,
     kdf::{derive_key, derive_p256_key_pair_from_bytes},
 };
@@ -486,7 +489,7 @@ fn simulate_quote(
         return Err(anyhow::anyhow!("Quote not found"));
     };
 
-    quote.quote[568..632].copy_from_slice(&report_data);
+    quote.quote[TDX_QUOTE_REPORT_DATA_RANGE].copy_from_slice(&report_data);
     Ok(GetQuoteResponse {
         quote: quote.quote.to_vec(),
         event_log: serde_json::to_string(&quote.event_log)

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -29,8 +29,7 @@ use or_panic::ResultOrPanic;
 use ra_rpc::{Attestation, CallContext, RpcCall};
 use ra_tls::{
     attestation::{
-        QuoteContentType, VersionedAttestation, DEFAULT_HASH_ALGORITHM,
-        TDX_QUOTE_REPORT_DATA_RANGE,
+        QuoteContentType, VersionedAttestation, DEFAULT_HASH_ALGORITHM, TDX_QUOTE_REPORT_DATA_RANGE,
     },
     cert::CertConfigV2,
     kdf::{derive_key, derive_p256_key_pair_from_bytes},


### PR DESCRIPTION
## Summary
- Extract the duplicated magic offset `568..632` into a named constant `TDX_QUOTE_REPORT_DATA_RANGE` in `dstack-attest`
- Use this constant in both `VersionedAttestation::set_report_data()` and `simulate_quote()`
- Add a `tracing::warn!` when the TDX quote is too short to patch report_data, instead of silently skipping

## Context
Follow-up to #541. The magic offset was duplicated in two places and a short quote was silently ignored, which could hide data corruption.

## Test plan
- [x] `cargo check -p dstack-attest -p dstack-guest-agent` passes