### PR TITLE
Fix path traversal in KMS remove_cache (#558)

### DIFF
--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -149,53 +149,24 @@ impl RpcHandler {
         if sub_dir.is_empty() {
             return Ok(());
         }
+
         if sub_dir == "all" {
             fs::remove_dir_all(parent_dir)?;
-
             return Ok(());
         }
 
-        let sub_path = Path::new(sub_dir);
-        if sub_path.is_absolute() {
-            bail!("Invalid cache path");
+        if !sub_dir.chars().all(|c| c.is_ascii_hexdigit()) {
+            bail!("Invalid cache key");
         }
 
-        let mut cleaned = PathBuf::new();
-        for component in sub_path.components() {
-            use std::path::Component;
+        let path = parent_dir.join(sub_dir);
 
-            match component {
-                Component::Normal(part) => cleaned.push(part),
-                Component::CurDir => {}
-                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                    bail!("Invalid cache path");
-                }
-            }
+        if path.is_dir() {
+            fs::remove_dir_all(path)?;
+        } else if path.is_file() {
+            fs::remove_file(path)?;
         }
 
-        if cleaned.as_os_str().is_empty() {
-            // Only separators or current-dir components – nothing to do.
-            return Ok(());
-        }
-
-        let path = parent_dir.join(&cleaned);
-
-        let canonical_parent = parent_dir
-            .canonicalize()
-            .unwrap_or_else(|_| parent_dir.to_path_buf());
-        let canonical = path
-            .canonicalize()
-            .unwrap_or_else(|_| canonical_parent.join(&cleaned));
-
-        if !canonical.starts_with(&canonical_parent) {
-            bail!("Invalid cache path");
-        }
-
-        if canonical.is_dir() {
-            fs::remove_dir_all(canonical)?;
-        } else {
-            fs::remove_file(canonical)?;
-        }
         Ok(())
     }
 

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{bail, Context, Result};
 use dstack_kms_rpc::{
@@ -142,19 +145,56 @@ impl RpcHandler {
         self.state.config.image.cache_dir.join("images")
     }
 
-    fn remove_cache(&self, parent_dir: &PathBuf, sub_dir: &str) -> Result<()> {
+    fn remove_cache(&self, parent_dir: &Path, sub_dir: &str) -> Result<()> {
         if sub_dir.is_empty() {
             return Ok(());
         }
         if sub_dir == "all" {
             fs::remove_dir_all(parent_dir)?;
-        } else {
-            let path = parent_dir.join(sub_dir);
-            if path.is_dir() {
-                fs::remove_dir_all(path)?;
-            } else {
-                fs::remove_file(path)?;
+
+            return Ok(());
+        }
+
+        let sub_path = Path::new(sub_dir);
+        if sub_path.is_absolute() {
+            bail!("Invalid cache path");
+        }
+
+        let mut cleaned = PathBuf::new();
+        for component in sub_path.components() {
+            use std::path::Component;
+
+            match component {
+                Component::Normal(part) => cleaned.push(part),
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    bail!("Invalid cache path");
+                }
             }
+        }
+
+        if cleaned.as_os_str().is_empty() {
+            // Only separators or current-dir components – nothing to do.
+            return Ok(());
+        }
+
+        let path = parent_dir.join(&cleaned);
+
+        let canonical_parent = parent_dir
+            .canonicalize()
+            .unwrap_or_else(|_| parent_dir.to_path_buf());
+        let canonical = path
+            .canonicalize()
+            .unwrap_or_else(|_| canonical_parent.join(&cleaned));
+
+        if !canonical.starts_with(&canonical_parent) {
+            bail!("Invalid cache path");
+        }
+
+        if canonical.is_dir() {
+            fs::remove_dir_all(canonical)?;
+        } else {
+            fs::remove_file(canonical)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR hardens the KMS admin `remove_cache` endpoint against path traversal.

**What changed**
- Treat the `sub_dir` argument as a relative path and reject absolute paths.
- Reject any cache keys containing `..`, root, or prefix components.
- Normalize the remaining path components and join against the configured cache directory.
- Use canonical paths (with a fallback when the target does not yet exist) and verify that the resolved path stays within the expected cache directory before deleting anything.
- Keep the existing `sub_dir == "all"` behavior for deleting the entire cache directory.

**Why**
Previously, `remove_cache` joined `sub_dir` directly onto the parent cache directory and passed the resulting path into `fs::remove_dir_all` / `fs::remove_file`. A caller that knows the admin token could supply a value like `../../etc` and cause deletion of directories outside the intended cache root.

The new logic ensures that only normalized, non-escaping paths rooted under the configured cache directory are ever removed.

**Testing**
- `cargo fmt`
- `cargo clippy -p dstack-kms --all-targets -- -D warnings`
- `cargo test -p dstack-kms --tests`

Closes #558.
