### PR TITLE
fix: make VMM discovery registration non-fatal

### DIFF
--- a/vmm/src/main.rs
+++ b/vmm/src/main.rs
@@ -19,7 +19,7 @@ use rocket::{
 use rocket_apitoken::ApiToken;
 use rocket_vsock_listener::VsockListener;
 use supervisor_client::SupervisorClient;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 mod app;
 mod config;
@@ -195,15 +195,20 @@ async fn main() -> Result<()> {
             None => endpoint.to_string(),
         }
     };
-    let _discovery_reg = discovery::DiscoveryRegistration::register(
+    let _discovery_reg = match discovery::DiscoveryRegistration::register(
         &listen_address,
         args.config.as_deref(),
         &config.image.path,
         &config.run_path,
         &config.node_name,
         &app_version(),
-    )
-    .context("failed to register VMM instance for discovery")?;
+    ) {
+        Ok(registration) => Some(registration),
+        Err(err) => {
+            warn!("failed to register VMM instance for discovery: {err:#}");
+            None
+        }
+    };
 
     let api_auth = ApiToken::new(config.auth.tokens.clone(), config.auth.enabled);
     let supervisor = {


### PR DESCRIPTION
## Summary
- Make VMM discovery registration best-effort instead of fatal.
- Keep the discovery registration handle alive when registration succeeds, so the registration file is still removed on shutdown.
- Log the full registration error as a warning when discovery setup fails.

## Why
`dstack-vmm` writes a local discovery file under `$XDG_RUNTIME_DIR/dstack-vmm`, falling back to `/run/user/<uid>/dstack-vmm`. This is used by `vmm-cli.py vmm ls` and `vmm-cli.py vmm switch` to discover running VMM instances on the same host.

When `dstack-vmm` runs as a systemd system service with `User=phala`, `/run/user/<uid>` may not exist because it is normally created by `systemd-logind` for login sessions. A service account does not always have a login session, so creating `/run/user/<uid>/dstack-vmm` can fail with `Permission denied`.

Before this change, that discovery failure aborted VMM startup:

```text
failed to register VMM instance for discovery
failed to create discovery directory
permission denied
```

Discovery is only a local CLI convenience feature. It should not prevent the VMM server from starting.

## Result
After this change:
- VMM startup continues even if discovery registration fails.
- Operators still get a warning with the root cause in the logs.
- Local auto-discovery keeps working when the discovery directory is available.
- VM management through explicit `--url`, configured URL, or normal API access is unaffected.

## Test Results
- `cargo fmt --all --check` passed.
- `prek` passed.
- `cargo check -p dstack-vmm` was attempted on macOS and failed in existing `dstack-port-forward` code because `nix::fcntl::splice` is Linux-only.
- `cargo check -p dstack-vmm --target x86_64-unknown-linux-gnu` was attempted and blocked by missing `x86_64-linux-gnu-gcc` cross compiler.

## Test Plan
- [x] Formatting checked
- [x] Pre-commit hooks run
- [x] Build check attempted and environment blocker documented
