### PR TITLE
fix: add SPDX license headers to sdk/go/ratls

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,6 +31,7 @@ path = [
     "kms/auth-simple/auth-config.example.json",
     "sdk/simulator/*.json",
     "sdk/go/go.sum",
+    "sdk/go/ratls/go.sum",
     "kms/dstack-app/builder/shared/kms-pinned-packages.txt",
     "kms/dstack-app/builder/shared/qemu-pinned-packages.txt",
     "gateway/dstack-app/builder/shared/builder-pinned-packages.txt",

--- a/sdk/go/ratls/go.mod
+++ b/sdk/go/ratls/go.mod
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/Dstack-TEE/dstack/sdk/go/ratls
 
 go 1.24.0

--- a/sdk/go/ratls/ratls.go
+++ b/sdk/go/ratls/ratls.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ratls provides RA-TLS certificate verification for dstack TEE applications.
 //
 // RA-TLS embeds TDX attestation quotes into X.509 certificate extensions.

--- a/sdk/go/ratls/ratls_test.go
+++ b/sdk/go/ratls/ratls_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package ratls_test
 
 import (


### PR DESCRIPTION
## Summary

- Add SPDX copyright/license headers to `sdk/go/ratls/ratls.go`, `ratls_test.go`, and `go.mod`
- Add `sdk/go/ratls/go.sum` to `REUSE.toml` annotations (go.sum can't contain comments)
- Fixes reuse-lint CI failure introduced by #512

## Test plan

- [x] reuse-lint CI check passes