### PR TITLE
mod-tdx-guest: validate RTMR index and remove dead code

### DIFF
--- a/mod-tdx-guest/mod.c
+++ b/mod-tdx-guest/mod.c
@@ -107,6 +107,11 @@ static long tdx_extend_rtmr(struct tdx_extend_rtmr_req __user *req)
 		goto out;
 	}
 
+	if (index > 3) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	{
 		struct tdx_module_args args = {
 			.rcx = virt_to_phys(data),
@@ -164,12 +169,7 @@ static int __init tdx_guest_init(void)
 	if (ret)
 		return ret;
 
-
 	return 0;
-
-	misc_deregister(&tdx_misc_dev);
-
-	return ret;
 }
 module_init(tdx_guest_init);
 


### PR DESCRIPTION
## Summary
- Add RTMR index bounds check (`index > 3 → -EINVAL`) before issuing `TDG_MR_RTMR_EXTEND` TDCALL, as TDX only defines RTMR0-3
- Remove unreachable dead code in `tdx_guest_init()`

Closes: Dstack-TEE/meta-dstack#45