### PR TITLE
vmm: disallow ISO rootfs for image versions >= 0.5.0

### DIFF
--- a/vmm/src/app/qemu.rs
+++ b/vmm/src/app/qemu.rs
@@ -419,6 +419,7 @@ impl VmConfig {
             ]);
         }
         if let Some(rootfs) = &self.image.rootfs {
+            let img_ver = self.image.info.version_tuple().unwrap_or_default();
             let ext = rootfs
                 .extension()
                 .unwrap_or_default()
@@ -426,6 +427,11 @@ impl VmConfig {
                 .unwrap_or_default();
             match ext {
                 "iso" => {
+                    if img_ver >= (0, 5, 0) {
+                        bail!(
+                            "Unsupported rootfs type: {ext}. Image versions >= 0.5.0 must use verity rootfs"
+                        );
+                    }
                     command.arg("-cdrom").arg(rootfs);
                 }
                 "verity" => {


### PR DESCRIPTION
### Motivation
- The new guest `dstack-util` setup path no longer accepts or validates a rootfs hash, which combined with the VMM still permitting `.iso` rootfs attachments allows a host to substitute an unverified rootfs and break the chain-of-trust. 
- Provide a minimal, conservative mitigation in the VMM launch path to prevent modern images from being launched with unverified ISO rootfs files while preserving legacy behavior.

### Description
- Add an image-version check in `vmm/src/app/qemu.rs` that reads `img_ver = self.image.info.version_tuple()` and `bail!`s when the rootfs extension is `"iso"` for images with version `>= (0, 5, 0)` so modern images must use verity-backed rootfs. 
- Leave `.verity` handling unchanged and continue allowing `.iso` for older/legacy image versions to maintain backward compatibility. 
- This is a minimal VMM-side guard that closes the immediate attack vector without reintroducing guest-side hash plumbing.

### Testing
- Ran `cargo check -p dstack-vmm` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cbc2c272d88327a2bda2dcbbd55956)