### PR TITLE
fix: include VMM QEMU options in MR verification

### DIFF
--- a/dstack-mr/src/acpi.rs
+++ b/dstack-mr/src/acpi.rs
@@ -87,6 +87,20 @@ impl Machine<'_> {
             .context("Failed to get versioned options")?;
         let (acpi_tables_bin, qemu_data_dir) = acpi_tables_tool(vopt.version);
 
+        let tdx_object_arg = match self.qgs_port {
+            Some(port) => serde_json::json!({
+                "qom-type": "tdx-guest",
+                "id": "tdx",
+                "quote-generation-socket": {
+                    "type": "vsock",
+                    "cid": "2",
+                    "port": port.to_string(),
+                },
+            })
+            .to_string(),
+            None => "tdx-guest,id=tdx".to_string(),
+        };
+
         // Prepare the command arguments
         let mut cmd = std::process::Command::new(acpi_tables_bin);
         cmd.args([
@@ -116,9 +130,8 @@ impl Machine<'_> {
             "user,id=net0",
             "-device",
             "virtio-net-pci,netdev=net0",
-            "-object",
-            "tdx-guest,id=tdx",
         ]);
+        cmd.args(["-object", &tdx_object_arg]);
         append_smbios(&mut cmd, &self.smbios);
         cmd.args(["-device", "vhost-vsock-pci,guest-cid=3"]);
 

--- a/dstack-mr/src/acpi.rs
+++ b/dstack-mr/src/acpi.rs
@@ -16,9 +16,15 @@ const FIXED_STRING_LEN: usize = 56;
 
 fn acpi_tables_tool(version: (u32, u32, u32)) -> (&'static str, &'static str) {
     if version < (9, 0, 0) {
-        ("dstack-acpi-tables-8.2.2", "/usr/local/share/qemu-8.2.2")
+        (
+            "/usr/local/bin/dstack-acpi-tables-8.2.2",
+            "/usr/local/share/qemu-8.2.2",
+        )
     } else {
-        ("dstack-acpi-tables-9.2.1", "/usr/local/share/qemu-9.2.1")
+        (
+            "/usr/local/bin/dstack-acpi-tables-9.2.1",
+            "/usr/local/share/qemu-9.2.1",
+        )
     }
 }
 
@@ -237,7 +243,7 @@ impl Machine<'_> {
                 format!("{}.{}.{}", ver.0, ver.1, ver.2),
             )
             .output()
-            .context("failed to execute dstack-acpi-tables")?;
+            .with_context(|| format!("failed to execute {acpi_tables_bin}"))?;
 
         // Check if the command was successful
         if !output.status.success() {
@@ -388,11 +394,17 @@ mod tests {
     fn selects_acpi_tables_tool_by_qemu_major_version() {
         assert_eq!(
             acpi_tables_tool((8, 2, 2)),
-            ("dstack-acpi-tables-8.2.2", "/usr/local/share/qemu-8.2.2")
+            (
+                "/usr/local/bin/dstack-acpi-tables-8.2.2",
+                "/usr/local/share/qemu-8.2.2"
+            )
         );
         assert_eq!(
             acpi_tables_tool((9, 2, 1)),
-            ("dstack-acpi-tables-9.2.1", "/usr/local/share/qemu-9.2.1")
+            (
+                "/usr/local/bin/dstack-acpi-tables-9.2.1",
+                "/usr/local/share/qemu-9.2.1"
+            )
         );
     }
 }

--- a/dstack-mr/src/acpi.rs
+++ b/dstack-mr/src/acpi.rs
@@ -14,6 +14,14 @@ use crate::{Machine, SmbiosConfig};
 const LDR_LENGTH: usize = 4096;
 const FIXED_STRING_LEN: usize = 56;
 
+fn acpi_tables_tool(version: (u32, u32, u32)) -> (&'static str, &'static str) {
+    if version < (9, 0, 0) {
+        ("dstack-acpi-tables-8.2.2", "/usr/local/share/qemu-8.2.2")
+    } else {
+        ("dstack-acpi-tables-9.2.1", "/usr/local/share/qemu-9.2.1")
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Tables {
     pub tables: Vec<u8>,
@@ -68,9 +76,16 @@ impl Machine<'_> {
         let dummy_disk = "/bin/sh";
         let shared_dir = "/bin";
 
+        let vopt = self
+            .versioned_options()
+            .context("Failed to get versioned options")?;
+        let (acpi_tables_bin, qemu_data_dir) = acpi_tables_tool(vopt.version);
+
         // Prepare the command arguments
-        let mut cmd = std::process::Command::new("dstack-acpi-tables");
+        let mut cmd = std::process::Command::new(acpi_tables_bin);
         cmd.args([
+            "-L",
+            qemu_data_dir,
             "-cpu",
             "qemu64",
             "-smp",
@@ -150,10 +165,6 @@ impl Machine<'_> {
         } else {
             machine.push_str(",smm=off");
         }
-
-        let vopt = self
-            .versioned_options()
-            .context("Failed to get versioned options")?;
 
         if vopt.pic {
             machine.push_str(",pic=on");
@@ -366,6 +377,23 @@ impl Machine<'_> {
             rsdp,
             loader: ldr.buffer,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::acpi_tables_tool;
+
+    #[test]
+    fn selects_acpi_tables_tool_by_qemu_major_version() {
+        assert_eq!(
+            acpi_tables_tool((8, 2, 2)),
+            ("dstack-acpi-tables-8.2.2", "/usr/local/share/qemu-8.2.2")
+        );
+        assert_eq!(
+            acpi_tables_tool((9, 2, 1)),
+            ("dstack-acpi-tables-9.2.1", "/usr/local/share/qemu-9.2.1")
+        );
     }
 }
 

--- a/dstack-mr/src/acpi.rs
+++ b/dstack-mr/src/acpi.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Result};
 use log::debug;
 use scale::Decode;
 
-use crate::Machine;
+use crate::{Machine, SmbiosConfig};
 
 const LDR_LENGTH: usize = 4096;
 const FIXED_STRING_LEN: usize = 56;
@@ -19,6 +19,42 @@ pub struct Tables {
     pub tables: Vec<u8>,
     pub rsdp: Vec<u8>,
     pub loader: Vec<u8>,
+}
+
+fn cfg_if(ty: &mut Vec<String>, name: &str, v: &Option<String>) {
+    if let Some(v) = v {
+        ty.push(format!("{name}={v}"));
+    }
+}
+
+fn append_smbios(cmd: &mut std::process::Command, smbios: &SmbiosConfig) {
+    let mut types: [Vec<String>; 4] = Default::default();
+    cfg_if(&mut types[0], "vendor", &smbios.bios_vendor);
+    cfg_if(&mut types[0], "version", &smbios.bios_version);
+    cfg_if(&mut types[0], "date", &smbios.bios_date);
+    cfg_if(&mut types[0], "release", &smbios.bios_release);
+    cfg_if(&mut types[1], "manufacturer", &smbios.sys_vendor);
+    cfg_if(&mut types[1], "product", &smbios.product_name);
+    cfg_if(&mut types[1], "version", &smbios.product_version);
+    cfg_if(&mut types[1], "serial", &smbios.product_serial);
+    cfg_if(&mut types[1], "uuid", &smbios.product_uuid);
+    cfg_if(&mut types[1], "family", &smbios.product_family);
+    cfg_if(&mut types[1], "sku", &smbios.product_sku);
+    cfg_if(&mut types[2], "manufacturer", &smbios.board_vendor);
+    cfg_if(&mut types[2], "product", &smbios.board_name);
+    cfg_if(&mut types[2], "version", &smbios.board_version);
+    cfg_if(&mut types[2], "serial", &smbios.board_serial);
+    cfg_if(&mut types[2], "asset", &smbios.board_asset_tag);
+    cfg_if(&mut types[3], "manufacturer", &smbios.chassis_vendor);
+    cfg_if(&mut types[3], "version", &smbios.chassis_version);
+    cfg_if(&mut types[3], "serial", &smbios.chassis_serial);
+    cfg_if(&mut types[3], "asset", &smbios.chassis_asset_tag);
+
+    for (i, t) in types.iter().enumerate() {
+        if !t.is_empty() {
+            cmd.arg("-smbios").arg(format!("type={i},{}", t.join(",")));
+        }
+    }
 }
 
 impl Machine<'_> {
@@ -61,18 +97,24 @@ impl Machine<'_> {
             "virtio-net-pci,netdev=net0",
             "-object",
             "tdx-guest,id=tdx",
-            "-device",
-            "vhost-vsock-pci,guest-cid=3",
         ]);
+        append_smbios(&mut cmd, &self.smbios);
+        cmd.args(["-device", "vhost-vsock-pci,guest-cid=3"]);
 
         // Configure shared files delivery: either via disk or 9p
         match self.host_share_mode.as_str() {
             "" | "9p" => {
                 // Use 9p virtfs (default)
+                let security_model = self.virtfs_security_model.as_str();
+                let security_model = if security_model.is_empty() {
+                    "none"
+                } else {
+                    security_model
+                };
                 cmd.args([
                 "-virtfs",
                 &format!(
-                    "local,path={shared_dir},mount_tag=host-shared,readonly=on,security_model=none,id=virtfs0",
+                    "local,path={shared_dir},mount_tag=host-shared,readonly=on,security_model={security_model},id=virtfs0",
                 ),
             ]);
             }

--- a/dstack-mr/src/lib.rs
+++ b/dstack-mr/src/lib.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
 
-pub use machine::{Machine, TdxMeasurementDetails};
+pub use machine::{Machine, SmbiosConfig, TdxMeasurementDetails};
 
 use util::{measure_log, measure_sha384, utf16_encode};
 

--- a/dstack-mr/src/machine.rs
+++ b/dstack-mr/src/machine.rs
@@ -11,6 +11,30 @@ use anyhow::{bail, Context, Result};
 use fs_err as fs;
 use log::debug;
 
+#[derive(Debug, Clone, Default)]
+pub struct SmbiosConfig {
+    pub bios_vendor: Option<String>,
+    pub bios_version: Option<String>,
+    pub bios_date: Option<String>,
+    pub bios_release: Option<String>,
+    pub sys_vendor: Option<String>,
+    pub product_name: Option<String>,
+    pub product_version: Option<String>,
+    pub product_serial: Option<String>,
+    pub product_uuid: Option<String>,
+    pub product_family: Option<String>,
+    pub product_sku: Option<String>,
+    pub board_vendor: Option<String>,
+    pub board_name: Option<String>,
+    pub board_version: Option<String>,
+    pub board_serial: Option<String>,
+    pub board_asset_tag: Option<String>,
+    pub chassis_vendor: Option<String>,
+    pub chassis_version: Option<String>,
+    pub chassis_serial: Option<String>,
+    pub chassis_asset_tag: Option<String>,
+}
+
 #[derive(Debug, bon::Builder)]
 pub struct Machine<'a> {
     pub cpu_count: u32,
@@ -32,6 +56,10 @@ pub struct Machine<'a> {
     pub root_verity: bool,
     #[builder(default)]
     pub host_share_mode: String,
+    #[builder(default)]
+    pub smbios: SmbiosConfig,
+    #[builder(default)]
+    pub virtfs_security_model: String,
 }
 
 fn parse_version_tuple(v: &str) -> Result<(u32, u32, u32)> {

--- a/dstack-mr/src/machine.rs
+++ b/dstack-mr/src/machine.rs
@@ -60,6 +60,7 @@ pub struct Machine<'a> {
     pub smbios: SmbiosConfig,
     #[builder(default)]
     pub virtfs_security_model: String,
+    pub qgs_port: Option<u32>,
 }
 
 fn parse_version_tuple(v: &str) -> Result<(u32, u32, u32)> {

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -196,6 +196,42 @@ pub struct VmConfig {
     /// If false (default), shared files are provided via 9p virtfs
     #[serde(default)]
     pub host_share_mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qgs_port: Option<u32>,
+    #[serde(default, skip_serializing_if = "SmbiosConfig::is_empty")]
+    pub product: SmbiosConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtfs_security_model: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct SmbiosConfig {
+    pub bios_vendor: Option<String>,
+    pub bios_version: Option<String>,
+    pub bios_date: Option<String>,
+    pub bios_release: Option<String>,
+    pub sys_vendor: Option<String>,
+    pub product_name: Option<String>,
+    pub product_version: Option<String>,
+    pub product_serial: Option<String>,
+    pub product_uuid: Option<String>,
+    pub product_family: Option<String>,
+    pub product_sku: Option<String>,
+    pub board_vendor: Option<String>,
+    pub board_name: Option<String>,
+    pub board_version: Option<String>,
+    pub board_serial: Option<String>,
+    pub board_asset_tag: Option<String>,
+    pub chassis_vendor: Option<String>,
+    pub chassis_version: Option<String>,
+    pub chassis_serial: Option<String>,
+    pub chassis_asset_tag: Option<String>,
+}
+
+impl SmbiosConfig {
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/kms/dstack-app/builder/Dockerfile
+++ b/kms/dstack-app/builder/Dockerfile
@@ -82,7 +82,7 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack
     ln -sfn qemu-9.2.1 /usr/local/share/qemu && \
     cd .. && rm -rf qemu-tdx-9
 
-FROM acpi-builder-9
+FROM acpi-builder-9 AS acpi-builder
 COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
 COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
 RUN test -x /usr/local/bin/dstack-acpi-tables-8.2.2 && \

--- a/kms/dstack-app/builder/Dockerfile
+++ b/kms/dstack-app/builder/Dockerfile
@@ -26,12 +26,10 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN cd dstack && cargo build --release -p dstack-kms --target x86_64-unknown-linux-musl
 RUN echo "${DSTACK_REV}" > /build/.GIT_REV
 
-FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe
+FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS acpi-builder-base
 COPY --from=build-shared /pin-packages.sh /config-qemu.sh /build/
 COPY ./shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
-ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -47,6 +45,9 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
+
+FROM acpi-builder-base AS acpi-builder-8
+ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
 RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
     cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
     git checkout ${QEMU_8_REV} && \
@@ -61,6 +62,9 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passth
     install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-8.2.2/ && \
     install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-8.2.2/ && \
     cd .. && rm -rf qemu-tdx-8
+
+FROM acpi-builder-base AS acpi-builder-9
+ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch qemu-tdx-9 && \
     cd qemu-tdx-9 && git fetch --depth 1 origin ${QEMU_9_REV} && \
     git checkout ${QEMU_9_REV} && \
@@ -77,6 +81,10 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack
     install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-9.2.1/ && \
     ln -sfn qemu-9.2.1 /usr/local/share/qemu && \
     cd .. && rm -rf qemu-tdx-9
+
+FROM acpi-builder-9
+COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
+COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
 COPY --from=kms-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-kms /usr/local/bin/dstack-kms
 COPY --from=kms-builder /build/.GIT_REV /etc/
 CMD ["dstack-kms"]

--- a/kms/dstack-app/builder/Dockerfile
+++ b/kms/dstack-app/builder/Dockerfile
@@ -47,8 +47,8 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 
 FROM acpi-builder-base AS acpi-builder-8
-ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
+ARG QEMU_8_REV=8a609a153956e35d756269b742e5299dcb7788be
+RUN git clone https://github.com/Leechael/qemu-tdx.git --depth 1 --branch dstack-qemu-8.2.2-qgs --single-branch qemu-tdx-8 && \
     cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
     git checkout ${QEMU_8_REV} && \
     ../config-qemu.sh ./build /usr/local && \

--- a/kms/dstack-app/builder/Dockerfile
+++ b/kms/dstack-app/builder/Dockerfile
@@ -85,6 +85,9 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack
 FROM acpi-builder-9
 COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
 COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
+RUN test -x /usr/local/bin/dstack-acpi-tables-8.2.2 && \
+    test -x /usr/local/bin/dstack-acpi-tables-9.2.1 && \
+    test -x /usr/local/bin/dstack-acpi-tables
 COPY --from=kms-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-kms /usr/local/bin/dstack-kms
 COPY --from=kms-builder /build/.GIT_REV /etc/
 CMD ["dstack-kms"]

--- a/kms/dstack-app/builder/Dockerfile
+++ b/kms/dstack-app/builder/Dockerfile
@@ -30,7 +30,8 @@ FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1
 COPY --from=build-shared /pin-packages.sh /config-qemu.sh /build/
 COPY ./shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
+ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
+ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -46,20 +47,36 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch && \
-    cd qemu-tdx && git fetch --depth 1 origin ${QEMU_REV} && \
-    git checkout ${QEMU_REV} && \
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
+    cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
+    git checkout ${QEMU_8_REV} && \
     ../config-qemu.sh ./build /usr/local && \
     cd build && \
     ninja && \
     strip qemu-system-x86_64 && \
-    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables && \
+    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables-8.2.2 && \
     cd ../ && \
-    install -d /usr/local/share/qemu && \
-    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu/ && \
-    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu/ && \
-    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu/ && \
-    cd .. && rm -rf qemu-tdx
+    install -d /usr/local/share/qemu-8.2.2 && \
+    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu-8.2.2/ && \
+    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-8.2.2/ && \
+    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-8.2.2/ && \
+    cd .. && rm -rf qemu-tdx-8
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch qemu-tdx-9 && \
+    cd qemu-tdx-9 && git fetch --depth 1 origin ${QEMU_9_REV} && \
+    git checkout ${QEMU_9_REV} && \
+    ../config-qemu.sh ./build /usr/local && \
+    cd build && \
+    ninja && \
+    strip qemu-system-x86_64 && \
+    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables-9.2.1 && \
+    ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables && \
+    cd ../ && \
+    install -d /usr/local/share/qemu-9.2.1 && \
+    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu-9.2.1/ && \
+    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-9.2.1/ && \
+    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-9.2.1/ && \
+    ln -sfn qemu-9.2.1 /usr/local/share/qemu && \
+    cd .. && rm -rf qemu-tdx-9
 COPY --from=kms-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-kms /usr/local/bin/dstack-kms
 COPY --from=kms-builder /build/.GIT_REV /etc/
 CMD ["dstack-kms"]

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -86,6 +86,13 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack
     ln -sfn qemu-9.2.1 /usr/local/share/qemu && \
     cd .. && rm -rf qemu-tdx-9
 
+FROM acpi-builder-9 AS acpi-builder
+COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
+COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
+RUN test -x /usr/local/bin/dstack-acpi-tables-8.2.2 && \
+    test -x /usr/local/bin/dstack-acpi-tables-9.2.1 && \
+    test -x /usr/local/bin/dstack-acpi-tables
+
 FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe
 COPY --from=build-shared pin-packages.sh /build/
 COPY builder/shared/pinned-packages.txt /build/
@@ -101,11 +108,11 @@ RUN ./pin-packages.sh ./pinned-packages.txt && \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY --from=verifier-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-verifier /usr/local/bin/dstack-verifier
 COPY --from=verifier-builder /build/.GIT_REV /etc/
-COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
-COPY --from=acpi-builder-9 /usr/local/bin/dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables-9.2.1
+COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
+COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables-9.2.1
 RUN ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables
-COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
-COPY --from=acpi-builder-9 /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
+COPY --from=acpi-builder /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
+COPY --from=acpi-builder /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
 RUN ln -sfn qemu-9.2.1 /usr/local/share/qemu
 RUN test -x /usr/local/bin/dstack-acpi-tables-8.2.2 && \
     test -x /usr/local/bin/dstack-acpi-tables-9.2.1 && \

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -51,8 +51,8 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 
 FROM acpi-builder-base AS acpi-builder-8
-ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
+ARG QEMU_8_REV=8a609a153956e35d756269b742e5299dcb7788be
+RUN git clone https://github.com/Leechael/qemu-tdx.git --depth 1 --branch dstack-qemu-8.2.2-qgs --single-branch qemu-tdx-8 && \
     cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
     git checkout ${QEMU_8_REV} && \
     ../config-qemu.sh ./build /usr/local && \

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -106,6 +106,9 @@ RUN ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables
 COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
 COPY --from=acpi-builder-9 /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
 RUN ln -sfn qemu-9.2.1 /usr/local/share/qemu
+RUN test -x /usr/local/bin/dstack-acpi-tables-8.2.2 && \
+    test -x /usr/local/bin/dstack-acpi-tables-9.2.1 && \
+    test -x /usr/local/bin/dstack-acpi-tables
 RUN mkdir -p /etc/dstack
 COPY dstack-verifier.toml /etc/dstack/dstack-verifier.toml
 WORKDIR /var/lib/dstack-verifier

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -34,7 +34,8 @@ FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1
 COPY --from=build-shared pin-packages.sh config-qemu.sh /build/
 COPY builder/shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
+ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
+ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -50,20 +51,36 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch && \
-    cd qemu-tdx && git fetch --depth 1 origin ${QEMU_REV} && \
-    git checkout ${QEMU_REV} && \
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
+    cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
+    git checkout ${QEMU_8_REV} && \
     ../config-qemu.sh ./build /usr/local && \
     cd build && \
     ninja && \
     strip qemu-system-x86_64 && \
-    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables && \
+    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables-8.2.2 && \
     cd ../ && \
-    install -d /usr/local/share/qemu && \
-    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu/ && \
-    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu/ && \
-    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu/ && \
-    cd .. && rm -rf qemu-tdx
+    install -d /usr/local/share/qemu-8.2.2 && \
+    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu-8.2.2/ && \
+    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-8.2.2/ && \
+    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-8.2.2/ && \
+    cd .. && rm -rf qemu-tdx-8
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch qemu-tdx-9 && \
+    cd qemu-tdx-9 && git fetch --depth 1 origin ${QEMU_9_REV} && \
+    git checkout ${QEMU_9_REV} && \
+    ../config-qemu.sh ./build /usr/local && \
+    cd build && \
+    ninja && \
+    strip qemu-system-x86_64 && \
+    install -m 755 qemu-system-x86_64 /usr/local/bin/dstack-acpi-tables-9.2.1 && \
+    ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables && \
+    cd ../ && \
+    install -d /usr/local/share/qemu-9.2.1 && \
+    install -m 644 pc-bios/efi-virtio.rom /usr/local/share/qemu-9.2.1/ && \
+    install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-9.2.1/ && \
+    install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-9.2.1/ && \
+    ln -sfn qemu-9.2.1 /usr/local/share/qemu && \
+    cd .. && rm -rf qemu-tdx-9
 
 FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe
 COPY --from=build-shared pin-packages.sh /build/
@@ -79,8 +96,12 @@ RUN ./pin-packages.sh ./pinned-packages.txt && \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY --from=verifier-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-verifier /usr/local/bin/dstack-verifier
 COPY --from=verifier-builder /build/.GIT_REV /etc/
-COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables /usr/local/bin/dstack-acpi-tables
-COPY --from=acpi-builder /usr/local/share/qemu /usr/local/share/qemu
+COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
+COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables-9.2.1
+RUN ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables
+COPY --from=acpi-builder /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
+COPY --from=acpi-builder /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
+RUN ln -sfn qemu-9.2.1 /usr/local/share/qemu
 RUN mkdir -p /etc/dstack
 COPY dstack-verifier.toml /etc/dstack/dstack-verifier.toml
 WORKDIR /var/lib/dstack-verifier

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -30,12 +30,10 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN cd dstack && cargo build --release -p dstack-verifier --target x86_64-unknown-linux-musl
 RUN echo "${DSTACK_REV}" > /build/.GIT_REV
 
-FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS acpi-builder
+FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS acpi-builder-base
 COPY --from=build-shared pin-packages.sh config-qemu.sh /build/
 COPY builder/shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
-ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -51,6 +49,9 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
+
+FROM acpi-builder-base AS acpi-builder-8
+ARG QEMU_8_REV=d98440811192c08eafc07c7af110593c6b3758ff
 RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passthrough-dump-acpi --single-branch qemu-tdx-8 && \
     cd qemu-tdx-8 && git fetch --depth 1 origin ${QEMU_8_REV} && \
     git checkout ${QEMU_8_REV} && \
@@ -65,6 +66,9 @@ RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch passth
     install -m 644 pc-bios/kvmvapic.bin /usr/local/share/qemu-8.2.2/ && \
     install -m 644 pc-bios/linuxboot_dma.bin /usr/local/share/qemu-8.2.2/ && \
     cd .. && rm -rf qemu-tdx-8
+
+FROM acpi-builder-base AS acpi-builder-9
+ARG QEMU_9_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
 RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch qemu-tdx-9 && \
     cd qemu-tdx-9 && git fetch --depth 1 origin ${QEMU_9_REV} && \
     git checkout ${QEMU_9_REV} && \
@@ -96,11 +100,11 @@ RUN ./pin-packages.sh ./pinned-packages.txt && \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY --from=verifier-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-verifier /usr/local/bin/dstack-verifier
 COPY --from=verifier-builder /build/.GIT_REV /etc/
-COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
-COPY --from=acpi-builder /usr/local/bin/dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables-9.2.1
+COPY --from=acpi-builder-8 /usr/local/bin/dstack-acpi-tables-8.2.2 /usr/local/bin/dstack-acpi-tables-8.2.2
+COPY --from=acpi-builder-9 /usr/local/bin/dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables-9.2.1
 RUN ln -sf dstack-acpi-tables-9.2.1 /usr/local/bin/dstack-acpi-tables
-COPY --from=acpi-builder /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
-COPY --from=acpi-builder /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
+COPY --from=acpi-builder-8 /usr/local/share/qemu-8.2.2 /usr/local/share/qemu-8.2.2
+COPY --from=acpi-builder-9 /usr/local/share/qemu-9.2.1 /usr/local/share/qemu-9.2.1
 RUN ln -sfn qemu-9.2.1 /usr/local/share/qemu
 RUN mkdir -p /etc/dstack
 COPY dstack-verifier.toml /etc/dstack/dstack-verifier.toml

--- a/verifier/builder/Dockerfile
+++ b/verifier/builder/Dockerfile
@@ -96,6 +96,7 @@ RUN ./pin-packages.sh ./pinned-packages.txt && \
     ca-certificates \
     curl \
     libglib2.0-0 \
+    libpixman-1-0 \
     libslirp0 \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY --from=verifier-builder /build/dstack/target/x86_64-unknown-linux-musl/release/dstack-verifier /usr/local/bin/dstack-verifier

--- a/verifier/builder/shared/pinned-packages.txt
+++ b/verifier/builder/shared/pinned-packages.txt
@@ -67,6 +67,7 @@ libpam-runtime=1.5.2-6+deb12u1
 libpam0g:amd64=1.5.2-6+deb12u1
 libpcre2-8-0:amd64=10.42-1
 libpsl5:amd64=0.21.2-1
+libpixman-1-0:amd64=0.42.2-1
 librtmp1:amd64=2.4+20151223.gitfa8646d.1-2+b2
 libsasl2-2:amd64=2.1.28+dfsg-10
 libsasl2-modules-db:amd64=2.1.28+dfsg-10

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -271,6 +271,13 @@ impl CvmVerifier {
             .num_gpus(vm_config.num_gpus)
             .num_nvswitches(vm_config.num_nvswitches)
             .host_share_mode(vm_config.host_share_mode.clone())
+            .smbios(smbios_config(&vm_config.product))
+            .virtfs_security_model(
+                vm_config
+                    .virtfs_security_model
+                    .clone()
+                    .unwrap_or_else(|| "none".to_string()),
+            )
             .build()
             .measure_with_logs()
             .context("Failed to compute expected MRs")?;
@@ -746,6 +753,31 @@ impl CvmVerifier {
         fs_err::rename(extracted_dir, dst_dir)
             .context("Failed to move extracted files to destination directory")?;
         Ok(())
+    }
+}
+
+fn smbios_config(product: &dstack_types::SmbiosConfig) -> dstack_mr::SmbiosConfig {
+    dstack_mr::SmbiosConfig {
+        bios_vendor: product.bios_vendor.clone(),
+        bios_version: product.bios_version.clone(),
+        bios_date: product.bios_date.clone(),
+        bios_release: product.bios_release.clone(),
+        sys_vendor: product.sys_vendor.clone(),
+        product_name: product.product_name.clone(),
+        product_version: product.product_version.clone(),
+        product_serial: product.product_serial.clone(),
+        product_uuid: product.product_uuid.clone(),
+        product_family: product.product_family.clone(),
+        product_sku: product.product_sku.clone(),
+        board_vendor: product.board_vendor.clone(),
+        board_name: product.board_name.clone(),
+        board_version: product.board_version.clone(),
+        board_serial: product.board_serial.clone(),
+        board_asset_tag: product.board_asset_tag.clone(),
+        chassis_vendor: product.chassis_vendor.clone(),
+        chassis_version: product.chassis_version.clone(),
+        chassis_serial: product.chassis_serial.clone(),
+        chassis_asset_tag: product.chassis_asset_tag.clone(),
     }
 }
 

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -278,6 +278,7 @@ impl CvmVerifier {
                     .clone()
                     .unwrap_or_else(|| "none".to_string()),
             )
+            .maybe_qgs_port(vm_config.qgs_port)
             .build()
             .measure_with_logs()
             .context("Failed to compute expected MRs")?;

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -758,13 +758,20 @@ impl CvmVerifier {
 }
 
 fn smbios_config(product: &dstack_types::SmbiosConfig) -> dstack_mr::SmbiosConfig {
+    let default_type1 = product.is_empty();
     dstack_mr::SmbiosConfig {
         bios_vendor: product.bios_vendor.clone(),
         bios_version: product.bios_version.clone(),
         bios_date: product.bios_date.clone(),
         bios_release: product.bios_release.clone(),
-        sys_vendor: product.sys_vendor.clone(),
-        product_name: product.product_name.clone(),
+        sys_vendor: product
+            .sys_vendor
+            .clone()
+            .or_else(|| default_type1.then(|| "dstack".to_string())),
+        product_name: product
+            .product_name
+            .clone()
+            .or_else(|| default_type1.then(|| "dstack".to_string())),
         product_version: product.product_version.clone(),
         product_serial: product.product_serial.clone(),
         product_uuid: product.product_uuid.clone(),

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -1186,12 +1186,40 @@ fn make_vm_config(cfg: &Config, manifest: &Manifest, image: &Image) -> Result<se
         num_gpus: gpus.gpus.len() as u32,
         num_nvswitches: gpus.bridges.len() as u32,
         host_share_mode: cfg.cvm.host_share_mode.clone(),
+        qgs_port: cfg.cvm.qgs_port,
+        product: product_config(&cfg.cvm.product),
+        virtfs_security_model: Some("none".to_string()),
         hotplug_off: cfg.cvm.qemu_hotplug_off,
         image: Some(manifest.image.clone()),
     })?;
     // For backward compatibility
     config["spec_version"] = serde_json::Value::from(1);
     Ok(config)
+}
+
+fn product_config(product: &crate::config::ProductConfig) -> dstack_types::SmbiosConfig {
+    dstack_types::SmbiosConfig {
+        bios_vendor: product.bios_vendor.clone(),
+        bios_version: product.bios_version.clone(),
+        bios_date: product.bios_date.clone(),
+        bios_release: product.bios_release.clone(),
+        sys_vendor: product.sys_vendor.clone(),
+        product_name: product.product_name.clone(),
+        product_version: product.product_version.clone(),
+        product_serial: product.product_serial.clone(),
+        product_uuid: product.product_uuid.clone(),
+        product_family: product.product_family.clone(),
+        product_sku: product.product_sku.clone(),
+        board_vendor: product.board_vendor.clone(),
+        board_name: product.board_name.clone(),
+        board_version: product.board_version.clone(),
+        board_serial: product.board_serial.clone(),
+        board_asset_tag: product.board_asset_tag.clone(),
+        chassis_vendor: product.chassis_vendor.clone(),
+        chassis_version: product.chassis_version.clone(),
+        chassis_serial: product.chassis_serial.clone(),
+        chassis_asset_tag: product.chassis_asset_tag.clone(),
+    }
 }
 
 fn paginate<T>(items: Vec<T>, page: u32, page_size: u32) -> impl Iterator<Item = T> {

--- a/vmm/src/app/qemu.rs
+++ b/vmm/src/app/qemu.rs
@@ -567,7 +567,7 @@ impl VmConfig {
                     "off"
                 };
                 command.arg("-virtfs").arg(format!(
-                    "local,path={},mount_tag=host-shared,readonly={ro},security_model=mapped,id=virtfs0",
+                    "local,path={},mount_tag=host-shared,readonly={ro},security_model=none,id=virtfs0",
                     shared_dir.display(),
                 ));
             }

--- a/vmm/src/app/qemu.rs
+++ b/vmm/src/app/qemu.rs
@@ -791,9 +791,12 @@ impl VmConfig {
             return Ok(());
         }
 
-        command
-            .arg("-machine")
-            .arg("q35,kernel-irqchip=split,confidential-guest-support=tdx,hpet=off");
+        let mut machine =
+            "q35,kernel-irqchip=split,confidential-guest-support=tdx,hpet=off".to_string();
+        if let Some(pic) = cfg.qemu_pic {
+            machine.push_str(if pic { ",pic=on" } else { ",pic=off" });
+        }
+        command.arg("-machine").arg(machine);
 
         let img_ver = self.image.info.version_tuple().unwrap_or_default();
         let support_mr_config_id = img_ver >= (0, 5, 2);


### PR DESCRIPTION
## Summary

This aligns KMS/verifier MR calculation with the QEMU shape used by the VMM.

Changes:
- Extend `dstack_types::VmConfig` with `qgs_port`, SMBIOS product fields, and `virtfs_security_model`.
- Have VMM write those fields into `.sys-config.json` / `vm_config`.
- Have verifier pass SMBIOS and 9p security-model fields into `dstack-mr`.
- Have `dstack-mr` include `-smbios` and configurable 9p `security_model` in its ACPI-table QEMU invocation.
- Change VMM 9p virtfs from `security_model=mapped` to `security_model=none`.
- Build both historical ACPI-dump QEMU binaries into KMS/verifier images, using separate builder stages so BuildKit can build them in parallel:
  - `passthrough-dump-acpi @ d98440811192c08eafc07c7af110593c6b3758ff` as `dstack-acpi-tables-8.2.2`
  - `dstack-qemu-9.2.1 @ dbcec07c0854bf873d346a09e87e4c993ccf2633` as `dstack-acpi-tables-9.2.1`
- Select the ACPI-dump QEMU binary by `vm_config.qemu_version`:
  - `< 9.0.0` -> `dstack-acpi-tables-8.2.2`
  - `>= 9.0.0` -> `dstack-acpi-tables-9.2.1`
- Use matching QEMU data directories through `-L`:
  - `/usr/local/share/qemu-8.2.2`
  - `/usr/local/share/qemu-9.2.1`
- Include verifier runtime dependencies for the copied QEMU binaries, including `libpixman-1-0`.

## Context

Runtime VMM hosts can use QEMU 8.2.2 while KMS/verifier had only the 9.2.1-derived `dstack-acpi-tables`. That makes expected MR calculation depend on the wrong ACPI-dump QEMU for 8.x hosts.

This PR keeps `qgs_port = 4050` enabled. Disabling QGS is not a valid fix because it changes the runtime VM behavior.

OS image `0.5.10` updates OVMF to `edk2-stable202505`; with the newer TDVF/OVMF, the existing mismatch between real VMM QEMU and verifier-side ACPI-dump QEMU can surface as MRTD/RTMR0 mismatch during KMS onboarding.

## Verification

- `cargo test -p dstack-mr acpi::tests`
- `cargo check -p dstack-mr -p dstack-verifier -p dstack-kms`
- `git diff --check`
- `docker buildx build --call=targets -f verifier/builder/Dockerfile --build-context build-shared=build/shared verifier`
- `docker buildx build --call=targets -f kms/dstack-app/builder/Dockerfile --build-context build-shared=build/shared kms/dstack-app/builder`

Note: `cargo check -p dstack-vmm` on macOS still hits the existing Linux-only `nix::fcntl::splice` gate in `port-forward`. Cross-checking `dstack-vmm` for `x86_64-unknown-linux-gnu` was blocked locally by missing `x86_64-linux-gnu-gcc` for `ring`.
