### PR TITLE
ci: replace tag-triggered SDK publish with release-plz

### DIFF
--- a/.github/workflows/rust-sdk-release.yml
+++ b/.github/workflows/rust-sdk-release.yml
@@ -1,25 +1,56 @@
-# SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+# SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Publish SDK to crates.io
+name: Release-plz
+
 on:
   push:
-    tags: ['rust-sdk-v*']
+    branches:
+      - master
+
 jobs:
-  publish:
+  release-plz-pr:
+    name: Release-plz PR
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Dstack-TEE' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Dstack-TEE' }}
     environment: sdk-release
     permissions:
+      contents: write
+      pull-requests: read
       id-token: write
     steps:
-    - uses: actions/checkout@v5
-    - uses: rust-lang/crates-io-auth-action@v1
-      id: auth
-    - run: cargo publish -p dstack-sdk-types
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-    - run: cargo publish -p dstack-sdk
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# release-plz only manages the public SDK crates. Every other workspace
+# member is internal and must never be published to crates.io.
+
+[workspace]
+release = false
+pr_branch_prefix = "release-plz/"
+pr_labels = ["release"]
+semver_check = true
+changelog_update = true
+
+[[package]]
+name = "dstack-sdk-types"
+release = true
+
+[[package]]
+name = "dstack-sdk"
+release = true


### PR DESCRIPTION
## Summary

Replaces the broken tag-triggered `cargo publish` workflow with [release-plz](https://release-plz.dev), a PR-driven release manager for cargo workspaces.

### Why

The current `rust-sdk-release.yml` triggers on `rust-sdk-v*` tags and serially `cargo publish`es `dstack-sdk-types` then `dstack-sdk`. It's been awkward in practice:

- Tag version (`rust-sdk-v0.5.9`) is decoupled from the actual crate version in `Cargo.toml` (`0.1.2`). The [last run](https://github.com/Dstack-TEE/dstack/actions/runs/24703384896) failed with `crate dstack-sdk-types@0.1.2 already exists on crates.io index` — no one had bumped `Cargo.toml`.
- Two-step serial publish has no retry path: if `types` succeeds but `sdk` fails, the next attempt fails immediately on `types`.
- Both crates must be kept at the same version by hand. Today there's already drift: workspace dep pin is `0.1.1` but the crate is `0.1.2`.

### How release-plz fixes this

- On every push to `master`, opens/updates a single **Release PR** that bumps versions in `Cargo.toml`, updates workspace dependency pins, and regenerates per-crate `CHANGELOG.md` from commits since the last release.
- Merging the PR auto-tags each crate (`dstack-sdk-v*`, `dstack-sdk-types-v*`), publishes to crates.io **in dependency order**, idempotently. Already-published versions are skipped.
- `cargo semver-checks` runs automatically and warns if a change should bump major.
- OIDC trusted publishing (`id-token: write`) replaces the static token flow.

### Changes

- **New** `release-plz.toml` — allowlist config: workspace default `release = false`, only `dstack-sdk` and `dstack-sdk-types` are managed. All other ~30 internal crates are protected from accidental publish.
- **Rewritten** `.github/workflows/rust-sdk-release.yml` — two jobs: `release-plz-pr` (open/update Release PR), `release-plz-release` (publish on merge). Same filename and `environment: sdk-release` as before, so existing crates.io trusted publisher entries continue to work without changes.

### First release after merge

The first push to master will open a Release PR that:
1. Fixes the workspace dep version drift (`0.1.1` → current).
2. Bumps both crates to the next version based on commits since `0.1.2`.
3. Generates initial CHANGELOG files.

Review and merge that PR to publish.

## Test plan

- [ ] CI passes (lint, SDK tests)
- [ ] After merge, verify `Release-plz PR` job runs and opens a Release PR
- [ ] Review the first Release PR, adjust version numbers if needed, merge it
- [ ] Verify both crates publish successfully to crates.io and tags + GitHub Releases appear