### PR TITLE
feat: support wildcard custom domains in gateway

### DIFF
--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -58,17 +58,12 @@ async fn resolve_app_address(prefix: &str, sni: &str, compat: bool) -> Result<Ap
             };
             return AppAddress::parse(data).context("failed to parse app address");
         }
-    } else {
-        let lookup = resolver
-            .txt_lookup(txt_domain)
-            .await
-            .context("failed to lookup app address")?;
-        let txt_record = lookup.iter().next().context("no txt record found")?;
-        let data = txt_record
-            .txt_data()
-            .first()
-            .context("no data in txt record")?;
-        return AppAddress::parse(data).context("failed to parse app address");
+    } else if let Ok(lookup) = resolver.txt_lookup(txt_domain).await {
+        if let Some(txt_record) = lookup.iter().next() {
+            if let Some(data) = txt_record.txt_data().first() {
+                return AppAddress::parse(data).context("failed to parse app address");
+            }
+        }
     }
 
     // wildcard fallback: try {prefix}-wildcard.{parent_domain}


### PR DESCRIPTION
## Summary

Add fallback to `_dstack-app-address-wildcard.{parent}` TXT record
when exact `_dstack-app-address.{sni}` lookup fails. This allows a
single TXT record to route all subdomains of a custom domain to the
same app, while still allowing per-subdomain overrides via exact records.

## Lookup order

1. `_dstack-app-address.{sni}` — exact match
2. `_tapp-address.{sni}` — legacy compat
3. `_dstack-app-address-wildcard.{parent}` — wildcard fallback

## Test plan

- [x] Verify existing exact custom domain resolution still works — `exact-test.test111.kvin.wang` resolved via `_dstack-app-address.exact-test.test111.kvin.wang` TXT, cert CN=`exact-test.test111.kvin.wang`
- [x] Test wildcard fallback with `_dstack-app-address-wildcard` TXT record — `foo.test111.kvin.wang` resolved via `_dstack-app-address-wildcard.test111.kvin.wang`, cert CN=`*.test111.kvin.wang`
- [x] Test exact record overrides wildcard for specific subdomains — `exact-test.test111.kvin.wang` (app `fdd0dbc3...`) and `foo.test111.kvin.wang` (app `8de234a6...`) route to different VMs with different certs