### PR TITLE
fix(verifier,vmm): resolve OVMF variant from metadata.json before parsing image name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
  "clap",
  "dirs",
  "dstack-kms-rpc",
+ "dstack-mr",
  "dstack-port-forward",
  "dstack-types",
  "dstack-vmm-rpc",

--- a/verifier/src/verification.rs
+++ b/verifier/src/verification.rs
@@ -121,7 +121,10 @@ fn collect_rtmr_mismatch(
 // Bump whenever expected RTMR computation changes so stale entries get ignored.
 // v2: edk2-stable202505 OVMF RTMR[0] layout (added 4 events, reshaped BootOrder
 // and Boot0000); the legacy 13-event log no longer matches any in-field image.
-const MEASUREMENT_CACHE_VERSION: u32 = 2;
+// v3: resolve OVMF variant from the image's metadata.json (explicit field, or
+// `version`) when vm_config doesn't declare one; previous versions silently
+// fell back to image-name parsing which fails for `dstack-X.Y.Z-<hash>` dirs.
+const MEASUREMENT_CACHE_VERSION: u32 = 3;
 
 #[derive(Clone, Serialize, Deserialize)]
 struct CachedMeasurement {
@@ -134,6 +137,11 @@ struct ImagePaths {
     kernel_path: PathBuf,
     initrd_path: PathBuf,
     kernel_cmdline: String,
+    /// OVMF variant resolved from the image's metadata.json: the explicit
+    /// `ovmf_variant` field when present, otherwise derived from `version`.
+    /// `None` only when metadata.json declares neither — callers should then
+    /// fall back to image-name heuristics.
+    image_ovmf_variant: Option<dstack_types::OvmfVariant>,
 }
 
 pub struct CvmVerifier {
@@ -248,15 +256,25 @@ impl CvmVerifier {
         kernel_path: &Path,
         initrd_path: &Path,
         kernel_cmdline: &str,
+        image_ovmf_variant: Option<dstack_types::OvmfVariant>,
     ) -> Result<TdxMeasurementDetails> {
         let firmware = fw_path.display().to_string();
         let kernel = kernel_path.display().to_string();
         let initrd = initrd_path.display().to_string();
 
-        // Prefer the explicit variant the image declared; fall back to parsing
-        // the version out of the image name for pre-`ovmf_variant` deployments.
+        // Resolve OVMF variant in priority order:
+        //   1. `vm_config.ovmf_variant` — explicit declaration from the VMM
+        //      (only emitted by VMM 0.5.11+; deployments persisted by older
+        //      VMMs are `None` and need a fallback).
+        //   2. `image_ovmf_variant` — resolved from the downloaded image's
+        //      metadata.json (explicit field, or derived from `version`).
+        //      This catches the common case of an old VMM serving a new image.
+        //   3. `ovmf_variant_for_image` on `vm_config.image` — last-resort
+        //      parsing of the image directory name, kept only for legacy
+        //      images whose metadata.json predates the `version` field.
         let ovmf_variant = vm_config
             .ovmf_variant
+            .or(image_ovmf_variant)
             .unwrap_or_else(|| dstack_mr::ovmf_variant_for_image(vm_config.image.as_deref()));
 
         let details = dstack_mr::Machine::builder()
@@ -295,6 +313,7 @@ impl CvmVerifier {
         kernel_path: &Path,
         initrd_path: &Path,
         kernel_cmdline: &str,
+        image_ovmf_variant: Option<dstack_types::OvmfVariant>,
     ) -> Result<TdxMeasurements> {
         self.compute_measurement_details(
             vm_config,
@@ -302,6 +321,7 @@ impl CvmVerifier {
             kernel_path,
             initrd_path,
             kernel_cmdline,
+            image_ovmf_variant,
         )
         .map(|details| details.measurements)
     }
@@ -313,6 +333,7 @@ impl CvmVerifier {
         kernel_path: &Path,
         initrd_path: &Path,
         kernel_cmdline: &str,
+        image_ovmf_variant: Option<dstack_types::OvmfVariant>,
     ) -> Result<TdxMeasurements> {
         let cache_key = Self::vm_config_cache_key(vm_config)?;
 
@@ -326,6 +347,7 @@ impl CvmVerifier {
             kernel_path,
             initrd_path,
             kernel_cmdline,
+            image_ovmf_variant,
         )?;
 
         if let Err(e) = self.store_measurements_in_cache(&cache_key, &measurements) {
@@ -367,6 +389,9 @@ impl CvmVerifier {
         let fw_path = image_dir.join(&image_info.bios);
         let kernel_path = image_dir.join(&image_info.kernel);
         let initrd_path = image_dir.join(&image_info.initrd);
+        let image_ovmf_variant = image_info
+            .ovmf_variant
+            .or_else(|| dstack_mr::ovmf_variant_for_version(&image_info.version).ok());
         let kernel_cmdline = image_info.cmdline + " initrd=initrd";
 
         Ok(ImagePaths {
@@ -374,6 +399,7 @@ impl CvmVerifier {
             kernel_path,
             initrd_path,
             kernel_cmdline,
+            image_ovmf_variant,
         })
     }
 
@@ -394,6 +420,7 @@ impl CvmVerifier {
             &image_paths.kernel_path,
             &image_paths.initrd_path,
             &image_paths.kernel_cmdline,
+            image_paths.image_ovmf_variant,
         )
     }
 
@@ -556,6 +583,7 @@ impl CvmVerifier {
                     &image_paths.kernel_path,
                     &image_paths.initrd_path,
                     &image_paths.kernel_cmdline,
+                    image_paths.image_ovmf_variant,
                 )
                 .context("Failed to compute expected measurements")?;
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -47,6 +47,7 @@ load_config.workspace = true
 key-provider-client.workspace = true
 dstack-port-forward.workspace = true
 dstack-types.workspace = true
+dstack-mr.workspace = true
 hex_fmt.workspace = true
 lspci.workspace = true
 base64.workspace = true

--- a/vmm/src/app.rs
+++ b/vmm/src/app.rs
@@ -1188,7 +1188,16 @@ fn make_vm_config(cfg: &Config, manifest: &Manifest, image: &Image) -> Result<se
         host_share_mode: cfg.cvm.host_share_mode.clone(),
         hotplug_off: cfg.cvm.qemu_hotplug_off,
         image: Some(manifest.image.clone()),
-        ovmf_variant: image.info.ovmf_variant,
+        // Prefer the explicit field from metadata.json; fall back to deriving
+        // the variant from the image's `version` string. Without this fallback,
+        // pre-0.5.11 OS images (whose metadata.json predates the ovmf_variant
+        // field) ship with `None` and force verifiers to guess from the image
+        // directory name — which fails for the standard `dstack-X.Y.Z-<hash>`
+        // naming convention.
+        ovmf_variant: image
+            .info
+            .ovmf_variant
+            .or_else(|| dstack_mr::ovmf_variant_for_version(&image.info.version).ok()),
     })?;
     // For backward compatibility
     config["spec_version"] = serde_json::Value::from(1);


### PR DESCRIPTION
## Summary

When `vm_config.ovmf_variant` is absent (any deployment persisted by VMM ≤ 0.5.11-pre), the verifier currently jumps straight to parsing the image directory name via `extract_version_from_image_name`. That parser only accepts `dstack-X.Y.Z[.SUFFIX]`, so it returns `None` for the real meta-dstack release convention `dstack-X.Y.Z-<HEXHASH>` (rsplit on `-` lands on the hash segment, not the version). The default `OvmfVariant::Pre202505` then mismatches the `Stable202505` firmware shipped by 0.5.10+ images, producing an RTMR0 mismatch during KMS onboarding.

This PR closes the gap by reading the version straight from `metadata.json`, which both the verifier (`ensure_image_downloaded`) and the VMM (`Image::load`) already load:

- **vmm/src/app.rs**: in `make_vm_config`, derive `ovmf_variant` from `image.info.version` when `metadata.json` does not declare it explicitly. The resulting `vm_config` becomes an authoritative source of truth for new deployments.
- **verifier/src/verification.rs**: thread an `image_ovmf_variant` (resolved from metadata's explicit field or its `version` string) through `ImagePaths` into `compute_measurement_details`, inserting it as a middle priority between `vm_config.ovmf_variant` and the legacy image-name fallback. The image-name fallback remains for very old metadata.json files that predate the `version` field.
- **MEASUREMENT_CACHE_VERSION**: bumped 2 → 3 so entries written with the old resolution order get invalidated.

The `extract_version_from_image_name` parser is intentionally left as-is — it is no longer on the hot path for any image whose metadata.json carries `version`.

## Repro

Onboarding a fresh KMS node:

- VMM `v0.5.10-28-g53e217cae7` (no `ovmf_variant` field in `make_vm_config`)
- OS image: `dstack-0.5.10-4c9bd024/` (real release naming)
- `metadata.json.version = "0.5.10"`, no `ovmf_variant` field
- KMS verifying the request: `dstacktee/dstack-kms:0.5.11`

```
Failed to onboard: Request failed with status=400 Bad Request, error={
  "error": "Failed to verify os image hash: Failed to verify os image hash: MRs do not match: RTMR0 mismatch: expected=68102e7b...875c, actual=d357b91a...875c"
}
```

`expected` is the verifier's locally computed value using `Pre202505` (wrong). `actual` is the value the firmware actually extended into RTMR0 using the `Stable202505` event layout. With this PR, the verifier resolves variant from `metadata.json.version = "0.5.10"` → `Stable202505`, matching the quote.

## Why three layers instead of just fixing the parser

Two layers are about making `vm_config.ovmf_variant` and `metadata.json` the source of truth. The image-name parser remains as a last-resort fallback, but it no longer needs to handle the `-<HEXHASH>` suffix because metadata.json answers the question more reliably and is always present alongside the image being measured. Extending the parser would re-encode information that is already structured elsewhere.

## Test plan

- [ ] CI builds dstack-kms and dstack-vmm with `dstack-mr` added as a vmm dep
- [ ] Re-run KMS onboard against a CVM running OS `dstack-0.5.10-<hash>` with this build of KMS → RTMR0 matches
- [ ] Existing dstack-mr / dstack-types unit tests still pass (no behavioural change to the parser)
- [ ] Confirm measurement cache entries get re-computed on first hit after the version bump (cache key includes vm_config; new entries written with v3, old v2 entries ignored)

## Out of scope (intentionally)

- Fixing `extract_version_from_image_name` to recognise `-<HEXHASH>`. Skipped — metadata.json supersedes it on the resolution chain.
- Backfilling `ovmf_variant` into the released `dstack-0.5.10` `metadata.json`. Future meta-dstack releases can declare it explicitly; existing images are covered by the `version` derivation path.

## Note

I could not run `cargo check` locally (macOS Xcode license blocked all native build scripts on this machine), so the build verification is delegated to CI. `prek` hooks pass.