### PR TITLE
dstack-cloud: honor gcp_config.private_ip (bind static internal IP)

### DIFF
--- a/scripts/bin/dstack-cloud
+++ b/scripts/bin/dstack-cloud
@@ -196,6 +196,7 @@ class GcpConfig:
     # Network settings
     network: str = "default"
     subnet: str = ""
+    private_ip: str = ""  # static internal IP to bind (--private-network-ip)
 
     # Identity settings
     service_account: str = ""
@@ -236,6 +237,7 @@ class GcpConfig:
             "bucket": "",
             "network": "default",
             "subnet": "",
+            "private_ip": "",
             "service_account": "",
             "scopes": [],
             "tags": [],
@@ -1408,6 +1410,13 @@ class CloudDeploymentManager:
             create_args.append(f"--network={config.network}")
         if config.subnet:
             create_args.append(f"--subnet={config.subnet}")
+        if config.private_ip:
+            # Bind a reserved static internal IP so the VM keeps the same RFC1918
+            # address across remove/deploy. --private-network-ip needs the subnet
+            # named, so default it when the user didn't set one.
+            if not config.subnet:
+                create_args.append("--subnet=default")
+            create_args.append(f"--private-network-ip={config.private_ip}")
         if config.service_account:
             create_args.append(f"--service-account={config.service_account}")
         if config.scopes:


### PR DESCRIPTION
## Problem

`GcpConfig` has no `private_ip` field, so a `private_ip` set in an app's `app.json` is **silently dropped** when the config is loaded (`from_dict` filters to known dataclass fields), and `prepare`/`deploy` then **rewrite `app.json` stripping the field**. The VM is also never created with `--private-network-ip`, so it always gets an **ephemeral** internal IP.

This breaks any deployment that addresses a VM by a **stable internal IP** across `remove`+`deploy` — e.g. an in-VPC KMS whose TLS cert SAN / `kms_urls` pin a fixed RFC1918 address. After a redeploy the IP changes and clients can no longer reach (or verify) the service.

## Fix

- Add `private_ip: str = ""` to `GcpConfig` (and to `get_template()`).
- In the instance `create_args`, when `private_ip` is set, pass `--private-network-ip=<ip>` (and default `--subnet=default` when the user didn't name a subnet, since gcloud requires the subnet for a custom internal IP).

Reserve the address first, e.g.:
```bash
gcloud compute addresses create my-kms-ip --region=us-central1 --subnet=default --addresses=10.128.15.220
```
then set `gcp_config.private_ip = "10.128.15.220"` in `app.json`. The VM now keeps that address across redeploys.

## Testing

Deployed two CVMs with reserved static IPs (`10.128.15.220` / `10.128.15.230`); `deploy` output's Internal IP matched the reserved addresses, and they stayed stable across `remove`+`deploy`. Without the patch the same configs produced ephemeral IPs.

Backwards compatible: when `private_ip` is empty (the default), behavior is unchanged.