### PR TITLE
fix: prevent u64 underflow panic in online instance count

### DIFF
--- a/gateway/src/admin_service.rs
+++ b/gateway/src/admin_service.rs
@@ -157,7 +157,7 @@ impl AdminRpc for AdminRpcHandler {
             .values()
             .filter(|(ts, _)| {
                 // Skip instances that never connected (ts == 0)
-                *ts != 0 && (now - *ts) < 300
+                *ts != 0 && now.saturating_sub(*ts) < 300
             })
             .count();
 


### PR DESCRIPTION
Bare subtraction now - ts panics in debug builds and silently wraps around in release builds when a peer reports a future timestamp due to clock skew. Use saturating_sub to handle this safely.