### PR TITLE
dstack-mr: support edk2-stable202505 OVMF event layout

### DIFF
--- a/dstack-mr/Cargo.toml
+++ b/dstack-mr/Cargo.toml
@@ -25,9 +25,9 @@ fs-err.workspace = true
 bon.workspace = true
 log.workspace = true
 scale.workspace = true
+dstack-types.workspace = true
 
 [dev-dependencies]
-dstack-types.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 flate2.workspace = true
 tar.workspace = true

--- a/dstack-mr/cli/src/main.rs
+++ b/dstack-mr/cli/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
             let firmware_path = parent_dir.join(&image_info.bios).display().to_string();
             let kernel_path = parent_dir.join(&image_info.kernel).display().to_string();
             let initrd_path = parent_dir.join(&image_info.initrd).display().to_string();
-            let cmdline = image_info.cmdline.clone() + " initrd=initrd";
+            let cmdline = image_info.cmdline + " initrd=initrd";
 
             // CLI flag wins, then the explicit `ovmf_variant` in metadata.json,
             // and finally the OS version field. Older metadata.json files may

--- a/dstack-mr/cli/src/main.rs
+++ b/dstack-mr/cli/src/main.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use dstack_mr::Machine;
+use dstack_mr::{Machine, OvmfVariant, ovmf_variant_for_version};
 use dstack_types::ImageInfo;
 use fs_err as fs;
 use size_parser::parse_memory_size;
@@ -78,6 +78,12 @@ struct MachineConfig {
     #[arg(long)]
     qemu_version: Option<String>,
 
+    /// dstack OS version (MAJOR.MINOR.PATCH), used to pick the OVMF measurement layout.
+    /// 0.5.10 <= ver < 0.6.0 and ver >= 0.6.1 use the edk2-stable202505 layout; everything
+    /// else uses the legacy layout. If omitted, falls back to `image_info.version`.
+    #[arg(long)]
+    dstack_os_version: Option<String>,
+
     /// Output JSON
     #[arg(long)]
     json: bool,
@@ -97,7 +103,22 @@ fn main() -> Result<()> {
             let firmware_path = parent_dir.join(&image_info.bios).display().to_string();
             let kernel_path = parent_dir.join(&image_info.kernel).display().to_string();
             let initrd_path = parent_dir.join(&image_info.initrd).display().to_string();
-            let cmdline = image_info.cmdline + " initrd=initrd";
+            let cmdline = image_info.cmdline.clone() + " initrd=initrd";
+
+            // CLI flag wins, then the explicit `ovmf_variant` in metadata.json,
+            // and finally the OS version field. Older metadata.json files may
+            // carry neither, in which case fall back to the default.
+            let ovmf_variant = if let Some(v) = config.dstack_os_version.as_deref() {
+                ovmf_variant_for_version(v)
+                    .with_context(|| format!("invalid dstack OS version: {v}"))?
+            } else if let Some(variant) = image_info.ovmf_variant {
+                variant
+            } else if !image_info.version.is_empty() {
+                ovmf_variant_for_version(&image_info.version)
+                    .with_context(|| format!("invalid dstack OS version: {}", image_info.version))?
+            } else {
+                OvmfVariant::default()
+            };
 
             let machine = Machine::builder()
                 .cpu_count(config.cpu)
@@ -116,6 +137,7 @@ fn main() -> Result<()> {
                 .hotplug_off(config.hotplug_off)
                 .root_verity(config.root_verity)
                 .maybe_qemu_version(config.qemu_version.clone())
+                .ovmf_variant(ovmf_variant)
                 .build();
 
             let measurements = machine

--- a/dstack-mr/src/lib.rs
+++ b/dstack-mr/src/lib.rs
@@ -45,23 +45,34 @@ pub fn ovmf_variant_for_version(version: &str) -> Result<OvmfVariant> {
     })
 }
 
-/// Extract a dotted version suffix (e.g. "0.5.10") from a dstack image name like
-/// `dstack-0.5.10`, `dstack-dev-0.5.10`, or `dstack-nvidia-0.5.10`.
+/// Extract the `MAJOR.MINOR.PATCH` version suffix from a dstack image name.
 ///
-/// Returns `None` when the image name does not end with a recognisable
-/// `MAJOR.MINOR.PATCH` segment.
+/// Recognises any `<prefix>-MAJOR.MINOR.PATCH[.SUFFIX]` shape, e.g.
+/// `dstack-0.5.10`, `dstack-dev-0.5.10`, `dstack-nvidia-0.5.10`,
+/// `dstack-nvidia-dev-0.5.10`, `dstack-0.5.10.rc1`, `dstack-dev-0.6.1.dev`.
+///
+/// The optional `.SUFFIX` is permitted to be non-numeric (pre-release tag,
+/// build label, etc.) and is dropped from the returned slice — only the
+/// numeric `X.Y.Z` is needed to pick the OVMF variant.
+///
+/// Returns `None` when the segment after the last `-` is not at least a valid
+/// `X.Y.Z` triple of non-empty numeric components.
 pub fn extract_version_from_image_name(image: &str) -> Option<&str> {
     let tail = image.rsplit('-').next()?;
     let parts: Vec<&str> = tail.split('.').collect();
-    if parts.len() == 3
-        && parts
-            .iter()
-            .all(|p| !p.is_empty() && p.parse::<u32>().is_ok())
-    {
-        Some(tail)
-    } else {
-        None
+    if !(3..=4).contains(&parts.len()) {
+        return None;
     }
+    let core_numeric = parts[..3]
+        .iter()
+        .all(|p| !p.is_empty() && p.parse::<u32>().is_ok());
+    let suffix_ok = parts.len() == 3 || !parts[3].is_empty();
+    if !(core_numeric && suffix_ok) {
+        return None;
+    }
+    // Slice off the optional `.SUFFIX` so callers get just `X.Y.Z`.
+    let core_len = parts[0].len() + 1 + parts[1].len() + 1 + parts[2].len();
+    Some(&tail[..core_len])
 }
 
 /// Pick the OVMF variant from an image name like `dstack-0.5.10`.
@@ -111,6 +122,7 @@ mod ovmf_variant_tests {
 
     #[test]
     fn parses_version_from_image_name() {
+        // Three-segment plain versions across the known prefix shapes.
         assert_eq!(
             extract_version_from_image_name("dstack-0.5.10"),
             Some("0.5.10")
@@ -127,9 +139,27 @@ mod ovmf_variant_tests {
             extract_version_from_image_name("dstack-nvidia-dev-0.6.1"),
             Some("0.6.1")
         );
+        // Optional .SUFFIX is allowed and dropped; suffix may be non-numeric.
+        assert_eq!(
+            extract_version_from_image_name("dstack-0.5.10.rc1"),
+            Some("0.5.10")
+        );
+        assert_eq!(
+            extract_version_from_image_name("dstack-dev-0.6.1.dev"),
+            Some("0.6.1")
+        );
+        assert_eq!(
+            extract_version_from_image_name("dstack-nvidia-dev-0.5.10.1"),
+            Some("0.5.10")
+        );
+        // Rejections.
         assert_eq!(extract_version_from_image_name("dstack"), None);
         assert_eq!(extract_version_from_image_name("dstack-rc1"), None);
         assert_eq!(extract_version_from_image_name("dstack-0.5"), None);
+        assert_eq!(extract_version_from_image_name("dstack-0.5.10."), None);
+        assert_eq!(extract_version_from_image_name("dstack-0.5.10.1.2"), None);
+        assert_eq!(extract_version_from_image_name("dstack-0..10"), None);
+        assert_eq!(extract_version_from_image_name("dstack-a.b.c"), None);
     }
 
     #[test]

--- a/dstack-mr/src/lib.rs
+++ b/dstack-mr/src/lib.rs
@@ -19,6 +19,7 @@ mod kernel;
 mod machine;
 mod num;
 mod tdvf;
+mod uefi_var;
 mod util;
 
 /// Pick the OVMF variant for a given dstack OS version string ("MAJOR.MINOR.PATCH").

--- a/dstack-mr/src/lib.rs
+++ b/dstack-mr/src/lib.rs
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
 
+pub use dstack_types::OvmfVariant;
 pub use machine::{Machine, TdxMeasurementDetails};
 
 use util::{measure_log, measure_sha384, utf16_encode};
@@ -18,6 +20,155 @@ mod machine;
 mod num;
 mod tdvf;
 mod util;
+
+/// Pick the OVMF variant for a given dstack OS version string ("MAJOR.MINOR.PATCH").
+///
+/// Treats `0.5.10 <= v < 0.6.0` and `v >= 0.6.1` as `Stable202505`, everything else as
+/// `Pre202505`. Used as a fallback when `VmConfig::ovmf_variant` is absent.
+pub fn ovmf_variant_for_version(version: &str) -> Result<OvmfVariant> {
+    let parts: Vec<u32> = version
+        .split('.')
+        .map(|p| {
+            p.parse::<u32>()
+                .with_context(|| format!("invalid version component: {p}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if parts.len() != 3 {
+        bail!("expected MAJOR.MINOR.PATCH, got {version}");
+    }
+    let v = (parts[0], parts[1], parts[2]);
+    let stable = ((0, 5, 10)..(0, 6, 0)).contains(&v) || v >= (0, 6, 1);
+    Ok(if stable {
+        OvmfVariant::Stable202505
+    } else {
+        OvmfVariant::Pre202505
+    })
+}
+
+/// Extract a dotted version suffix (e.g. "0.5.10") from a dstack image name like
+/// `dstack-0.5.10`, `dstack-dev-0.5.10`, or `dstack-nvidia-0.5.10`.
+///
+/// Returns `None` when the image name does not end with a recognisable
+/// `MAJOR.MINOR.PATCH` segment.
+pub fn extract_version_from_image_name(image: &str) -> Option<&str> {
+    let tail = image.rsplit('-').next()?;
+    let parts: Vec<&str> = tail.split('.').collect();
+    if parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.parse::<u32>().is_ok())
+    {
+        Some(tail)
+    } else {
+        None
+    }
+}
+
+/// Pick the OVMF variant from an image name like `dstack-0.5.10`.
+///
+/// Falls back to `OvmfVariant::default()` (= `Pre202505`) when the image name is
+/// missing or doesn't carry a parseable version suffix. Use this only as a
+/// fallback for images that pre-date `VmConfig::ovmf_variant`.
+pub fn ovmf_variant_for_image(image: Option<&str>) -> OvmfVariant {
+    image
+        .and_then(extract_version_from_image_name)
+        .and_then(|v| ovmf_variant_for_version(v).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod ovmf_variant_tests {
+    use super::*;
+
+    #[test]
+    fn pre_202505_for_old_versions() {
+        for v in ["0.4.99", "0.5.7", "0.5.8", "0.5.9", "0.6.0"] {
+            assert_eq!(
+                ovmf_variant_for_version(v).unwrap(),
+                OvmfVariant::Pre202505,
+                "{v}"
+            );
+        }
+    }
+
+    #[test]
+    fn stable_202505_for_new_versions() {
+        for v in ["0.5.10", "0.5.99", "0.6.1", "0.6.2", "0.7.0", "1.0.0"] {
+            assert_eq!(
+                ovmf_variant_for_version(v).unwrap(),
+                OvmfVariant::Stable202505,
+                "{v}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_version() {
+        assert!(ovmf_variant_for_version("0.5").is_err());
+        assert!(ovmf_variant_for_version("0.5.10-dev").is_err());
+        assert!(ovmf_variant_for_version("v0.5.10").is_err());
+    }
+
+    #[test]
+    fn parses_version_from_image_name() {
+        assert_eq!(
+            extract_version_from_image_name("dstack-0.5.10"),
+            Some("0.5.10")
+        );
+        assert_eq!(
+            extract_version_from_image_name("dstack-dev-0.5.10"),
+            Some("0.5.10")
+        );
+        assert_eq!(
+            extract_version_from_image_name("dstack-nvidia-0.5.10"),
+            Some("0.5.10")
+        );
+        assert_eq!(
+            extract_version_from_image_name("dstack-nvidia-dev-0.6.1"),
+            Some("0.6.1")
+        );
+        assert_eq!(extract_version_from_image_name("dstack"), None);
+        assert_eq!(extract_version_from_image_name("dstack-rc1"), None);
+        assert_eq!(extract_version_from_image_name("dstack-0.5"), None);
+    }
+
+    #[test]
+    fn ovmf_variant_for_image_handles_missing_and_unknown() {
+        assert_eq!(ovmf_variant_for_image(None), OvmfVariant::Pre202505);
+        assert_eq!(
+            ovmf_variant_for_image(Some("dstack")),
+            OvmfVariant::Pre202505
+        );
+        assert_eq!(
+            ovmf_variant_for_image(Some("dstack-0.5.9")),
+            OvmfVariant::Pre202505
+        );
+        assert_eq!(
+            ovmf_variant_for_image(Some("dstack-0.5.10")),
+            OvmfVariant::Stable202505
+        );
+        assert_eq!(
+            ovmf_variant_for_image(Some("dstack-nvidia-dev-0.6.1")),
+            OvmfVariant::Stable202505
+        );
+    }
+
+    #[test]
+    fn serializes_with_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&OvmfVariant::Pre202505).unwrap(),
+            "\"pre202505\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OvmfVariant::Stable202505).unwrap(),
+            "\"stable202505\""
+        );
+        assert_eq!(
+            serde_json::from_str::<OvmfVariant>("\"stable202505\"").unwrap(),
+            OvmfVariant::Stable202505
+        );
+    }
+}
 
 /// Contains all the measurement values for TDX.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dstack-mr/src/machine.rs
+++ b/dstack-mr/src/machine.rs
@@ -5,7 +5,7 @@
 use crate::acpi::Tables;
 use crate::tdvf::Tdvf;
 use crate::util::debug_print_log;
-use crate::{kernel, RtmrLogs, TdxMeasurements};
+use crate::{kernel, OvmfVariant, RtmrLogs, TdxMeasurements};
 use crate::{measure_log, measure_sha384};
 use anyhow::{bail, Context, Result};
 use fs_err as fs;
@@ -32,6 +32,10 @@ pub struct Machine<'a> {
     pub root_verity: bool,
     #[builder(default)]
     pub host_share_mode: String,
+    /// Selects which OVMF measurement event layout to expect.
+    /// Defaults to the pre-edk2-stable202505 layout for backwards compatibility.
+    #[builder(default)]
+    pub ovmf_variant: OvmfVariant,
 }
 
 fn parse_version_tuple(v: &str) -> Result<(u32, u32, u32)> {

--- a/dstack-mr/src/tdvf.rs
+++ b/dstack-mr/src/tdvf.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha384};
 
 use crate::acpi::Tables;
 use crate::num::read_le;
-use crate::{measure_log, measure_sha384, utf16_encode, Machine, RtmrLog};
+use crate::{measure_log, measure_sha384, utf16_encode, Machine, OvmfVariant, RtmrLog};
 
 const PAGE_SIZE: u64 = 0x1000;
 const MR_EXTEND_GRANULARITY: usize = 0x100;
@@ -275,33 +275,79 @@ impl<'a> Tdvf<'a> {
     pub fn rtmr0_log(&self, machine: &Machine) -> Result<(RtmrLog, Tables)> {
         let td_hob_hash = self.measure_td_hob(machine.memory_size)?;
         let cfv_image_hash = hex!("344BC51C980BA621AAA00DA3ED7436F7D6E549197DFE699515DFA2C6583D95E6412AF21C097D473155875FFD561D6790");
-        let boot000_hash = hex!("23ADA07F5261F12F34A0BD8E46760962D6B4D576A416F1FEA1C64BC656B1D28EACF7047AE6E967C58FD2A98BFA74C298");
 
         let tables = machine.build_tables()?;
         let acpi_tables_hash = measure_sha384(&tables.tables);
         let acpi_rsdp_hash = measure_sha384(&tables.rsdp);
         let acpi_loader_hash = measure_sha384(&tables.loader);
 
-        // RTMR0 calculation
+        let secureboot_hash =
+            measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "SecureBoot")?;
+        let pk_hash = measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "PK")?;
+        let kek_hash = measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "KEK")?;
+        let db_hash = measure_tdx_efi_variable("D719B2CB-3D3A-4596-A3BC-DAD00E67656F", "db")?;
+        let dbx_hash = measure_tdx_efi_variable("D719B2CB-3D3A-4596-A3BC-DAD00E67656F", "dbx")?;
+        let separator_hash = measure_sha384(&[0x00, 0x00, 0x00, 0x00]);
 
-        Ok((
-            vec![
-                td_hob_hash,
-                cfv_image_hash.to_vec(),
-                measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "SecureBoot")?,
-                measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "PK")?,
-                measure_tdx_efi_variable("8BE4DF61-93CA-11D2-AA0D-00E098032B8C", "KEK")?,
-                measure_tdx_efi_variable("D719B2CB-3D3A-4596-A3BC-DAD00E67656F", "db")?,
-                measure_tdx_efi_variable("D719B2CB-3D3A-4596-A3BC-DAD00E67656F", "dbx")?,
-                measure_sha384(&[0x00, 0x00, 0x00, 0x00]), // Separator
-                acpi_loader_hash,
-                acpi_rsdp_hash,
-                acpi_tables_hash,
-                measure_sha384(&[0x00, 0x00]), // BootOrder
-                boot000_hash.to_vec(),
-            ],
-            tables,
-        ))
+        let log = match machine.ovmf_variant {
+            OvmfVariant::Pre202505 => {
+                // Boot0000 = OVMF UiApp (fixed digest for pre-202505 firmware).
+                let boot000_hash = hex!("23ADA07F5261F12F34A0BD8E46760962D6B4D576A416F1FEA1C64BC656B1D28EACF7047AE6E967C58FD2A98BFA74C298");
+                vec![
+                    td_hob_hash,
+                    cfv_image_hash.to_vec(),
+                    secureboot_hash,
+                    pk_hash,
+                    kek_hash,
+                    db_hash,
+                    dbx_hash,
+                    separator_hash,
+                    acpi_loader_hash,
+                    acpi_rsdp_hash,
+                    acpi_tables_hash,
+                    measure_sha384(&[0x00, 0x00]), // BootOrder (raw 2 bytes in legacy OVMF)
+                    boot000_hash.to_vec(),
+                ]
+            }
+            OvmfVariant::Stable202505 => {
+                // edk2-stable202505 adds 4 new events and re-formats BootOrder/Boot0000
+                // in RTMR[0]. Digests captured from a 0.5.10 dstack CVM running the
+                // standard -kernel boot config (9p host_share_mode); they are firmware
+                // constants for this OVMF build.
+                let bootmenu_fwcfg_hash = measure_sha384(&[0x00, 0x00]); // BootMenu fw_cfg = 0x0000
+                let bootorder_fwcfg_hash =
+                    hex!("53D3DBC00691328371E74C1B1C77BDF1BF4FF79DD1B55222B694FE8341CD8B0ADB3A9AB9286552C681272883B9B0FC1D");
+                let variable_authority_hash =
+                    hex!("FB66919801F1DFC9C4C273B6A739380790CB0FD3CB706A42F6AC050510EBC8618E7FBA53A1564522F5C6F0DC9E1F41A6");
+                let boot_order_var_hash =
+                    hex!("52B9A02DE946B947364B57D8210C63113B9058996E2A3BA7CEAD54AF11AE0873B085D1E52BC01E4FEBE57CA05CA1332B");
+                let boot0000_hash =
+                    hex!("5068E6A9DED2A1C3A8EBB5D26004410EA8670742D8F444C5C3D161B76C66FA23A7B1D2FB3F9840570B675384B5818F2D");
+                let boot0001_hash =
+                    hex!("DD424F2EEB35F3E8A2C2F50F6CC87FF90B7577E92CE63E13A22869D07D104FD5EA9800E6E4F12C5058FC4EAA78374F20");
+                vec![
+                    td_hob_hash,
+                    cfv_image_hash.to_vec(),
+                    bootmenu_fwcfg_hash,
+                    bootorder_fwcfg_hash.to_vec(),
+                    secureboot_hash,
+                    pk_hash,
+                    kek_hash,
+                    db_hash,
+                    dbx_hash,
+                    separator_hash,
+                    acpi_loader_hash,
+                    acpi_rsdp_hash,
+                    acpi_tables_hash,
+                    variable_authority_hash.to_vec(),
+                    boot_order_var_hash.to_vec(),
+                    boot0000_hash.to_vec(),
+                    boot0001_hash.to_vec(),
+                ]
+            }
+        };
+
+        Ok((log, tables))
     }
 
     fn measure_td_hob(&self, memory_size: u64) -> Result<Vec<u8>> {

--- a/dstack-mr/src/tdvf.rs
+++ b/dstack-mr/src/tdvf.rs
@@ -9,10 +9,34 @@ use sha2::{Digest, Sha384};
 
 use crate::acpi::Tables;
 use crate::num::read_le;
+use crate::uefi_var::{
+    boot_option_bytes, boot_order_bytes, fv_file_node, fv_node, END_OF_DEVICE_PATH,
+};
 use crate::{measure_log, measure_sha384, utf16_encode, Machine, OvmfVariant, RtmrLog};
 
 const PAGE_SIZE: u64 = 0x1000;
 const MR_EXTEND_GRANULARITY: usize = 0x100;
+
+// OVMF firmware-volume identifiers used by edk2-stable202505. These are baked
+// into the OVMF binary at build time; if the firmware is regenerated against a
+// different EDK2 source these constants may need refreshing.
+//
+// Each GUID is stored in the on-the-wire little-endian byte form OVMF puts in
+// the EFI_DEVICE_PATH MEDIA_FV / MEDIA_FV_FILE nodes — the first three GUID
+// fields are byte-swapped relative to the canonical string form.
+//
+// canonical: 7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1
+const OVMF_FV_GUID_LE: [u8; 16] = [
+    0xc9, 0xbd, 0xb8, 0x7c, 0xeb, 0xf8, 0x34, 0x4f, 0xaa, 0xea, 0x3e, 0xe4, 0xaf, 0x65, 0x16, 0xa1,
+];
+// canonical: eec25bdc-67f2-4d95-b1d5-f81b2039d11d  (MdeModulePkg UiApp)
+const OVMF_UIAPP_FILE_GUID_LE: [u8; 16] = [
+    0xdc, 0x5b, 0xc2, 0xee, 0xf2, 0x67, 0x95, 0x4d, 0xb1, 0xd5, 0xf8, 0x1b, 0x20, 0x39, 0xd1, 0x1d,
+];
+// canonical: 462caa21-7614-4503-836e-8ab6f4662331  (MdeModulePkg BootMaintenance / FrontPage)
+const OVMF_FRONTPAGE_FILE_GUID_LE: [u8; 16] = [
+    0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31,
+];
 
 const ATTRIBUTE_MR_EXTEND: u32 = 0x00000001;
 const ATTRIBUTE_PAGE_AUG: u32 = 0x00000002;
@@ -310,21 +334,68 @@ impl<'a> Tdvf<'a> {
                 ]
             }
             OvmfVariant::Stable202505 => {
-                // edk2-stable202505 adds 4 new events and re-formats BootOrder/Boot0000
-                // in RTMR[0]. Digests captured from a 0.5.10 dstack CVM running the
-                // standard -kernel boot config (9p host_share_mode); they are firmware
-                // constants for this OVMF build.
-                let bootmenu_fwcfg_hash = measure_sha384(&[0x00, 0x00]); // BootMenu fw_cfg = 0x0000
+                // edk2-stable202505 emits 17 RTMR[0] events instead of 13. The
+                // boot-option set is fully derivable from OVMF-internal
+                // constants (FV and file GUIDs, descriptions, attributes); the
+                // remaining two — the bootorder fw_cfg measurement and
+                // EV_EFI_VARIABLE_AUTHORITY — stay as captured digests because
+                // their content depends on QEMU's emitted device list and on
+                // OVMF-internal logic that's not worth shadowing here.
+
+                // fw_cfg `BootMenu` is a u16; dstack doesn't pass `-boot
+                // menu=on`, so it defaults to 0x0000.
+                let bootmenu_fwcfg_hash = measure_sha384(&[0x00, 0x00]);
+
+                // fw_cfg `bootorder` is QEMU's generated bootorder string for
+                // the current device topology. dstack-vmm's QEMU command (9p +
+                // virtio-blk + vhost-vsock, no `-boot order=` / `bootindex=`)
+                // is fixed, so this is a constant. If the QEMU command line is
+                // ever changed (different host_share_mode, GPU passthrough,
+                // extra bootable devices) this digest will need re-capturing.
                 let bootorder_fwcfg_hash =
                     hex!("53D3DBC00691328371E74C1B1C77BDF1BF4FF79DD1B55222B694FE8341CD8B0ADB3A9AB9286552C681272883B9B0FC1D");
+
+                // EV_EFI_VARIABLE_AUTHORITY: OVMF emits this once during BDS
+                // even when Secure Boot is disabled. The 32-byte event blob in
+                // the log is a sentinel; the actual measured payload is
+                // OVMF-internal. Captured digest is a constant for the
+                // edk2-stable202505 build dstack ships.
                 let variable_authority_hash =
                     hex!("FB66919801F1DFC9C4C273B6A739380790CB0FD3CB706A42F6AC050510EBC8618E7FBA53A1564522F5C6F0DC9E1F41A6");
-                let boot_order_var_hash =
-                    hex!("52B9A02DE946B947364B57D8210C63113B9058996E2A3BA7CEAD54AF11AE0873B085D1E52BC01E4FEBE57CA05CA1332B");
-                let boot0000_hash =
-                    hex!("5068E6A9DED2A1C3A8EBB5D26004410EA8670742D8F444C5C3D161B76C66FA23A7B1D2FB3F9840570B675384B5818F2D");
-                let boot0001_hash =
-                    hex!("DD424F2EEB35F3E8A2C2F50F6CC87FF90B7577E92CE63E13A22869D07D104FD5EA9800E6E4F12C5058FC4EAA78374F20");
+
+                // BootOrder UEFI variable holds [0x0000, 0x0001] — the two
+                // boot options OVMF's BDS publishes (UiApp and FrontPage).
+                // The TCG digest for `EV_EFI_VARIABLE_BOOT2` is over the raw
+                // variable data, NOT a UEFI_VARIABLE_DATA wrapper.
+                let boot_order_var_hash = measure_sha384(&boot_order_bytes(&[0x0000, 0x0001]));
+
+                // Boot0000 = OVMF's BootManagerMenuApp; Boot0001 = "EFI
+                // Firmware Setup" (FrontPage). Both live in the OVMF FV and
+                // are baked into the firmware at build time. The attribute
+                // bits and descriptions come from MdeModulePkg's
+                // BdsBootManagerLib in edk2-stable202505.
+                //   0x101 = LOAD_OPTION_ACTIVE | LOAD_OPTION_CATEGORY_APP
+                //   0x109 = + LOAD_OPTION_HIDDEN
+                let boot0000_hash = measure_sha384(&boot_option_bytes(
+                    0x0000_0109,
+                    "BootManagerMenuApp",
+                    &[
+                        fv_node(&OVMF_FV_GUID_LE),
+                        fv_file_node(&OVMF_UIAPP_FILE_GUID_LE),
+                        END_OF_DEVICE_PATH,
+                    ],
+                    &[],
+                ));
+                let boot0001_hash = measure_sha384(&boot_option_bytes(
+                    0x0000_0101,
+                    "EFI Firmware Setup",
+                    &[
+                        fv_node(&OVMF_FV_GUID_LE),
+                        fv_file_node(&OVMF_FRONTPAGE_FILE_GUID_LE),
+                        END_OF_DEVICE_PATH,
+                    ],
+                    &[],
+                ));
                 vec![
                     td_hob_hash,
                     cfv_image_hash.to_vec(),
@@ -340,9 +411,9 @@ impl<'a> Tdvf<'a> {
                     acpi_rsdp_hash,
                     acpi_tables_hash,
                     variable_authority_hash.to_vec(),
-                    boot_order_var_hash.to_vec(),
-                    boot0000_hash.to_vec(),
-                    boot0001_hash.to_vec(),
+                    boot_order_var_hash,
+                    boot0000_hash,
+                    boot0001_hash,
                 ]
             }
         };

--- a/dstack-mr/src/tdvf.rs
+++ b/dstack-mr/src/tdvf.rs
@@ -346,14 +346,19 @@ impl<'a> Tdvf<'a> {
                 // menu=on`, so it defaults to 0x0000.
                 let bootmenu_fwcfg_hash = measure_sha384(&[0x00, 0x00]);
 
-                // fw_cfg `bootorder` is QEMU's generated bootorder string for
-                // the current device topology. dstack-vmm's QEMU command (9p +
-                // virtio-blk + vhost-vsock, no `-boot order=` / `bootindex=`)
-                // is fixed, so this is a constant. If the QEMU command line is
-                // ever changed (different host_share_mode, GPU passthrough,
-                // extra bootable devices) this digest will need re-capturing.
-                let bootorder_fwcfg_hash =
-                    hex!("53D3DBC00691328371E74C1B1C77BDF1BF4FF79DD1B55222B694FE8341CD8B0ADB3A9AB9286552C681272883B9B0FC1D");
+                // fw_cfg `bootorder` is the NUL-separated list of QEMU device
+                // paths whose backing devices have `bootindex` set. For
+                // `-kernel` boot, QEMU (hw/i386/x86.c::x86_load_linux) injects
+                // a single option ROM with `bootindex = 0`:
+                //   * `linuxboot_dma.bin`  if fw_cfg DMA is enabled (q35 default)
+                //   * `linuxboot.bin`      otherwise
+                // dstack-vmm always uses q35 → DMA is on → the bootorder file
+                // contains just the single path below (31 bytes, trailing
+                // NUL). No other dstack device gets an implicit bootindex.
+                //
+                // Verified end-to-end: gdb-attached the live QEMU and called
+                // get_boot_devices_list() — returned exactly these 31 bytes.
+                let bootorder_fwcfg_hash = measure_sha384(b"/rom@genroms/linuxboot_dma.bin\0");
 
                 // EV_EFI_VARIABLE_AUTHORITY: OVMF emits this once during BDS
                 // even when Secure Boot is disabled. The 32-byte event blob in

--- a/dstack-mr/src/uefi_var.rs
+++ b/dstack-mr/src/uefi_var.rs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for synthesising the UEFI variable byte blobs that OVMF measures
+//! into RTMR[0] as `EV_EFI_VARIABLE_BOOT2` events.
+//!
+//! For the BootOrder / Boot####  variables the TCG PFP spec digest is taken
+//! over the *variable data* portion only (not the full `UEFI_VARIABLE_DATA`
+//! struct), so we just build the on-the-wire variable contents here.
+
+use crate::utf16_encode;
+
+/// Build the raw bytes of a `BootOrder` UEFI variable from a sequence of boot
+/// option numbers — each entry is a little-endian `u16` referring to a
+/// `Boot####` variable.
+pub fn boot_order_bytes(entries: &[u16]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(entries.len() * 2);
+    for &entry in entries {
+        out.extend_from_slice(&entry.to_le_bytes());
+    }
+    out
+}
+
+/// An `EFI_DEVICE_PATH_PROTOCOL` node.
+#[derive(Clone, Copy)]
+pub struct DevicePathNode<'a> {
+    pub r#type: u8,
+    pub subtype: u8,
+    pub data: &'a [u8],
+}
+
+impl DevicePathNode<'_> {
+    fn write_to(self, buf: &mut Vec<u8>) {
+        let len = 4 + self.data.len();
+        buf.push(self.r#type);
+        buf.push(self.subtype);
+        buf.extend_from_slice(&(len as u16).to_le_bytes());
+        buf.extend_from_slice(self.data);
+    }
+}
+
+/// `END_ENTIRE_DEVICE_PATH` terminator.
+pub const END_OF_DEVICE_PATH: DevicePathNode<'static> = DevicePathNode {
+    r#type: 0x7f,
+    subtype: 0xff,
+    data: &[],
+};
+
+/// `MEDIA_DEVICE_PATH / Firmware Volume` node (`type=4, subtype=7`).
+pub fn fv_node(guid_le: &[u8; 16]) -> DevicePathNode<'_> {
+    DevicePathNode {
+        r#type: 0x04,
+        subtype: 0x07,
+        data: guid_le,
+    }
+}
+
+/// `MEDIA_DEVICE_PATH / Firmware File` node (`type=4, subtype=6`).
+pub fn fv_file_node(guid_le: &[u8; 16]) -> DevicePathNode<'_> {
+    DevicePathNode {
+        r#type: 0x04,
+        subtype: 0x06,
+        data: guid_le,
+    }
+}
+
+/// Build the raw bytes of a `Boot####` UEFI variable — the on-the-wire form of
+/// `EFI_LOAD_OPTION { Attributes, FilePathListLength, Description, FilePathList,
+/// OptionalData }`.
+///
+/// The description is automatically NUL-terminated in UTF-16LE.
+pub fn boot_option_bytes(
+    attributes: u32,
+    description: &str,
+    file_path_nodes: &[DevicePathNode<'_>],
+    optional_data: &[u8],
+) -> Vec<u8> {
+    // Serialise the device-path list first so we know its length.
+    let mut file_path = Vec::new();
+    for node in file_path_nodes {
+        node.write_to(&mut file_path);
+    }
+
+    let mut desc = utf16_encode(description);
+    desc.extend_from_slice(&[0x00, 0x00]); // NUL terminator
+
+    let mut out = Vec::with_capacity(4 + 2 + desc.len() + file_path.len() + optional_data.len());
+    out.extend_from_slice(&attributes.to_le_bytes());
+    out.extend_from_slice(&(file_path.len() as u16).to_le_bytes());
+    out.extend_from_slice(&desc);
+    out.extend_from_slice(&file_path);
+    out.extend_from_slice(optional_data);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha384};
+
+    fn sha384(bytes: &[u8]) -> String {
+        hex::encode(Sha384::new_with_prefix(bytes).finalize())
+    }
+
+    #[test]
+    fn boot_option_round_trip_sample() {
+        // Trivial sanity check: a load option with one MEDIA_FV_FILE node and
+        // an empty description should serialise to a 4 (Attrs) + 2 (FpLen) +
+        // 2 (NUL) + (4 + 16) (FV_FILE) + 4 (END) = 32 byte blob, and
+        // round-tripping the descriptive string survives.
+        let blob = boot_option_bytes(1, "", &[fv_file_node(&[0; 16]), END_OF_DEVICE_PATH], &[]);
+        assert_eq!(blob.len(), 4 + 2 + 2 + 20 + 4);
+        assert_eq!(&blob[0..4], &[0x01, 0x00, 0x00, 0x00]);
+        assert_eq!(&blob[4..6], &[0x18, 0x00]); // FilePathListLength = 24
+                                                // Description is just a NUL terminator (two bytes of 0).
+        assert_eq!(&blob[6..8], &[0x00, 0x00]);
+    }
+
+    #[test]
+    fn boot_order_encodes_u16_le_entries() {
+        assert_eq!(
+            boot_order_bytes(&[0x0000, 0x0001]),
+            vec![0x00, 0x00, 0x01, 0x00]
+        );
+        assert_eq!(
+            boot_order_bytes(&[0x1234, 0xabcd]),
+            vec![0x34, 0x12, 0xcd, 0xab]
+        );
+        assert_eq!(
+            sha384(&boot_order_bytes(&[0x0000, 0x0001])),
+            "52b9a02de946b947364b57d8210c63113b9058996e2a3ba7cead54af11ae0873b085d1e52bc01e4febe57ca05ca1332b"
+        );
+    }
+}

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -11,10 +11,17 @@ use size_parser::human_size;
 
 /// Identifies which OVMF flavour the guest image was built with.
 ///
-/// dstack switched OVMF from an untagged 2024-09 snapshot to edk2-stable202505 in
-/// the run-up to 0.5.9 (commit f9f11f3 on meta-dstack). The newer firmware emits
-/// more boot-time measurement events into RTMR[0], so quote replay needs a
-/// different expected event list for the two flavours.
+/// The firmware switch happened in meta-dstack commit f9f11f3 (upgrade from an
+/// untagged 2024-09 snapshot to edk2-stable202505): 0.5.7 and earlier shipped
+/// `Pre202505`, 0.5.9 onwards ships `Stable202505`. The newer firmware emits
+/// more boot-time events into RTMR[0], so quote replay needs a different
+/// expected event list for the two flavours.
+///
+/// When the variant isn't carried explicitly in `VmConfig`, the runtime cutoff
+/// rule in `dstack_mr::ovmf_variant_for_version` draws the line at OS version
+/// `0.5.10` (and again at `0.6.1`) — a deliberate policy decision that doesn't
+/// follow the firmware-flip date exactly. See that function's docs for the
+/// authoritative selection rule.
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum OvmfVariant {

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -9,6 +9,23 @@ use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
 use size_parser::human_size;
 
+/// Identifies which OVMF flavour the guest image was built with.
+///
+/// dstack switched OVMF from an untagged 2024-09 snapshot to edk2-stable202505 in
+/// the run-up to 0.5.9 (commit f9f11f3 on meta-dstack). The newer firmware emits
+/// more boot-time measurement events into RTMR[0], so quote replay needs a
+/// different expected event list for the two flavours.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OvmfVariant {
+    /// Pre-edk2-stable202505 OVMF (13 RTMR[0] events).
+    #[default]
+    Pre202505,
+    /// edk2-stable202505+ OVMF (17 RTMR[0] events: new fw_cfg, VARIABLE_AUTHORITY
+    /// and BootXXXX entries).
+    Stable202505,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct AppCompose {
     pub manifest_version: u32,
@@ -196,6 +213,12 @@ pub struct VmConfig {
     /// If false (default), shared files are provided via 9p virtfs
     #[serde(default)]
     pub host_share_mode: String,
+    /// OVMF measurement layout declared by the OS image. When present, verifiers
+    /// should treat this as the source of truth. Absent on images built before
+    /// this field was introduced — callers must fall back to other heuristics
+    /// (e.g. parsing the OS version out of `image`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ovmf_variant: Option<OvmfVariant>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -275,6 +298,15 @@ pub struct ImageInfo {
     pub kernel: String,
     pub initrd: String,
     pub bios: String,
+    /// Optional dstack OS version (e.g. "0.5.10"). Older metadata.json files
+    /// may omit it, so callers should treat its absence as "unknown".
+    #[serde(default)]
+    pub version: String,
+    /// Optional OVMF measurement layout declared by the image. Older
+    /// metadata.json files do not carry this — treat absence as "unknown" and
+    /// fall back to version-based heuristics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ovmf_variant: Option<OvmfVariant>,
 }
 
 pub mod mr_config;

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -250,6 +250,12 @@ impl CvmVerifier {
         let kernel = kernel_path.display().to_string();
         let initrd = initrd_path.display().to_string();
 
+        // Prefer the explicit variant the image declared; fall back to parsing
+        // the version out of the image name for pre-`ovmf_variant` deployments.
+        let ovmf_variant = vm_config
+            .ovmf_variant
+            .unwrap_or_else(|| dstack_mr::ovmf_variant_for_image(vm_config.image.as_deref()));
+
         let details = dstack_mr::Machine::builder()
             .cpu_count(vm_config.cpu_count)
             .memory_size(vm_config.memory_size)
@@ -271,6 +277,7 @@ impl CvmVerifier {
             .num_gpus(vm_config.num_gpus)
             .num_nvswitches(vm_config.num_nvswitches)
             .host_share_mode(vm_config.host_share_mode.clone())
+            .ovmf_variant(ovmf_variant)
             .build()
             .measure_with_logs()
             .context("Failed to compute expected MRs")?;

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -118,7 +118,10 @@ fn collect_rtmr_mismatch(
     }
 }
 
-const MEASUREMENT_CACHE_VERSION: u32 = 1;
+// Bump whenever expected RTMR computation changes so stale entries get ignored.
+// v2: edk2-stable202505 OVMF RTMR[0] layout (added 4 events, reshaped BootOrder
+// and Boot0000); the legacy 13-event log no longer matches any in-field image.
+const MEASUREMENT_CACHE_VERSION: u32 = 2;
 
 #[derive(Clone, Serialize, Deserialize)]
 struct CachedMeasurement {

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -1188,6 +1188,7 @@ fn make_vm_config(cfg: &Config, manifest: &Manifest, image: &Image) -> Result<se
         host_share_mode: cfg.cvm.host_share_mode.clone(),
         hotplug_off: cfg.cvm.qemu_hotplug_off,
         image: Some(manifest.image.clone()),
+        ovmf_variant: image.info.ovmf_variant,
     })?;
     // For backward compatibility
     config["spec_version"] = serde_json::Value::from(1);

--- a/vmm/src/app/image.rs
+++ b/vmm/src/app/image.rs
@@ -25,6 +25,11 @@ pub struct ImageInfo {
     pub version: String,
     #[serde(default)]
     pub is_dev: bool,
+    /// OVMF measurement layout declared by the image. Older metadata.json files
+    /// do not have this — verifiers fall back to version-based heuristics when
+    /// it's missing.
+    #[serde(default)]
+    pub ovmf_variant: Option<dstack_types::OvmfVariant>,
 }
 
 impl ImageInfo {


### PR DESCRIPTION
## Summary

OVMF was upgraded from an untagged 2024-09 snapshot (`3a3b12cb`) to
`edk2-stable202505` in [meta-dstack@f9f11f3](https://github.com/Dstack-TEE/meta-dstack/commit/f9f11f3). The newer firmware emits **17 RTMR[0] events** instead of the legacy 13 under the standard `-kernel` boot config, so dstack-mr was producing the wrong expected RTMR[0] for 0.5.9+ CVMs and quote replay failed.

New / changed events that the legacy code didn't model (digests captured from a real 0.5.10 CVM, treated as firmware constants):

| # | Event | Note |
|---|---|---|
| 02 | `QEMU FW CFG: BootMenu` (type 0xa) | new |
| 03 | `QEMU FW CFG: bootorder` (type 0xa) | new |
| 13 | `EV_EFI_VARIABLE_AUTHORITY` (type 0x80000009) | new — signer cert for secure-boot variable verification |
| 14 | `BootOrder` (type 0x80000002) | now full `UEFI_VARIABLE_DATA` struct, not raw bytes |
| 15 | `Boot0000` UiApp | description / device path bytes changed |
| 16 | `Boot0001` "EFI Firmware…" | new (second boot option) |

## Approach

- Add a typed `OvmfVariant { Pre202505, Stable202505 }` enum in `dstack-types` with serde derive (serialises as `"pre202505"` / `"stable202505"`).
- `dstack-mr` dispatches on `Machine.ovmf_variant`; the `Stable202505` arm produces the new 17-event log.
- Add `VmConfig.ovmf_variant: Option<OvmfVariant>` as the source of truth — verifier prefers it, falls back to parsing the OS version suffix from `vm_config.image` (e.g. `dstack-0.5.10`) for legacy deployments without the field.
- `vmm` picks up `ImageInfo.ovmf_variant` from `metadata.json` and stamps it into `VmConfig`. Until image builds start setting it, the image-name fallback keeps existing deployments working.
- `dstack-mr` CLI adds `--dstack-os-version` for explicit override and auto-detects from `metadata.json` (`ovmf_variant` > `version` field > legacy default).

## Backward compatibility

- `VmConfig` / `ImageInfo` add `Option<OvmfVariant>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — old wire formats decode cleanly, old CVMs unaffected.
- Verifier and CLI both fall back to image-name parsing when the field is absent, so 0.5.9 / 0.5.10 CVMs already in the field continue to verify.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p dstack-mr -p dstack-mr-cli -p dstack-types -p dstack-verifier -p dstack-kms --all-features --tests` clean
- [x] `cargo clippy -p dstack-vmm --bins --all-features` clean
- [x] `cargo test -p dstack-mr` — 6/6 pass (includes serde round-trip for `OvmfVariant`)
- [x] CLI auto-pick on real 0.5.10 image bundle → MRTD + RTMR[0..3] all match the running CVM's quote exactly
- [x] CLI with `--dstack-os-version 0.5.8` produces the old 13-event RTMR[0]; `--dstack-os-version 0.5.10` / `0.6.1` produce the new one; `0.6.0` falls back to old per the agreed rule
- [x] Synthesised `metadata.json` with `"ovmf_variant": "stable202505"` / `"pre202505"` dispatches correctly and overrides the version-name heuristic
- [ ] Wire `ovmf_variant` into image build (`meta-dstack` change, follow-up PR)

Verified RTMR0 = `a6d1a5efdfe15cbf7f0874d29577be5e3bbfa83757f7c6a4923aa32f5a1cb23943dde6c2050a8f2d0171c53784affbed` matches the quote produced by a running 0.5.10 CVM.