### PR TITLE
gw: expose /health on main RPC server

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -312,6 +312,7 @@ async fn main() -> Result<()> {
 
     let mut rocket = rocket::custom(figment)
         .mount("/prpc", prpc!(Proxy, RpcHandler, trim: "Tproxy."))
+        .mount("/", web_routes::health_routes())
         // Mount WaveKV sync endpoint (requires mTLS gateway auth)
         .mount("/", web_routes::wavekv_sync_routes())
         .attach(AdHoc::on_response("Add app version header", |_req, res| {


### PR DESCRIPTION
## Summary

- Mounts `health_routes()` on the main RPC server so `GET /health` returns `OK` without authentication
- Replaces the admin `GetMeta` endpoint as a monitoring/health-check target after admin auth was added in #674

## Test plan

- `curl http://127.0.0.1:<GATEWAY_RPC_PORT>/health` should return `OK` with 200
- Admin endpoints still require token (no regression)