### PR TITLE
chore(sdk): bump JS SDK to 0.5.8 and Python SDK to 0.5.4

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -18,7 +18,7 @@ jobs:
   gateway:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -62,7 +62,7 @@ jobs:
   kms:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -116,7 +116,7 @@ jobs:
   verifier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: kms/auth-eth
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/gateway-release.yml
+++ b/.github/workflows/gateway-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Parse version from tag
         run: |
@@ -68,7 +68,7 @@ jobs:
           push-to-registry: true
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "Gateway Release v${{ env.VERSION }}"
           body: |

--- a/.github/workflows/js-sdk-release.yml
+++ b/.github/workflows/js-sdk-release.yml
@@ -33,6 +33,11 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for trusted publishers support
+        run: |
+          npm install -g npm@latest
+          echo "npm: $(npm --version)"
+
       - name: Verify OIDC token availability
         run: |
           if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL}" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" ]; then

--- a/.github/workflows/js-sdk-release.yml
+++ b/.github/workflows/js-sdk-release.yml
@@ -26,9 +26,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -104,7 +104,7 @@ jobs:
 
       - name: GitHub Release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "JS SDK v${{ steps.tag.outputs.version }}"
           body: |

--- a/.github/workflows/kms-release.yml
+++ b/.github/workflows/kms-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Parse version from tag
         run: |
@@ -78,7 +78,7 @@ jobs:
           forge build
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "KMS Release v${{ env.VERSION }}"
           files: |

--- a/.github/workflows/prek-check.yml
+++ b/.github/workflows/prek-check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
@@ -79,7 +79,7 @@ jobs:
 
       - name: GitHub Release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "Python SDK v${{ steps.version.outputs.version }}"
           body: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
   rust-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.86

--- a/.github/workflows/simulator-release.yml
+++ b/.github/workflows/simulator-release.yml
@@ -25,7 +25,7 @@ jobs:
       TARGET_TRIPLE: x86_64-unknown-linux-musl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve version and tag
         run: |
@@ -60,7 +60,7 @@ jobs:
         run: ./guest-agent-simulator/package-release.sh "${VERSION}" "${TARGET_TRIPLE}"
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG }}
           name: "Simulator Release v${{ env.VERSION }}"

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   reuse-lint:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
-      
+
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5
       with:

--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Parse version from tag
         run: |
@@ -69,7 +69,7 @@ jobs:
           push-to-registry: true
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: "Verifier Release v${{ env.VERSION }}"
           body: |

--- a/.github/workflows/vmm-ui.yml
+++ b/.github/workflows/vmm-ui.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/dstack-sdk",
-  "version": "0.5.8-beta.2",
+  "version": "0.5.8",
   "description": "dstack SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "dstack-sdk"
-version = "0.5.4b1"
+version = "0.5.4"
 description = "dstack SDK for Python"
 authors = [
     {name = "Leechael Yim", email = "yanleech@gmail.com"},


### PR DESCRIPTION
## Summary
- Bump JS SDK version from `0.5.8-beta.2` to `0.5.8` for stable release
- Bump Python SDK version from `0.5.4b1` to `0.5.4` for stable release

## Test plan
- [ ] After merge, tag `js-sdk-v0.5.8` to trigger npm publish
- [ ] After merge, tag `python-sdk-v0.5.4` to trigger PyPI publish