### PR TITLE
feat(vmm): improve VMM discovery - XDG_RUNTIME_DIR, cross-user, subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "key-provider-client",
  "load_config",
  "lspci",
+ "nix 0.29.0",
  "or-panic",
  "path-absolutize",
  "ra-rpc",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { workspace = true, features = ["v4"] }
 sha2.workspace = true
 hex.workspace = true
 fs-err.workspace = true
+nix = { workspace = true, features = ["user"] }
 dirs.workspace = true
 which.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }

--- a/vmm/src/discovery.rs
+++ b/vmm/src/discovery.rs
@@ -13,8 +13,15 @@ use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-/// Well-known directory where VMM instances register themselves.
-const DISCOVERY_DIR: &str = "/run/dstack-vmm";
+/// Returns the discovery directory path.
+/// Uses $XDG_RUNTIME_DIR/dstack-vmm if set, otherwise falls back to /run/dstack-vmm.
+fn discovery_dir() -> PathBuf {
+    if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+        PathBuf::from(xdg).join("dstack-vmm")
+    } else {
+        PathBuf::from("/run/dstack-vmm")
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VmmInstanceInfo {
@@ -57,8 +64,8 @@ impl DiscoveryRegistration {
         node_name: &str,
         version: &str,
     ) -> Result<Self> {
-        let dir = Path::new(DISCOVERY_DIR);
-        fs_err::create_dir_all(dir).context("failed to create discovery directory")?;
+        let dir = discovery_dir();
+        fs_err::create_dir_all(&dir).context("failed to create discovery directory")?;
 
         let id = Uuid::new_v4().to_string();
         let path = dir.join(format!("{id}.json"));
@@ -104,7 +111,7 @@ impl Drop for DiscoveryRegistration {
 
 /// Clean up stale discovery files from dead processes.
 pub fn cleanup_stale_registrations() {
-    let dir = Path::new(DISCOVERY_DIR);
+    let dir = discovery_dir();
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,

--- a/vmm/src/discovery.rs
+++ b/vmm/src/discovery.rs
@@ -19,16 +19,7 @@ fn discovery_dir() -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
         return PathBuf::from(xdg).join("dstack-vmm");
     }
-    // Read real uid from /proc/self/status to avoid adding a libc dependency.
-    let uid = std::fs::read_to_string("/proc/self/status")
-        .ok()
-        .and_then(|s| {
-            s.lines()
-                .find(|l| l.starts_with("Uid:"))
-                .and_then(|l| l.split_whitespace().nth(1))
-                .and_then(|v| v.parse::<u32>().ok())
-        })
-        .expect("failed to determine uid from /proc/self/status");
+    let uid = nix::unistd::getuid();
     PathBuf::from(format!("/run/user/{uid}/dstack-vmm"))
 }
 

--- a/vmm/src/discovery.rs
+++ b/vmm/src/discovery.rs
@@ -13,14 +13,23 @@ use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-/// Returns the discovery directory path.
-/// Uses $XDG_RUNTIME_DIR/dstack-vmm if set, otherwise falls back to /run/dstack-vmm.
+/// Returns the discovery directory path under $XDG_RUNTIME_DIR/dstack-vmm.
+/// Falls back to /run/user/<uid>/dstack-vmm if XDG_RUNTIME_DIR is not set.
 fn discovery_dir() -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
-        PathBuf::from(xdg).join("dstack-vmm")
-    } else {
-        PathBuf::from("/run/dstack-vmm")
+        return PathBuf::from(xdg).join("dstack-vmm");
     }
+    // Read real uid from /proc/self/status to avoid adding a libc dependency.
+    let uid = std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("Uid:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse::<u32>().ok())
+        })
+        .expect("failed to determine uid from /proc/self/status");
+    PathBuf::from(format!("/run/user/{uid}/dstack-vmm"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -37,16 +37,21 @@ DEFAULT_KMS_WHITELIST_PATH = os.path.expanduser("~/.dstack-vmm/kms-whitelist.jso
 # VMM discovery directories
 # Each user's instances are in $XDG_RUNTIME_DIR/dstack-vmm (typically /run/user/<uid>/dstack-vmm).
 # CLI scans all users' directories so operators can see every instance on the host.
-def _get_discovery_dirs() -> List[str]:
+def _get_discovery_dirs() -> List[Tuple[str, Optional[str]]]:
+    """Return list of (discovery_dir, username) tuples."""
+    import pwd
     dirs = []
-    # Scan all /run/user/*/dstack-vmm
     run_user = "/run/user"
     if os.path.isdir(run_user):
         try:
-            for uid_dir in os.listdir(run_user):
-                candidate = os.path.join(run_user, uid_dir, "dstack-vmm")
+            for uid_str in os.listdir(run_user):
+                candidate = os.path.join(run_user, uid_str, "dstack-vmm")
                 if os.path.isdir(candidate):
-                    dirs.append(candidate)
+                    try:
+                        username = pwd.getpwuid(int(uid_str)).pw_name
+                    except (KeyError, ValueError):
+                        username = f"uid:{uid_str}"
+                    dirs.append((candidate, username))
         except PermissionError:
             pass
     return dirs
@@ -76,19 +81,8 @@ def discover_vmm_instances() -> List[Dict[str, Any]]:
         List of VMM instance info dicts, sorted by started_at.
 
     """
-    import pwd
     instances = []
-    for discovery_dir in _get_discovery_dirs():
-        # Extract uid from /run/user/<uid>/dstack-vmm path
-        parts = discovery_dir.split('/')
-        uid_str = parts[3] if len(parts) > 3 and parts[1] == 'run' and parts[2] == 'user' else None
-        username = None
-        if uid_str and uid_str.isdigit():
-            try:
-                username = pwd.getpwuid(int(uid_str)).pw_name
-            except KeyError:
-                username = f"uid:{uid_str}"
-
+    for discovery_dir, username in _get_discovery_dirs():
         for fname in os.listdir(discovery_dir):
             if not fname.endswith(".json"):
                 continue
@@ -100,7 +94,7 @@ def discover_vmm_instances() -> List[Dict[str, Any]]:
                 if pid and not os.path.exists(f"/proc/{pid}"):
                     continue
                 if username:
-                    info['user'] = username
+                    info["user"] = username
                 instances.append(info)
             except (json.JSONDecodeError, FileNotFoundError, PermissionError):
                 continue
@@ -186,7 +180,7 @@ def cmd_ls_vmm(args):
 
     if not instances:
         print("No running VMM instances found.")
-        print(f"  (scanned: {', '.join(_get_discovery_dirs()) or '/run/user/*/dstack-vmm'})")
+        print(f"  (scanned: {', '.join(d for d, _ in _get_discovery_dirs()) or '/run/user/*/dstack-vmm'})")
         return
 
     if getattr(args, "json", False):

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -34,8 +34,22 @@ except ImportError:
 DEFAULT_CONFIG_PATH = os.path.expanduser("~/.dstack-vmm/config.json")
 DEFAULT_KMS_WHITELIST_PATH = os.path.expanduser("~/.dstack-vmm/kms-whitelist.json")
 
-# VMM discovery directory
-DISCOVERY_DIR = os.path.join(os.environ.get("XDG_RUNTIME_DIR", "/run"), "dstack-vmm")
+# VMM discovery directories
+# Each user's instances are in $XDG_RUNTIME_DIR/dstack-vmm (typically /run/user/<uid>/dstack-vmm).
+# CLI scans all users' directories so operators can see every instance on the host.
+def _get_discovery_dirs() -> List[str]:
+    dirs = []
+    # Scan all /run/user/*/dstack-vmm
+    run_user = "/run/user"
+    if os.path.isdir(run_user):
+        try:
+            for uid_dir in os.listdir(run_user):
+                candidate = os.path.join(run_user, uid_dir, "dstack-vmm")
+                if os.path.isdir(candidate):
+                    dirs.append(candidate)
+        except PermissionError:
+            pass
+    return dirs
 
 
 def load_config() -> Dict[str, Any]:
@@ -56,31 +70,27 @@ def load_config() -> Dict[str, Any]:
 
 
 def discover_vmm_instances() -> List[Dict[str, Any]]:
-    """Discover all running VMM instances from the discovery directory.
+    """Discover all running VMM instances across all users on the host.
 
     Returns:
         List of VMM instance info dicts, sorted by started_at.
 
     """
     instances = []
-    if not os.path.isdir(DISCOVERY_DIR):
-        return instances
-
-    for fname in os.listdir(DISCOVERY_DIR):
-        if not fname.endswith(".json"):
-            continue
-        fpath = os.path.join(DISCOVERY_DIR, fname)
-        try:
-            with open(fpath, "r") as f:
-                info = json.load(f)
-            # Check if process is still alive
-            pid = info.get("pid")
-            if pid and not os.path.exists(f"/proc/{pid}"):
-                # Stale file, skip
+    for discovery_dir in _get_discovery_dirs():
+        for fname in os.listdir(discovery_dir):
+            if not fname.endswith(".json"):
                 continue
-            instances.append(info)
-        except (json.JSONDecodeError, FileNotFoundError, PermissionError):
-            continue
+            fpath = os.path.join(discovery_dir, fname)
+            try:
+                with open(fpath, "r") as f:
+                    info = json.load(f)
+                pid = info.get("pid")
+                if pid and not os.path.exists(f"/proc/{pid}"):
+                    continue
+                instances.append(info)
+            except (json.JSONDecodeError, FileNotFoundError, PermissionError):
+                continue
 
     instances.sort(key=lambda x: x.get("started_at", 0))
     return instances
@@ -163,7 +173,7 @@ def cmd_ls_vmm(args):
 
     if not instances:
         print("No running VMM instances found.")
-        print(f"  (discovery directory: {DISCOVERY_DIR})")
+        print(f"  (scanned: {', '.join(_get_discovery_dirs()) or '/run/user/*/dstack-vmm'})")
         return
 
     if getattr(args, "json", False):

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -1549,6 +1549,23 @@ def main():
         "vmm_id", help="VMM instance ID (prefix match supported)"
     )
 
+    # Register nested subcommands for top-level help display
+    _nested_commands = {
+        'vmm ls': 'List all running VMM instances on this host',
+        'vmm switch': 'Switch active VMM instance',
+    }
+
+    # Patch parser's format_help to show nested subcommands
+    _orig_format_help = parser.format_help
+    def _patched_format_help():
+        text = _orig_format_help()
+        # Append nested subcommands after the subparser listing
+        extra = "\nnested commands:\n"
+        for cmd, desc in _nested_commands.items():
+            extra += f"    {cmd:<24s}{desc}\n"
+        return text + extra
+    parser.format_help = _patched_format_help
+
     # List command
     lsvm_parser = subparsers.add_parser("lsvm", help="List VMs")
     lsvm_parser.add_argument(

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -34,12 +34,14 @@ except ImportError:
 DEFAULT_CONFIG_PATH = os.path.expanduser("~/.dstack-vmm/config.json")
 DEFAULT_KMS_WHITELIST_PATH = os.path.expanduser("~/.dstack-vmm/kms-whitelist.json")
 
+
 # VMM discovery directories
 # Each user's instances are in $XDG_RUNTIME_DIR/dstack-vmm (typically /run/user/<uid>/dstack-vmm).
 # CLI scans all users' directories so operators can see every instance on the host.
 def _get_discovery_dirs() -> List[Tuple[str, Optional[str]]]:
     """Return list of (discovery_dir, username) tuples."""
     import pwd
+
     dirs = []
     run_user = "/run/user"
     if os.path.isdir(run_user):
@@ -180,7 +182,9 @@ def cmd_ls_vmm(args):
 
     if not instances:
         print("No running VMM instances found.")
-        print(f"  (scanned: {', '.join(d for d, _ in _get_discovery_dirs()) or '/run/user/*/dstack-vmm'})")
+        print(
+            f"  (scanned: {', '.join(d for d, _ in _get_discovery_dirs()) or '/run/user/*/dstack-vmm'})"
+        )
         return
 
     if getattr(args, "json", False):
@@ -1560,12 +1564,13 @@ def main():
 
     # Register nested subcommands for top-level help display
     _nested_commands = {
-        'vmm ls': 'List all running VMM instances on this host',
-        'vmm switch': 'Switch active VMM instance',
+        "vmm ls": "List all running VMM instances on this host",
+        "vmm switch": "Switch active VMM instance",
     }
 
     # Patch parser's format_help to show nested subcommands
     _orig_format_help = parser.format_help
+
     def _patched_format_help():
         text = _orig_format_help()
         # Append nested subcommands after the subparser listing
@@ -1573,6 +1578,7 @@ def main():
         for cmd, desc in _nested_commands.items():
             extra += f"    {cmd:<24s}{desc}\n"
         return text + extra
+
     parser.format_help = _patched_format_help
 
     # List command

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -1527,18 +1527,25 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    # VMM discovery commands
-    ls_vmm_parser = subparsers.add_parser(
-        "ls-vmm", help="List all running VMM instances on this host"
+    # VMM discovery commands (vmm ls / vmm switch)
+    vmm_parser = subparsers.add_parser(
+        "vmm", help="VMM instance management (ls, switch)"
     )
-    ls_vmm_parser.add_argument(
+    vmm_subparsers = vmm_parser.add_subparsers(
+        dest="vmm_command", help="VMM sub-commands"
+    )
+
+    vmm_ls_parser = vmm_subparsers.add_parser(
+        "ls", help="List all running VMM instances on this host"
+    )
+    vmm_ls_parser.add_argument(
         "--json", action="store_true", help="Output in JSON format"
     )
 
-    switch_vmm_parser = subparsers.add_parser(
-        "switch-vmm", help="Switch active VMM instance"
+    vmm_switch_parser = vmm_subparsers.add_parser(
+        "switch", help="Switch active VMM instance"
     )
-    switch_vmm_parser.add_argument(
+    vmm_switch_parser.add_argument(
         "vmm_id", help="VMM instance ID (prefix match supported)"
     )
 
@@ -1889,11 +1896,13 @@ def main():
     args = parser.parse_args()
 
     # Handle discovery commands before creating CLI (they don't need a connection)
-    if args.command == "ls-vmm":
-        cmd_ls_vmm(args)
-        return
-    elif args.command == "switch-vmm":
-        cmd_switch_vmm(args)
+    if args.command == "vmm":
+        if args.vmm_command == "ls":
+            cmd_ls_vmm(args)
+        elif args.vmm_command == "switch":
+            cmd_switch_vmm(args)
+        else:
+            vmm_parser.print_help()
         return
 
     # Resolve the URL with auto-discovery

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -35,7 +35,7 @@ DEFAULT_CONFIG_PATH = os.path.expanduser("~/.dstack-vmm/config.json")
 DEFAULT_KMS_WHITELIST_PATH = os.path.expanduser("~/.dstack-vmm/kms-whitelist.json")
 
 # VMM discovery directory
-DISCOVERY_DIR = "/run/dstack-vmm"
+DISCOVERY_DIR = os.path.join(os.environ.get("XDG_RUNTIME_DIR", "/run"), "dstack-vmm")
 
 
 def load_config() -> Dict[str, Any]:

--- a/vmm/src/vmm-cli.py
+++ b/vmm/src/vmm-cli.py
@@ -76,8 +76,19 @@ def discover_vmm_instances() -> List[Dict[str, Any]]:
         List of VMM instance info dicts, sorted by started_at.
 
     """
+    import pwd
     instances = []
     for discovery_dir in _get_discovery_dirs():
+        # Extract uid from /run/user/<uid>/dstack-vmm path
+        parts = discovery_dir.split('/')
+        uid_str = parts[3] if len(parts) > 3 and parts[1] == 'run' and parts[2] == 'user' else None
+        username = None
+        if uid_str and uid_str.isdigit():
+            try:
+                username = pwd.getpwuid(int(uid_str)).pw_name
+            except KeyError:
+                username = f"uid:{uid_str}"
+
         for fname in os.listdir(discovery_dir):
             if not fname.endswith(".json"):
                 continue
@@ -88,6 +99,8 @@ def discover_vmm_instances() -> List[Dict[str, Any]]:
                 pid = info.get("pid")
                 if pid and not os.path.exists(f"/proc/{pid}"):
                     continue
+                if username:
+                    info['user'] = username
                 instances.append(info)
             except (json.JSONDecodeError, FileNotFoundError, PermissionError):
                 continue
@@ -182,18 +195,19 @@ def cmd_ls_vmm(args):
 
     # Table output
 
-    fmt = "  {active} {id:<12s} {pid:<8s} {node:<12s} {address:<24s} {workdir}"
+    fmt = "  {active} {id:<12s} {pid:<8s} {user:<10s} {node:<12s} {address:<24s} {workdir}"
     print(
         fmt.format(
             active="",
             id="ID",
             pid="PID",
+            user="USER",
             node="NAME",
             address="ADDRESS",
             workdir="WORKING DIR",
         )
     )
-    print("  " + "-" * 90)
+    print("  " + "-" * 100)
 
     for inst in instances:
         short_id = inst["id"][:8]
@@ -206,6 +220,7 @@ def cmd_ls_vmm(args):
                 active=is_active,
                 id=short_id,
                 pid=str(inst.get("pid", "?")),
+                user=inst.get("user", "?")[:10],
                 node=node_name[:12],
                 address=address[:24],
                 workdir=inst.get("working_dir", "?"),


### PR DESCRIPTION
## Summary
Follow-up to #584. Improvements to the VMM instance discovery mechanism:

- Use `$XDG_RUNTIME_DIR/dstack-vmm` instead of `/run/dstack-vmm` so no root permissions are needed; fall back to `/run/user/<uid>/dstack-vmm` via `nix::unistd::getuid()` when the env var is unset
- `vmm-cli.py` scans `/run/user/*/dstack-vmm/` to discover instances from **all users** on the host (verified: normal user can discover root's VMM)
- Rename `ls-vmm` / `switch-vmm` → `vmm ls` / `vmm switch` subcommand group
- Nested subcommands shown in top-level `--help` output

## Test plan
- [x] VMM registers in `$XDG_RUNTIME_DIR/dstack-vmm/` (tested)
- [x] Fallback to `/run/user/<uid>/` when `XDG_RUNTIME_DIR` unset (tested with `env -u`)
- [x] Root VMM instance discoverable by normal user (tested)
- [x] `vmm ls` and `vmm switch` work correctly
- [x] Top-level `--help` shows nested `vmm ls` / `vmm switch`
- [x] `cargo fmt`, `cargo clippy` clean