### PR TITLE
sdk(rust): drop hickory-dns from reqwest features (RUSTSEC-2026-0119)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -21,7 +21,7 @@ bon.workspace = true
 hex = { workspace = true, features = ["std"] }
 http.workspace = true
 http-client-unix-domain-socket = "0.1.1"
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "charset"] }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true


### PR DESCRIPTION
## Summary

The Rust SDK currently inherits the workspace `reqwest` dependency, which has `hickory-dns` enabled. This pulls in `hickory-resolver 0.25.2` → `hickory-proto 0.25.2`, which is flagged by [RUSTSEC-2026-0119](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp) (O(n²) name compression / CPU-exhaustion in `hickory-proto < 0.26.1`).

There is no patched 0.25.x release — the fix is in `hickory-proto 0.26.1`, and `reqwest 0.12.x` requires `hickory-resolver ^0.25`, so the chain cannot be updated via `cargo update`.

The SDK itself does not need a custom DNS resolver: its only HTTP traffic is to the local dstack Unix socket / loopback. Pinning `reqwest` directly with the same non-hickory features the workspace already uses (`rustls-tls`, `charset`) keeps TLS/charset behavior identical and removes the vulnerable transitive from every downstream consumer of `dstack-sdk`.

Other workspace members (`gateway`, `kms`, ...) continue to use `reqwest = { workspace = true }` and are unaffected.

## Change

`sdk/rust/Cargo.toml`:

```diff
- reqwest = { workspace = true, features = ["json"] }
+ reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "charset"] }
```