### PR TITLE
dstack-util: honor a deploy-time app_id without KMS

### DIFF
--- a/docs/encrypted-env-spec.md
+++ b/docs/encrypted-env-spec.md
@@ -29,6 +29,10 @@ app_id = SHA256(app-compose.json)[0..20]    // first 20 bytes, 40 hex characters
 compose hashing. Do not recompute from a re-formatted or re-serialized variant,
 or you may get a different `app_id`.
 
+> This formula is the **default**. A deployment may pin an explicit `app_id` (in
+> `.instance-info`); when it does, use that value — the attested `app_id` is the
+> deploy-time value, not necessarily the compose hash.
+
 Example:
 
 ```javascript

--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -55,11 +55,15 @@ This file contains metadata about the application instance:
 
 | Field | Description |
 |-------|-------------|
-| app_id | The application ID, determined by the SHA256 digest of the app-compose.json (truncated to the first 20 bytes) |
+| app_id | The application ID. This is the deploy-time `app_id` from this file; when it is unset it defaults to the SHA256 digest of the app-compose.json (truncated to the first 20 bytes). The deploy-time value is honored in all key-provider modes. |
 | instance_id | The instance ID, determined by the SHA256 digest of the instance_id_seed || app_id (truncated to the first 20 bytes). Empty if no_instance_id is true in app-compose.json |
 | instance_id_seed | The random seed that determines the instance ID |
 
 The hash of this file is not extended to any RTMR. Instead, the `app_id` and `instance_id` are extended to RTMR3 as event name `app-id` and `instance-id` respectively.
+
+> Because `app_id` can be pinned at deploy time (it is not necessarily derived from
+> `compose_hash`), a relying party that authorizes on `app_id` MUST also verify the
+> `compose_hash` independently — the two are separate measurements.
 
 ### .sys-config.json
 

--- a/docs/tutorials/attestation-verification.md
+++ b/docs/tutorials/attestation-verification.md
@@ -196,7 +196,7 @@ The response includes:
 | Field | Description |
 |-------|-------------|
 | `instance_id` | Unique identifier for this CVM instance |
-| `app_id` | Application identifier (from compose config) |
+| `app_id` | Application identifier (deploy-time `app_id` from `.instance-info`; defaults to the app-compose.json hash) |
 | `version` | dstack version running in the CVM |
 | `app_cert` | RA-TLS certificate (PEM-encoded X.509 with TDX quote in extensions) |
 | `tcb_info` | JSON string containing all measurements and the event log |

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1335,7 +1335,6 @@ impl<'a> Stage0<'a> {
     fn measure_app_info(&self) -> Result<AppInfo> {
         let compose_hash = sha256_file(self.shared.dir.app_compose_file())?;
         let truncated_compose_hash = truncate(&compose_hash, 20);
-        let kms_enabled = self.shared.app_compose.kms_enabled();
         let key_provider = self.shared.app_compose.key_provider();
         let mut instance_info = self.shared.instance_info.clone();
 
@@ -1365,11 +1364,14 @@ impl<'a> Stage0<'a> {
             sha256(&id_path)[..20].to_vec()
         };
         instance_info.instance_id = instance_id.clone();
-        let app_id = if kms_enabled {
-            instance_info.app_id.clone()
-        } else {
-            truncated_compose_hash.to_vec()
-        };
+        // app_id is the deploy-time instance_info.app_id (which defaults to the
+        // truncated compose hash when unset, see above). Previously the non-KMS
+        // path forced the compose-derived value; now a deployment may pin an
+        // explicit app_id even without a KMS. The app_id is measured into RTMR3
+        // (emit_runtime_event below), so a verifier sees exactly this value — with
+        // no KMS to bind it, the relying party MUST gate the compose_hash
+        // (which launcher build) separately from the app_id (which app).
+        let app_id = instance_info.app_id.clone();
 
         emit_runtime_event("system-preparing", &[])?;
         emit_runtime_event("app-id", &app_id)?;

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1371,10 +1371,9 @@ impl<'a> Stage0<'a> {
         // (emit_runtime_event below), so a verifier sees exactly this value — with
         // no KMS to bind it, the relying party MUST gate the compose_hash
         // (which launcher build) separately from the app_id (which app).
-        let app_id = instance_info.app_id.clone();
 
         emit_runtime_event("system-preparing", &[])?;
-        emit_runtime_event("app-id", &app_id)?;
+        emit_runtime_event("app-id", &instance_info.app_id)?;
         emit_runtime_event("compose-hash", &compose_hash)?;
         emit_runtime_event("instance-id", &instance_id)?;
         emit_runtime_event("boot-mr-done", &[])?;


### PR DESCRIPTION
## What

`measure_app_info()` forced `app_id = compose_hash[:20]` whenever KMS was not enabled, ignoring the deploy-time `.instance_info.app_id`. This honors `instance_info.app_id` in **all** modes.

It still defaults to the truncated compose hash when `.instance_info.app_id` is unset, so existing no-app_id deployments are unchanged — only deployments that *explicitly* set an app_id are affected, and only in the non-KMS path (the KMS path already used it).

## Why

A KMS-less profile (running `key_provider=tpm`/local) currently cannot give two apps distinct identities: `app-compose.json` doesn't contain app_id, so the forced `compose_hash[:20]` is identical for any two apps sharing a launcher build. Honoring the deploy-time app_id lets such deployments distinguish apps by an app_id chosen at deploy time, instead of synthesising a different compose per app.

## Security

With no KMS to bind app_id to an on-chain identity, app_id becomes operator-settable and is measured into RTMR3 (`emit_runtime_event("app-id", ...)`). A relying party verifying these quotes **must** gate the `compose_hash` (which launcher build) independently from the `app_id` (which app) — app_id alone is not a trust anchor in this mode. This matches how the KMS path already treats them as separate measurements.

Note: rebuilding the guest OS image with this change produces a new `os_image_hash`.