### PR TITLE
fix: enforce 20-byte app_id length in CVM setup

### DIFF
--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1288,6 +1288,12 @@ impl<'a> Stage0<'a> {
         if instance_info.app_id.is_empty() {
             instance_info.app_id = truncated_compose_hash.to_vec();
         }
+        if instance_info.app_id.len() != 20 {
+            bail!(
+                "Invalid app id length: expected 20 bytes, got {}",
+                instance_info.app_id.len()
+            );
+        }
 
         let disk_reusable = !key_provider.is_none();
         if (!disk_reusable) || instance_info.instance_id_seed.is_empty() {


### PR DESCRIPTION
This PR makes the 20-byte app_id requirement explicit in the CVM setup path.

- In , we now validate that  and fail fast with a clear error if not.
- This matches the existing hard requirement in , which already calls  with  and would reject any non–20-byte app_id.

In other words, configs that were valid before remain valid; the only behavioral change is that misconfigured app_ids that would have failed later now fail earlier with a more explicit error.

Related to #554.