### PR TITLE
Restrict runtime event log permissions

### DIFF
--- a/cc-eventlog/src/runtime_events.rs
+++ b/cc-eventlog/src/runtime_events.rs
@@ -64,9 +64,18 @@ impl RuntimeEvent {
             .context("failed to get event log directory")?;
         fs::create_dir_all(logfile_dir).context("failed to create event log directory")?;
 
-        let mut logfile = fs::OpenOptions::new()
-            .append(true)
-            .create(true)
+        let mut options = fs::OpenOptions::new();
+        options.append(true).create(true);
+
+        // Restrict runtime event log visibility and writability to the owner (root).
+        // This avoids other processes in the CVM tampering with or reading the log.
+        #[cfg(unix)]
+        {
+            use fs_err::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let mut logfile = options
             .open(logfile_path)
             .context("failed to open event log file")?;
 


### PR DESCRIPTION
This PR tightens filesystem permissions for the runtime event log so that it is only readable/writable by the owner (root).

- Use fs_err::OpenOptionsExt on Unix to create /run/log/dstack/runtime_events.log with mode 0600
- Keep the existing log format and location unchanged to avoid breaking consumers

This addresses part of the concern raised in #557 about other processes inside the CVM being able to tamper with the runtime event log. The CVM is not designed as a multi-tenant environment; untrusted workloads should be sandboxed by the application itself. However, making the log file private to the owning process is a straightforward hardening step with no downside.