### PR TITLE
key-provider-build: pin transitive deps for reproducible mr_enclave

### DIFF
--- a/key-provider-build/Dockerfile.key-provider
+++ b/key-provider-build/Dockerfile.key-provider
@@ -3,12 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc5518156b99b147c10a7b83722ac0c38
 
-RUN apt-get update && apt-get install -y \
-    git=1:2.34.1-1ubuntu1.17 \
-    build-essential=12.9ubuntu3 \
-    && rm -rf /var/lib/apt/lists/*
+# Pin Ubuntu apt sources to a fixed snapshot date so transitive dependencies
+# (e.g. libcurl3-gnutls, libc6) don't drift between builds. Without this,
+# Ubuntu point updates to packages pulled in by `build-essential` change the
+# bytes of files referenced by the Gramine manifest's trusted_files list,
+# which changes mr_enclave — breaking any attestation flow that pins to a
+# specific expected value.
+#
+# Each consumer should override APT_SNAPSHOT to the date that matches their
+# expected mr_enclave:
+#
+#   docker build --build-arg APT_SNAPSHOT=YYYYMMDDT000000Z ...
+ARG APT_SNAPSHOT=20260423T000000Z
+RUN { \
+      echo "deb https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT} jammy main universe restricted multiverse"; \
+      echo "deb https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT} jammy-updates main universe restricted multiverse"; \
+      echo "deb https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT} jammy-security main universe restricted multiverse"; \
+    } > /etc/apt/sources.list \
+ && rm -rf /etc/apt/sources.list.d/* \
+ && apt-get update && apt-get install -y \
+      git=1:2.34.1-1ubuntu1.17 \
+      build-essential=12.9ubuntu3 \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.85 -y
+# Pin rustup-init by sha256 instead of `curl https://sh.rustup.rs | sh` so the
+# installer bytes are deterministic. Pin --default-toolchain to the exact patch
+# version (1.85 alone resolves to the latest 1.85.x at install time).
+#
+# To bump RUSTUP_VERSION, fetch the matching sha256 with:
+#   curl -sf https://static.rust-lang.org/rustup/archive/<VERSION>/x86_64-unknown-linux-gnu/rustup-init.sha256
+ARG RUSTUP_VERSION=1.28.2
+ARG RUSTUP_INIT_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+ARG RUST_TOOLCHAIN=1.85.1
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+      "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" \
+      -o /tmp/rustup-init \
+ && echo "${RUSTUP_INIT_SHA256}  /tmp/rustup-init" | sha256sum -c - \
+ && chmod +x /tmp/rustup-init \
+ && /tmp/rustup-init -y --default-toolchain "${RUST_TOOLCHAIN}" \
+ && rm /tmp/rustup-init
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Set environment variables

--- a/key-provider-build/docker-compose.yaml
+++ b/key-provider-build/docker-compose.yaml
@@ -25,13 +25,21 @@ services:
       - "./sgx_default_qcnl.conf:/etc/sgx_default_qcnl.conf"
       - "aesmd:/var/run/aesmd/"
     network_mode: "host"
-  
+
   gramine-sealing-key-provider:
     <<: *common-config
     container_name: gramine-sealing-key-provider
     build:
       context: .
       dockerfile: Dockerfile.key-provider
+      # Defaults reproduce a canonical build; consumers that pin to a specific
+      # mr_enclave (e.g. attestation flows) override these via environment
+      # variables, e.g. `APT_SNAPSHOT=YYYYMMDDT000000Z ./run.sh`.
+      args:
+        APT_SNAPSHOT: ${APT_SNAPSHOT:-20260423T000000Z}
+        RUSTUP_VERSION: ${RUSTUP_VERSION:-1.28.2}
+        RUSTUP_INIT_SHA256: ${RUSTUP_INIT_SHA256:-20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c}
+        RUST_TOOLCHAIN: ${RUST_TOOLCHAIN:-1.85.1}
     privileged: true
     devices:
       - "/dev/sgx_enclave:/dev/sgx_enclave"


### PR DESCRIPTION
## Why

Two independent builds of `Dockerfile.key-provider` from the same commit weeks apart produced different `mr_enclave` values, traced to an unpinned `libcurl3-gnutls` apt update. The current Dockerfile pins gramine, git, build-essential, Rust major-minor, and the upstream source commit, but transitive apt deps, the Rust patch version, and the rustup-init script can all drift between builds.

## What

Parameterize and pin three drift channels via build-args, plumbed through `docker-compose.yaml` so they're overridable as env vars (no file edits needed):

| Build-arg / env | Default | Status |
|---|---|---|
| `APT_SNAPSHOT` | `20260423T000000Z` | **Empirical** — observed `libcurl3-gnutls` shifting `…ubuntu1.23 → …ubuntu1.24` produced a different `mr_enclave` |
| `RUST_TOOLCHAIN` | `1.85.1` | **Defensive** — `1.85` resolves to whatever 1.85.x is current at install time |
| `RUSTUP_VERSION` + `RUSTUP_INIT_SHA256` | `1.28.2` / `20a06e64…` | **Defensive** — replaces live `curl https://sh.rustup.rs \| sh` |

Only `APT_SNAPSHOT` has demonstrated drift today; the other two are forward-looking pins (universally correct, no per-consumer choice baked in).

To override any of these at build time, set the env var(s) before invoking `./run.sh`, e.g. `APT_SNAPSHOT=20260501T000000Z RUST_TOOLCHAIN=1.86.0 ./run.sh`.

The defaults reproduce a known-canonical build but are intentionally unopinionated — feel free to bump them. Each downstream consumer that pins to a specific `mr_enclave` overrides via env vars at build time.

## Verified

- Two clean builds with the same args produce byte-identical enclaves (deterministic).
- The `docker-compose build` path with an env-var override works end-to-end:
  ```
  APT_SNAPSHOT=20260423T000000Z ./run.sh
  ```
- For one example downstream consumer (NEAR's MPC TDX deployment), the default `APT_SNAPSHOT` reproduces their pinned `mr_enclave = 6b5ed02e…`. Other consumers with different canonical dates can override.

## Notes for maintainers

- Three values can be bumped trivially. They're `ARG` lines at the top of each Dockerfile section, also overridable via env vars or `--build-arg`.
- If you bump `RUSTUP_VERSION`, the matching `RUSTUP_INIT_SHA256` is published at:
  ```
  https://static.rust-lang.org/rustup/archive/<VERSION>/x86_64-unknown-linux-gnu/rustup-init.sha256
  ```
- Builds now require `snapshot.ubuntu.com` to be reachable. If that's a problem for any consumer's network, they fork and override `APT_SNAPSHOT` to point at a private mirror via the same env-var mechanism.

## Out of scope

- Adding a `key-provider-build/README.md` documenting the env-var knobs (no README exists today; happy to add as a follow-up if useful).
- Pinning `MoeMahhouk/gramine-sealing-key-provider` to a maintainer-controlled mirror (e.g. under `Dstack-TEE/`, `Phala-Network/`, or a fork) so a future force-push or repo deletion can't break builds. Currently `git clone` of an upstream commit hash.