### PR TITLE
fix(gateway): enable cluster sync without requiring BOOTNODE_URL

### DIFF
--- a/gateway/dstack-app/builder/entrypoint.sh
+++ b/gateway/dstack-app/builder/entrypoint.sh
@@ -43,7 +43,11 @@ if [[ ! "$NODE_ID" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-SYNC_ENABLED=$([ -z "$BOOTNODE_URL" ] && echo "false" || echo "true")
+# Sync is always enabled when NODE_ID > 0. Peer auto-discovery works via incoming
+# sync connections: when another node syncs to us, we learn about it automatically
+# through WaveKV's handle_sync, which auto-adds the sender as a peer.
+# BOOTNODE_URL is optional — it speeds up initial discovery but is not required.
+SYNC_ENABLED=$([ "$NODE_ID" -gt 0 ] && echo "true" || echo "false")
 
 echo "WG_IP: $WG_IP"
 echo "WG_RESERVED_NET: $WG_RESERVED_NET"


### PR DESCRIPTION
## Summary

- Fix chicken-and-egg bootstrap problem: `SYNC_ENABLED` was previously tied to `BOOTNODE_URL` being set, so the first node in a cluster could never enable sync
- Now sync is enabled whenever `NODE_ID > 0`, and peers are auto-discovered via incoming sync connections (WaveKV's `handle_sync` adds the sender as a peer)
- `BOOTNODE_URL` remains optional — it speeds up initial discovery but is no longer required

## Test plan

- [x] Deploy gateway-1 with `NODE_ID=1` and no `BOOTNODE_URL` → verify sync is enabled
- [x] Deploy gateway-2 with `NODE_ID=2` and `BOOTNODE_URL` pointing to gateway-1 → verify both nodes discover each other and sync