### PR TITLE
feat(vmm): local VMM instance discovery

### DIFF
--- a/vmm/src/discovery.rs
+++ b/vmm/src/discovery.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! VMM instance discovery via registration files.
+//!
+//! On startup each `dstack-vmm` process writes a JSON file to a well-known
+//! directory so that CLI tools can discover all running instances on the host.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Well-known directory where VMM instances register themselves.
+const DISCOVERY_DIR: &str = "/run/dstack-vmm";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VmmInstanceInfo {
+    /// Unique identifier for this VMM instance (random UUID).
+    pub id: String,
+    /// Process ID.
+    pub pid: u32,
+    /// Address the external API listens on (e.g. "unix:./vmm.sock" or "0.0.0.0:9080").
+    pub address: String,
+    /// Working directory of the VMM process.
+    pub working_dir: String,
+    /// Path to the configuration file (if provided via -c).
+    pub config_file: Option<String>,
+    /// Path where VM images are stored.
+    pub image_path: String,
+    /// Path where VM runtime data is stored.
+    pub run_path: String,
+    /// Node name from configuration.
+    pub node_name: String,
+    /// VMM version string.
+    pub version: String,
+    /// Unix timestamp (seconds) when the instance started.
+    pub started_at: u64,
+}
+
+/// Handle that manages the lifecycle of a discovery registration file.
+/// The file is removed when this handle is dropped.
+pub struct DiscoveryRegistration {
+    path: PathBuf,
+}
+
+impl DiscoveryRegistration {
+    /// Register a new VMM instance. Creates the discovery directory if needed
+    /// and writes the instance info JSON file.
+    pub fn register(
+        listen_address: &str,
+        config_file: Option<&str>,
+        image_path: &Path,
+        run_path: &Path,
+        node_name: &str,
+        version: &str,
+    ) -> Result<Self> {
+        let dir = Path::new(DISCOVERY_DIR);
+        fs_err::create_dir_all(dir).context("failed to create discovery directory")?;
+
+        let id = Uuid::new_v4().to_string();
+        let path = dir.join(format!("{id}.json"));
+
+        let cwd = std::env::current_dir().context("failed to get current directory")?;
+
+        let info = VmmInstanceInfo {
+            id: id.clone(),
+            pid: std::process::id(),
+            address: listen_address.to_string(),
+            working_dir: cwd.to_string_lossy().to_string(),
+            config_file: config_file.map(|s| s.to_string()),
+            image_path: image_path.to_string_lossy().to_string(),
+            run_path: run_path.to_string_lossy().to_string(),
+            node_name: node_name.to_string(),
+            version: version.to_string(),
+            started_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        };
+
+        let json =
+            serde_json::to_string_pretty(&info).context("failed to serialize instance info")?;
+        fs_err::write(&path, &json).context("failed to write discovery file")?;
+
+        info!("registered VMM instance {id} at {}", path.display());
+        Ok(Self { path })
+    }
+}
+
+impl Drop for DiscoveryRegistration {
+    fn drop(&mut self) {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => info!("unregistered VMM instance at {}", self.path.display()),
+            Err(e) => warn!(
+                "failed to remove discovery file {}: {e}",
+                self.path.display()
+            ),
+        }
+    }
+}
+
+/// Clean up stale discovery files from dead processes.
+pub fn cleanup_stale_registrations() {
+    let dir = Path::new(DISCOVERY_DIR);
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let info: VmmInstanceInfo = match serde_json::from_str(&content) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        // Check if the process is still alive
+        let alive = Path::new(&format!("/proc/{}", info.pid)).exists();
+        if !alive {
+            info!(
+                "removing stale discovery file for pid {} at {}",
+                info.pid,
+                path.display()
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}

--- a/vmm/src/main.rs
+++ b/vmm/src/main.rs
@@ -23,6 +23,7 @@ use tracing::{error, info};
 
 mod app;
 mod config;
+mod discovery;
 mod guest_api_service;
 mod host_api_service;
 mod main_routes;
@@ -178,6 +179,31 @@ async fn main() -> Result<()> {
             // Default server mode - continue to main server logic
         }
     }
+
+    // Register this VMM instance for local discovery
+    discovery::cleanup_stale_registrations();
+    let listen_address = {
+        // Use Rocket's Endpoint type to parse the address exactly as Rocket would,
+        // then override the port with the figment's port value (matching Rocket's behavior).
+        let endpoint: rocket::listener::Endpoint =
+            figment.extract_inner("address").unwrap_or_default();
+        match endpoint.tcp() {
+            Some(addr) => {
+                let port: u16 = figment.extract_inner("port").unwrap_or(addr.port());
+                format!("{}:{port}", addr.ip())
+            }
+            None => endpoint.to_string(),
+        }
+    };
+    let _discovery_reg = discovery::DiscoveryRegistration::register(
+        &listen_address,
+        args.config.as_deref(),
+        &config.image_path,
+        &config.run_path,
+        &config.node_name,
+        &app_version(),
+    )
+    .context("failed to register VMM instance for discovery")?;
 
     let api_auth = ApiToken::new(config.auth.tokens.clone(), config.auth.enabled);
     let supervisor = {

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -34,6 +34,9 @@ DEFAULT_CONFIG_PATH = os.path.expanduser("~/.dstack-vmm/config.json")
 DEFAULT_KMS_WHITELIST_PATH = os.path.expanduser(
     "~/.dstack-vmm/kms-whitelist.json")
 
+# VMM discovery directory
+DISCOVERY_DIR = "/run/dstack-vmm"
+
 
 def load_config() -> Dict[str, Any]:
     """
@@ -50,6 +53,173 @@ def load_config() -> Dict[str, Any]:
             return json.load(f)
     except (json.JSONDecodeError, FileNotFoundError):
         return {}
+
+
+def discover_vmm_instances() -> List[Dict[str, Any]]:
+    """
+    Discover all running VMM instances from the discovery directory.
+
+    Returns:
+        List of VMM instance info dicts, sorted by started_at.
+    """
+    instances = []
+    if not os.path.isdir(DISCOVERY_DIR):
+        return instances
+
+    for fname in os.listdir(DISCOVERY_DIR):
+        if not fname.endswith('.json'):
+            continue
+        fpath = os.path.join(DISCOVERY_DIR, fname)
+        try:
+            with open(fpath, 'r') as f:
+                info = json.load(f)
+            # Check if process is still alive
+            pid = info.get('pid')
+            if pid and not os.path.exists(f'/proc/{pid}'):
+                # Stale file, skip
+                continue
+            instances.append(info)
+        except (json.JSONDecodeError, FileNotFoundError, PermissionError):
+            continue
+
+    instances.sort(key=lambda x: x.get('started_at', 0))
+    return instances
+
+
+def resolve_vmm_url(instances: List[Dict[str, Any]], config: Dict[str, Any],
+                     explicit_url: Optional[str] = None) -> str:
+    """
+    Resolve the VMM URL to connect to.
+
+    Priority:
+    1. Explicit --url flag
+    2. DSTACK_VMM_URL env var
+    3. Config file url
+    4. If exactly one VMM instance is discovered, use that
+    5. If active instance is set in config, use that
+    6. Fall back to default
+
+    Returns the URL string.
+    """
+    # If user explicitly provided --url or env var, honor it
+    env_url = os.environ.get('DSTACK_VMM_URL')
+    if explicit_url and explicit_url != 'http://localhost:8080':
+        return explicit_url
+    if env_url:
+        return env_url
+    config_url = config.get('url')
+    if config_url:
+        return config_url
+
+    # Try auto-discovery
+    active_id = config.get('active_vmm')
+    if active_id:
+        for inst in instances:
+            if inst['id'] == active_id or inst['id'].startswith(active_id):
+                return vmm_address_to_url(inst)
+
+    if len(instances) == 1:
+        return vmm_address_to_url(instances[0])
+
+    return 'http://localhost:8080'
+
+
+def vmm_address_to_url(instance: Dict[str, Any]) -> str:
+    """Convert a VMM instance info dict to a connection URL."""
+    addr = instance.get('address', '')
+    if addr.startswith('unix:'):
+        # Resolve relative socket path against working directory
+        socket_path = addr[5:]
+        if not os.path.isabs(socket_path):
+            working_dir = instance.get('working_dir', '')
+            socket_path = os.path.join(working_dir, socket_path)
+        return f'unix:{socket_path}'
+    elif addr.startswith('http://') or addr.startswith('https://'):
+        return addr
+    else:
+        # host:port format from discovery
+        host, _, port = addr.rpartition(':')
+        if host == '0.0.0.0':
+            host = '127.0.0.1'
+        return f'http://{host}:{port}'
+
+
+def save_active_vmm(vmm_id: str):
+    """Save the active VMM instance ID to the config file."""
+    config = load_config()
+    config['active_vmm'] = vmm_id
+    os.makedirs(os.path.dirname(DEFAULT_CONFIG_PATH), exist_ok=True)
+    with open(DEFAULT_CONFIG_PATH, 'w') as f:
+        json.dump(config, f, indent=2)
+
+
+def cmd_ls_vmm(args):
+    """List all discovered VMM instances."""
+    instances = discover_vmm_instances()
+    config = load_config()
+    active_id = config.get('active_vmm')
+
+    if not instances:
+        print("No running VMM instances found.")
+        print(f"  (discovery directory: {DISCOVERY_DIR})")
+        return
+
+    if getattr(args, 'json', False):
+        print(json.dumps(instances, indent=2))
+        return
+
+    # Table output
+    from datetime import datetime
+
+    fmt = "  {active} {id:<12s} {pid:<8s} {node:<12s} {address:<24s} {workdir}"
+    print(fmt.format(
+        active='', id='ID', pid='PID', node='NAME',
+        address='ADDRESS', workdir='WORKING DIR'))
+    print("  " + "-" * 90)
+
+    for inst in instances:
+        short_id = inst['id'][:8]
+        is_active = '*' if active_id and inst['id'].startswith(active_id) else ' '
+        node_name = inst.get('node_name', '') or '-'
+        address = inst.get('address', '?')
+
+        print(fmt.format(
+            active=is_active,
+            id=short_id,
+            pid=str(inst.get('pid', '?')),
+            node=node_name[:12],
+            address=address[:24],
+            workdir=inst.get('working_dir', '?'),
+        ))
+
+
+def cmd_switch_vmm(args):
+    """Switch the active VMM instance."""
+    target = args.vmm_id
+    instances = discover_vmm_instances()
+
+    if not instances:
+        print("No running VMM instances found.")
+        return
+
+    # Find matching instance by prefix
+    matches = [i for i in instances if i['id'].startswith(target)]
+    if len(matches) == 0:
+        print(f"No VMM instance matching '{target}'.")
+        print("Available instances:")
+        for inst in instances:
+            print(f"  {inst['id'][:8]}  {inst.get('address', '?')}  {inst.get('working_dir', '?')}")
+        return
+    if len(matches) > 1:
+        print(f"Ambiguous ID '{target}', matches multiple instances:")
+        for inst in matches:
+            print(f"  {inst['id'][:8]}  {inst.get('address', '?')}")
+        return
+
+    selected = matches[0]
+    save_active_vmm(selected['id'])
+    url = vmm_address_to_url(selected)
+    print(f"Switched to VMM {selected['id'][:8]} ({url})")
 
 
 def encrypt_env(envs, hex_public_key: str) -> str:
@@ -1242,7 +1412,10 @@ def main():
     # Load config file defaults
     config = load_config()
 
-    # Priority: command line > environment variable > config file > default
+    # Discover running VMM instances
+    instances = discover_vmm_instances()
+
+    # Priority: command line > environment variable > config file > auto-discovery > default
     default_url = os.environ.get(
         'DSTACK_VMM_URL',
         config.get('url', 'http://localhost:8080'))
@@ -1266,6 +1439,17 @@ def main():
         help='Basic auth password (can also be set via DSTACK_VMM_AUTH_PASSWORD env var or config file)')
 
     subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    # VMM discovery commands
+    ls_vmm_parser = subparsers.add_parser(
+        'ls-vmm', help='List all running VMM instances on this host')
+    ls_vmm_parser.add_argument(
+        '--json', action='store_true', help='Output in JSON format')
+
+    switch_vmm_parser = subparsers.add_parser(
+        'switch-vmm', help='Switch active VMM instance')
+    switch_vmm_parser.add_argument(
+        'vmm_id', help='VMM instance ID (prefix match supported)')
 
     # List command
     lsvm_parser = subparsers.add_parser('lsvm', help='List VMs')
@@ -1554,7 +1738,17 @@ def main():
 
     args = parser.parse_args()
 
-    cli = VmmCLI(args.url, args.auth_user, args.auth_password)
+    # Handle discovery commands before creating CLI (they don't need a connection)
+    if args.command == 'ls-vmm':
+        cmd_ls_vmm(args)
+        return
+    elif args.command == 'switch-vmm':
+        cmd_switch_vmm(args)
+        return
+
+    # Resolve the URL with auto-discovery
+    url = resolve_vmm_url(instances, config, args.url)
+    cli = VmmCLI(url, args.auth_user, args.auth_password)
 
     if args.command == 'lsvm':
         cli.list_vms(args.verbose, args.json)


### PR DESCRIPTION
## Summary
- Each `dstack-vmm` process registers itself in `/run/dstack-vmm/<uuid>.json` on startup with instance metadata (listen address, pid, working dir, config path, image/run paths, node name, version)
- Registration file is automatically cleaned up on normal shutdown via `Drop`; stale files from crashed processes are detected by checking `/proc/<pid>` and cleaned on next VMM startup
- `vmm-cli.py` gains `ls-vmm` and `switch-vmm <id>` commands for multi-instance management
- Auto-discovery: when no explicit `--url` is given, CLI auto-connects to the active or sole running VMM instance

## Test plan
- [x] Two TCP VMM instances: `ls-vmm` shows both with correct ports
- [x] `switch-vmm` with prefix match, `*` marker, and `lsvm` auto-connects to selected instance
- [x] UDS listener (`unix:./vmm.sock`): discovery file, path resolution, auto-connect all work
- [x] Normal exit (SIGTERM): `Drop` removes registration file
- [x] Abnormal exit (SIGKILL): stale file remains but `ls-vmm` filters by `/proc/<pid>` check
- [x] `cargo fmt`, `cargo clippy` clean