### PR TITLE
feat(vmm): preserve serial logs across VM restarts

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -30,7 +30,7 @@ jobs:
           platforms: linux/amd64
           provenance: false
           build-args: |
-            DSTACK_REV=${{ github.sha }}
+            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}
             DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}
 
       - name: Build KMS contracts
@@ -55,7 +55,7 @@ jobs:
           platforms: linux/amd64
           provenance: false
           build-args: |
-            DSTACK_REV=${{ github.sha }}
+            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}
 
   verifier:
     runs-on: ubuntu-latest
@@ -74,4 +74,4 @@ jobs:
           platforms: linux/amd64
           provenance: false
           build-args: |
-            DSTACK_REV=${{ github.sha }}
+            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -242,6 +242,11 @@ impl App {
                     fs::remove_file(path)?;
                 }
             }
+            // Append current serial.log to serial.history.log before QEMU truncates it.
+            rotate_serial_log(&work_dir, self.config.cvm.serial_history_max_bytes);
+            // Add boot separator to stdout/stderr (they are opened in append mode).
+            append_boot_separator(&work_dir.stdout_file());
+            append_boot_separator(&work_dir.stderr_file());
 
             let devices = self.try_allocate_gpus(&vm_config.manifest)?;
             let processes = vm_config.config_qemu(&work_dir, &self.config.cvm, &devices)?;
@@ -1048,6 +1053,64 @@ impl App {
             self.start_vm(&id).await?;
         }
         Ok(())
+    }
+}
+
+/// Append a boot separator line with timestamp to an append-mode log file.
+fn append_boot_separator(path: &std::path::Path) {
+    use std::io::Write;
+    if !path.exists() {
+        return;
+    }
+    let Ok(mut file) = std::fs::OpenOptions::new().append(true).open(path) else {
+        return;
+    };
+    let timestamp = humantime::format_rfc3339_seconds(std::time::SystemTime::now());
+    let _ = writeln!(file, "\n===== boot @ {timestamp} =====\n");
+}
+
+/// Append current serial.log into serial.history.log with a boot separator,
+/// then truncate history if it exceeds `max_bytes`.
+fn rotate_serial_log(work_dir: &VmWorkDir, max_bytes: u64) {
+    use std::io::Write;
+
+    let serial = work_dir.serial_file();
+    if !serial.exists() {
+        return;
+    }
+    let Ok(content) = fs::read(&serial) else {
+        return;
+    };
+    if content.is_empty() {
+        return;
+    }
+    let history = work_dir.serial_history_file();
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&history)
+    else {
+        return;
+    };
+    let timestamp = humantime::format_rfc3339_seconds(std::time::SystemTime::now());
+    let _ = writeln!(file, "\n===== boot @ {timestamp} =====\n");
+    let _ = file.write_all(&content);
+    drop(file);
+
+    // Truncate from the front if history exceeds max_bytes.
+    if let Ok(meta) = fs::metadata(&history) {
+        if meta.len() > max_bytes {
+            if let Ok(data) = fs::read(&history) {
+                let skip = data.len() - max_bytes as usize;
+                // Find the next newline after skip point to avoid cutting mid-line.
+                let start = data[skip..]
+                    .iter()
+                    .position(|&b| b == b'\n')
+                    .map(|p| skip + p + 1)
+                    .unwrap_or(skip);
+                let _ = fs::write(&history, &data[start..]);
+            }
+        }
     }
 }
 

--- a/vmm/src/app/qemu.rs
+++ b/vmm/src/app/qemu.rs
@@ -1042,6 +1042,10 @@ impl VmWorkDir {
         self.workdir.join("serial.log")
     }
 
+    pub fn serial_history_file(&self) -> PathBuf {
+        self.workdir.join("serial.history.log")
+    }
+
     pub fn serial_pty(&self) -> PathBuf {
         self.workdir.join("serial.pty")
     }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -203,6 +203,13 @@ pub struct CvmConfig {
     /// SMBIOS product information for cloud environment detection
     #[serde(default)]
     pub product: ProductConfig,
+
+    /// Max size in bytes for serial.history.log (default 4MB).
+    /// Previous boot serial logs are appended here before each restart.
+    /// Accepts human-readable sizes like "4MB", "512KB".
+    #[serde(default = "default_serial_history_max_bytes")]
+    #[serde(with = "size_parser::human_size")]
+    pub serial_history_max_bytes: u64,
 }
 
 /// SMBIOS product information configuration.
@@ -450,6 +457,10 @@ pub struct KeyProviderConfig {
     pub enabled: bool,
     pub address: IpAddr,
     pub port: u16,
+}
+
+fn default_serial_history_max_bytes() -> u64 {
+    4 * 1024 * 1024 // 4MB
 }
 
 const CLIENT_CONF_PATH: &str = "/etc/dstack/client.conf";


### PR DESCRIPTION
## Problem

When a dstack VM crashes (kernel panic with `panic=1`) or gets restarted, QEMU truncates `serial.log` on the next boot — losing all previous boot logs. This is especially painful in TDX VMs where non-resettable CPUs cause `cpus are not resettable, terminating` → rapid restart loops, making it impossible to diagnose the original panic.

## Changes

**vmm: preserve serial logs across restarts**
- Before each VM restart, append `serial.log` content to `serial.history.log` with a timestamped `===== boot @ <rfc3339> =====` separator
- Cap `serial.history.log` at a configurable max size (default 4MB, trimmed from the front to keep most-recent data)
- Add the same boot separator timestamps to `stdout.log` and `stderr.log` so individual QEMU sessions are clearly delimited
- New config option `serial_history_max_bytes` (supports human-readable sizes: `"4M"`, `"512K"`)

**ci: fix Docker Build Check on PRs**
- `github.sha` for `pull_request` events is a temporary merge commit that only exists in GitHub's internal refs and is never pushed to the repo — Dockerfiles doing `git clone && git checkout ${DSTACK_REV}` fail with exit 128
- Use `github.event.pull_request.head.sha || github.sha` so PRs use the actual branch HEAD while push-to-branch events continue to use `github.sha`

## Test plan
- [x] Restart a VM, verify `serial.history.log` is created with previous boot's serial output and a `===== boot @ <timestamp> =====` separator
- [x] Verify `stdout.log` and `stderr.log` contain boot separators between restarts
- [x] Verify history truncation works when exceeding configured `serial_history_max_bytes` — tested with `1K` limit, 88KB history correctly trimmed to 991 bytes keeping tail content
- [x] Verify `serial.log` still works normally for the current boot