### PR TITLE
Pin dtolnay/rust-toolchain action refs in CI workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@1.86
       with:
         toolchain: 1.92.0
         components: clippy, rustfmt

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@1.86
         with:
           toolchain: 1.92.0
           components: clippy, rustfmt


### PR DESCRIPTION
### Motivation
- Remove a supply-chain vulnerability introduced by using the moving branch `dtolnay/rust-toolchain@master` in CI workflows so upstream changes cannot execute arbitrary code in the project's CI.
- Preserve the existing toolchain and workflow behavior while ensuring reproducible, auditable CI action refs.

### Description
- Replaced `dtolnay/rust-toolchain@master` with the fixed ref `dtolnay/rust-toolchain@1.86` in `.github/workflows/rust.yml`.
- Replaced `dtolnay/rust-toolchain@master` with the fixed ref `dtolnay/rust-toolchain@1.86` in `.github/workflows/sdk.yaml`.
- Kept existing `toolchain: 1.92.0`, components, and additional targets intact so workflow behavior is unchanged.

### Testing
- Verified the workflow contents with `sed -n '1,200p' .github/workflows/rust.yml` and `sed -n '1,220p' .github/workflows/sdk.yaml`, which showed the updated action refs and unchanged toolchain settings; these commands succeeded.
- Searched for remaining moving refs with `rg -n "dtolnay/rust-toolchain@" .github/workflows`, which returned only the pinned `@1.86` entries; this check succeeded.
- Inspected the diff with `git diff -- .github/workflows/rust.yml .github/workflows/sdk.yaml` to confirm only the action ref lines were changed; this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cba50de0b88327beb751b503e6cf12)