### PR TITLE
tdx-attest: fix infinite loop in ConfigFS generation wait (#565)

### DIFF
--- a/tdx-attest/src/linux.rs
+++ b/tdx-attest/src/linux.rs
@@ -18,7 +18,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::Mutex;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
@@ -52,6 +52,10 @@ const QGS_MSG_GET_QUOTE_RESP: u32 = 1;
 // QGS message version
 const QGS_MSG_VERSION_MAJOR: u16 = 1;
 const QGS_MSG_VERSION_MINOR: u16 = 0;
+
+// ConfigFS generation wait parameters
+const CONFIGFS_GEN_WAIT_TIMEOUT_SECS: u64 = 5;
+const CONFIGFS_GEN_POLL_INTERVAL_MS: u64 = 10;
 
 // ============================================================================
 // ioctl definitions for /dev/tdx_guest
@@ -431,12 +435,19 @@ fn write_inblob_with_retry(path: &str, data: &TdxReportData) -> Result<()> {
 }
 
 fn wait_for_generation_change(path: &str, current: i64) -> Result<i64> {
+    let deadline = Instant::now() + Duration::from_secs(CONFIGFS_GEN_WAIT_TIMEOUT_SECS);
+
     loop {
         let gen = read_generation(path)?;
         if gen != current {
             return Ok(gen);
         }
-        thread::sleep(Duration::from_micros(1));
+        if Instant::now() >= deadline {
+            return Err(TdxAttestError::QuoteFailure(
+                "timed out waiting for configfs generation to advance".to_string(),
+            ));
+        }
+        thread::sleep(Duration::from_millis(CONFIGFS_GEN_POLL_INTERVAL_MS));
     }
 }
 


### PR DESCRIPTION
Fixes #565.

The TDX attestation helper currently waits for the ConfigFS generation counter to advance in a tight loop with only a 1µs sleep. If the kernel interface gets stuck and never increments the counter, the loop will effectively run forever and can burn CPU.

This change:
- Adds a small polling delay (10ms) between reads.
- Introduces a 5 second timeout for the generation to advance.
- Returns a clear QuoteFailure error when the timeout is hit.

This keeps the happy path unchanged for normal hosts where the generation increases quickly, while ensuring that a stuck or misbehaving ConfigFS implementation leads to a bounded wait and a recoverable error instead of an infinite busy loop.