### PR TITLE
refactor: replace cbor with msgpack for AttestationV1 wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,33 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,7 +2243,6 @@ version = "0.5.8"
 dependencies = [
  "anyhow",
  "cc-eventlog",
- "ciborium",
  "dcap-qvl",
  "dstack-types",
  "errify",
@@ -2282,6 +2254,7 @@ dependencies = [
  "insta",
  "or-panic",
  "parity-scale-codec",
+ "rmp-serde",
  "serde",
  "serde-human-bytes",
  "serde_json",
@@ -3446,17 +3419,6 @@ dependencies = [
  "http",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]

--- a/dstack-attest/Cargo.toml
+++ b/dstack-attest/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 cc-eventlog.workspace = true
-ciborium.workspace = true
+rmp-serde.workspace = true
 dcap-qvl.workspace = true
 dstack-types.workspace = true
 ez-hash.workspace = true

--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -52,8 +52,9 @@ fn read_vm_config() -> Result<String> {
     Ok(sys_config.vm_config)
 }
 
-fn is_cbor_map_prefix(byte: u8) -> bool {
-    matches!(byte, 0xa0..=0xbf)
+fn is_msgpack_map_prefix(byte: u8) -> bool {
+    // fixmap (0x80..=0x8f), map16 (0xde), map32 (0xdf)
+    matches!(byte, 0x80..=0x8f | 0xde | 0xdf)
 }
 
 impl From<Attestation> for AttestationV1 {
@@ -409,8 +410,8 @@ impl VersionedAttestation {
                 LegacyVersionedAttestation::V0 { attestation } => Ok(Self::V0 { attestation }),
             };
         }
-        if is_cbor_map_prefix(first) {
-            let attestation = AttestationV1::from_cbor(bytes)?;
+        if is_msgpack_map_prefix(first) {
+            let attestation = AttestationV1::from_msgpack(bytes)?;
             return Ok(Self::V1 { attestation });
         }
         bail!("Unknown attestation wire format");
@@ -423,7 +424,7 @@ impl VersionedAttestation {
                 attestation: attestation.clone(),
             }
             .encode()),
-            Self::V1 { attestation } => attestation.to_cbor(),
+            Self::V1 { attestation } => attestation.to_msgpack(),
         }
     }
 
@@ -1336,7 +1337,7 @@ mod tests {
             .into_v1()
             .into_dstack_pod(payload.clone());
         let encoded = VersionedAttestation::V1 { attestation }.to_bytes().unwrap();
-        assert!(matches!(encoded.first(), Some(0xa0..=0xbf)));
+        assert!(matches!(encoded.first(), Some(0x80..=0x8f)));
         let decoded = VersionedAttestation::from_bytes(&encoded)
             .expect("decode attestation")
             .into_v1();

--- a/dstack-attest/src/v1.rs
+++ b/dstack-attest/src/v1.rs
@@ -147,21 +147,18 @@ impl Attestation {
         }
     }
 
-    pub fn to_cbor(&self) -> Result<Vec<u8>> {
+    pub fn to_msgpack(&self) -> Result<Vec<u8>> {
         let mut normalized = self.clone();
         normalized.version = ATTESTATION_VERSION;
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&normalized, &mut bytes)
-            .context("Failed to encode attestation as CBOR")?;
-        Ok(bytes)
+        rmp_serde::to_vec_named(&normalized).context("failed to encode attestation as msgpack")
     }
 
-    pub fn from_cbor(bytes: &[u8]) -> Result<Self> {
+    pub fn from_msgpack(bytes: &[u8]) -> Result<Self> {
         let value: Self =
-            ciborium::from_reader(bytes).context("Failed to decode attestation from CBOR")?;
+            rmp_serde::from_slice(bytes).context("failed to decode attestation from msgpack")?;
         if value.version != ATTESTATION_VERSION {
             bail!(
-                "Unsupported attestation version: expected {}, got {}",
+                "unsupported attestation version: expected {}, got {}",
                 ATTESTATION_VERSION,
                 value.version
             );
@@ -199,7 +196,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cbor_roundtrip_preserves_attestation() {
+    fn msgpack_roundtrip_preserves_attestation() {
         let attestation = Attestation::new(
             PlatformEvidence::Tdx {
                 quote: vec![1u8, 2, 3],
@@ -222,9 +219,9 @@ mod tests {
             },
         );
 
-        let encoded = attestation.to_cbor().expect("encode cbor");
-        assert!(matches!(encoded.first(), Some(0xa0..=0xbf)));
-        let decoded = Attestation::from_cbor(&encoded).expect("decode cbor");
+        let encoded = attestation.to_msgpack().expect("encode msgpack");
+        assert!(matches!(encoded.first(), Some(0x80..=0x8f)));
+        let decoded = Attestation::from_msgpack(&encoded).expect("decode msgpack");
         assert_eq!(decoded.version, ATTESTATION_VERSION);
         match decoded.platform {
             PlatformEvidence::Tdx { quote, event_log } => {


### PR DESCRIPTION
## Summary
- Replace `ciborium` (CBOR) with `rmp-serde` (msgpack) for `AttestationV1` serialization
- Consistent with existing msgpack usage in `ra-tls` for `AppInfo` encoding
- Removes `ciborium` dependency (and transitive deps `ciborium-io`, `ciborium-ll`, `half`)
- Broadens wire format detection to cover msgpack fixmap, map16, and map32 prefixes

## Test plan
- [x] `cargo test -p dstack-attest --all-features` — 6 tests pass
- [x] `cargo check -p dstack-attest -p ra-tls -p dstack-guest-agent -p dstack-guest-agent-simulator`