### PR TITLE
fix: avoid double serialization in VersionedAttestation SCALE size_hint

### DIFF
--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -355,7 +355,7 @@ pub enum VersionedAttestation {
 
 impl Encode for VersionedAttestation {
     fn size_hint(&self) -> usize {
-        self.to_bytes().map(|b| b.len()).unwrap_or(0)
+        0
     }
 
     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {


### PR DESCRIPTION
## Summary
- `Encode::size_hint()` was calling `to_bytes()` for the exact length, then `encode_to()` serialized again — wasting a full serialization pass
- Return 0 instead; SCALE's `size_hint` is best-effort and only used for buffer pre-allocation

## Test plan
- [x] `cargo check -p dstack-attest`