### PR TITLE
ci: fix docker-build-check for PRs from forks

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ master, next, dev-* ]
 
+env:
+  DSTACK_REV: ${{ github.event.pull_request.head.sha || github.sha }}
+  DSTACK_SRC_URL: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}', github.server_url, github.repository) }}
+
 jobs:
   gateway:
     runs-on: ubuntu-latest
@@ -30,8 +34,8 @@ jobs:
           build-contexts: |
             build-shared=build/shared
           build-args: |
-            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}
-            DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}
+            DSTACK_REV=${{ env.DSTACK_REV }}
+            DSTACK_SRC_URL=${{ env.DSTACK_SRC_URL }}
 
       - name: Verify pinned packages
         run: |
@@ -46,8 +50,8 @@ jobs:
             --tag gateway-builder-check:latest \
             --provenance=false \
             --build-context build-shared=build/shared \
-            --build-arg "DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}" \
-            --build-arg "DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}" \
+            --build-arg "DSTACK_REV=${DSTACK_REV}" \
+            --build-arg "DSTACK_SRC_URL=${DSTACK_SRC_URL}" \
             gateway/dstack-app/builder
 
       - name: Verify builder pinned packages
@@ -74,8 +78,8 @@ jobs:
           build-contexts: |
             build-shared=build/shared
           build-args: |
-            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}
-            DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}
+            DSTACK_REV=${{ env.DSTACK_REV }}
+            DSTACK_SRC_URL=${{ env.DSTACK_SRC_URL }}
 
       - name: Verify pinned packages (qemu stage)
         run: |
@@ -90,8 +94,8 @@ jobs:
             --tag kms-builder-check:latest \
             --provenance=false \
             --build-context build-shared=build/shared \
-            --build-arg "DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}" \
-            --build-arg "DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}" \
+            --build-arg "DSTACK_REV=${DSTACK_REV}" \
+            --build-arg "DSTACK_SRC_URL=${DSTACK_SRC_URL}" \
             kms/dstack-app/builder
 
       - name: Verify builder pinned packages
@@ -125,8 +129,8 @@ jobs:
           build-contexts: |
             build-shared=build/shared
           build-args: |
-            DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}
-            DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}
+            DSTACK_REV=${{ env.DSTACK_REV }}
+            DSTACK_SRC_URL=${{ env.DSTACK_SRC_URL }}
 
       - name: Verify pinned packages (runtime)
         run: |
@@ -142,8 +146,8 @@ jobs:
             --provenance=false \
             --file verifier/builder/Dockerfile \
             --build-context build-shared=build/shared \
-            --build-arg "DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}" \
-            --build-arg "DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}" \
+            --build-arg "DSTACK_REV=${DSTACK_REV}" \
+            --build-arg "DSTACK_SRC_URL=${DSTACK_SRC_URL}" \
             verifier
 
       - name: Verify builder pinned packages
@@ -160,8 +164,8 @@ jobs:
             --provenance=false \
             --file verifier/builder/Dockerfile \
             --build-context build-shared=build/shared \
-            --build-arg "DSTACK_REV=${{ github.event.pull_request.head.sha || github.sha }}" \
-            --build-arg "DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}" \
+            --build-arg "DSTACK_REV=${DSTACK_REV}" \
+            --build-arg "DSTACK_SRC_URL=${DSTACK_SRC_URL}" \
             verifier
 
       - name: Verify qemu pinned packages


### PR DESCRIPTION
## Summary

- `docker-build-check.yml` passes `DSTACK_SRC_URL=${{ github.server_url }}/${{ github.repository }}` to the Dockerfile, which is always the **base** repo (`Dstack-TEE/dstack`). The Dockerfile then runs `git clone $DSTACK_SRC_URL && git checkout $DSTACK_REV`.
- For PRs from forks, `DSTACK_REV` is the fork's head SHA, which does not exist in the base repo yet, so the checkout fails with `fatal: unable to read tree`. Seen on #653.
- This PR switches `DSTACK_SRC_URL` to `github.event.pull_request.head.repo.clone_url` when it's set (fork PRs and same-repo PRs), falling back to the base repo URL for `push` events. The 7 occurrences across the gateway / kms / verifier jobs are all updated.

## Test plan

- [ ] CI on this PR still green (same-repo case still works via fallback).
- [ ] Re-run CI on #653 (or any fork PR) and confirm the 3 Docker Build Check jobs now succeed past the `git checkout` step.