### PR TITLE
kms: use constant-time comparison for admin token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
+ "subtle",
  "tempfile",
  "tokio",
  "tracing",

--- a/kms/Cargo.toml
+++ b/kms/Cargo.toml
@@ -31,6 +31,7 @@ load_config.workspace = true
 serde-human-bytes.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 sha2.workspace = true
+subtle = "2"
 sha3.workspace = true
 k256.workspace = true
 rand.workspace = true

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -138,7 +138,12 @@ impl RpcHandler {
 
     fn ensure_admin(&self, token: &str) -> Result<()> {
         let token_hash = sha2::Sha256::new_with_prefix(token).finalize();
-        if token_hash.as_slice() != self.state.config.admin_token_hash.as_slice() {
+        use subtle::ConstantTimeEq;
+        if !bool::from(
+            token_hash
+                .as_slice()
+                .ct_eq(self.state.config.admin_token_hash.as_slice()),
+        ) {
             bail!("Invalid token");
         }
         Ok(())


### PR DESCRIPTION
## Summary
- Replace `!=` with `subtle::ConstantTimeEq` for admin token hash comparison in `ensure_admin()`
- Prevents timing side-channel attacks that could leak information about the admin token hash

## Test plan
- [x] `cargo check -p dstack-kms` passes
- [ ] Existing KMS E2E tests pass in CI