### PR TITLE
feat(kms): make self-authorization enforcement configurable

### DIFF
--- a/kms/kms.toml
+++ b/kms/kms.toml
@@ -26,6 +26,11 @@ mandatory = false
 cert_dir = "/etc/kms/certs"
 subject_postfix = ".dstack"
 admin_token_hash = ""
+# Whether trusted RPCs require the KMS to first attest itself to its own
+# auth API. Defaults to true (strict). Set to false ONLY when running KMS
+# outside a TEE (e.g. local dev/testing) where the local guest agent socket
+# is unavailable.
+enforce_self_authorization = true
 
 [core.image]
 verify = true

--- a/kms/src/config.rs
+++ b/kms/src/config.rs
@@ -40,6 +40,16 @@ pub(crate) struct KmsConfig {
     pub image: ImageConfig,
     #[serde(with = "serde_human_bytes")]
     pub admin_token_hash: Vec<u8>,
+    /// Whether trusted RPCs require the KMS to first attest itself to its
+    /// own auth API. Defaults to `true` (strict). Set `false` only for local
+    /// dev/testing where the KMS runs outside a TEE and cannot reach a guest
+    /// agent socket.
+    #[serde(default = "default_true")]
+    pub enforce_self_authorization: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl KmsConfig {

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -102,6 +102,9 @@ struct BootConfig {
 
 impl RpcHandler {
     async fn ensure_self_allowed(&self) -> Result<()> {
+        if !self.state.config.enforce_self_authorization {
+            return Ok(());
+        }
         let boot_info = self
             .state
             .self_boot_info

--- a/kms/src/main_service.rs
+++ b/kms/src/main_service.rs
@@ -26,7 +26,7 @@ use ra_tls::{
 use scale::Decode;
 use sha2::Digest;
 use tokio::sync::OnceCell;
-use tracing::info;
+use tracing::{info, warn};
 use upgrade_authority::{build_boot_info, local_kms_boot_info, BootInfo};
 
 use crate::{
@@ -76,6 +76,9 @@ impl KmsState {
             config.image.download_timeout,
             config.pccs_url.clone(),
         );
+        if !config.enforce_self_authorization {
+            warn!("self-authorization is disabled; trusted RPCs will not be gated by KMS self-attestation - do not use in production TEE deployments");
+        }
         Ok(Self {
             inner: Arc::new(KmsStateInner {
                 config,

--- a/kms/src/main_service/upgrade_authority.rs
+++ b/kms/src/main_service/upgrade_authority.rs
@@ -206,6 +206,9 @@ pub(crate) fn pad64(hash: [u8; 32]) -> Vec<u8> {
 }
 
 pub(crate) async fn ensure_self_kms_allowed(cfg: &KmsConfig) -> Result<()> {
+    if !cfg.enforce_self_authorization {
+        return Ok(());
+    }
     let boot_info = local_kms_boot_info(cfg.pccs_url.as_deref())
         .await
         .context("failed to build local KMS boot info")?;


### PR DESCRIPTION
## Summary

Add `core.enforce_self_authorization` (default `true`) so KMS can opt out of the self-attestation step on trusted RPCs when run intentionally outside a TEE.

## Motivation

Commit 06d89a29 (\"kms: enforce self authorization on trusted RPCs\") makes every trusted RPC first call \`local_kms_boot_info\` -> \`app_attest\`, which dials \`/var/run/dstack(.sock)\` (or its newer path) for a TDX quote. When KMS runs on a non-TEE host (local dev / integration testing setups), that socket does not exist, so the \`OnceCell\`-cached \`self_boot_info\` can never initialize and **every** trusted request returns 400 with \`KMS self authorization failed: ...: No such file or directory (os error 2)\`.

Existing host-mode setups that relied on this only kept working because their long-lived KMS process initialized the cache once when a socket happened to be present and then held it indefinitely. Any restart breaks them.

## Changes

- New field \`KmsConfig::enforce_self_authorization\` (defaults to \`true\` via \`#[serde(default)]\`, so existing configs and TEE deployments are unchanged).
- \`RpcHandler::ensure_self_allowed\` and the free \`ensure_self_kms_allowed\` short-circuit and return \`Ok(())\` when the flag is \`false\`.
- Default \`kms.toml\` documents the option with an explicit \`= true\` and a comment warning it should only be flipped for non-TEE local runs.

## Test plan

- [x] \`cargo clippy -p dstack-kms -- -D warnings -D clippy::expect_used -D clippy::unwrap_used\` clean
- [x] \`cargo fmt --check --all\` clean
- [x] \`cargo test -p dstack-kms\` passes
- [ ] Manual: run KMS on a non-TEE host with \`enforce_self_authorization = false\` and confirm \`SignCert\` / \`GetTempCaCert\` succeed (verifies the bypass path)
- [ ] Manual: confirm a TEE deployment with the default config still gates trusted RPCs as before