### PR TITLE
docs: restore Dstack-TEE GitHub URLs

### DIFF
--- a/attestation.md
+++ b/attestation.md
@@ -35,7 +35,7 @@ RTMR3 differs as it contains runtime information like compose hash and instance 
 MRTD, RTMR0, RTMR1, and RTMR2 correspond to the image. dstack OS builds all related software from source.
 Build version v0.5.4 using these commands:
 ```bash
-git clone https://github.com/Phala-Network/meta-dstack-cloud.git
+git clone https://github.com/Dstack-TEE/meta-dstack.git
 cd meta-dstack/
 git checkout f7c795b76faa693f218e1c255007e3a68c541d79
 git submodule update --init --recursive

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,7 +45,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ### Build Configuration
 
 ```bash
-git clone https://github.com/Phala-Network/meta-dstack-cloud.git --recursive
+git clone https://github.com/Dstack-TEE/meta-dstack.git --recursive
 cd meta-dstack/
 mkdir build && cd build
 ../build.sh hostcfg
@@ -126,7 +126,7 @@ If you skip the KMS allowlist step, the VM may boot and the onboard UI may still
 Clone and build dstack-vmm:
 
 ```bash
-git clone https://github.com/Phala-Network/dstack-cloud
+git clone https://github.com/Dstack-TEE/dstack
 cd dstack
 cargo build --release -p dstack-vmm -p supervisor
 mkdir -p vmm-data
@@ -162,7 +162,7 @@ address = "vsock:2"
 port = 10000
 ```
 
-Download guest images from [meta-dstack releases](https://github.com/Phala-Network/meta-dstack-cloud/releases) and extract to `./images/`.
+Download guest images from [meta-dstack releases](https://github.com/Dstack-TEE/meta-dstack/releases) and extract to `./images/`.
 
 > For reproducible builds and verification, see the [Security Model](./security/security-model.md).
 
@@ -259,7 +259,7 @@ AUTH_WEBHOOK_URL=http://your-auth-server:3001
 KMS_RPC_ADDR=0.0.0.0:9201
 GUEST_AGENT_ADDR=127.0.0.1:9205
 OS_IMAGE=dstack-0.5.5
-IMAGE_DOWNLOAD_URL=https://github.com/Phala-Network/meta-dstack-cloud/releases/download/v0.5.5/dstack-0.5.5.tar.gz
+IMAGE_DOWNLOAD_URL=https://github.com/Dstack-TEE/meta-dstack/releases/download/v0.5.5/dstack-0.5.5.tar.gz
 ```
 
 Then run:

--- a/docs/tutorials/troubleshooting-host-setup.md
+++ b/docs/tutorials/troubleshooting-host-setup.md
@@ -267,7 +267,7 @@ Now that TDX is enabled on your host, you can:
 ### dstack Resources
 
 - **dstack Documentation:** https://docs.phala.com/dstack/overview
-- **dstack GitHub:** https://github.com/Phala-Network/dstack
+- **dstack GitHub:** https://github.com/Dstack-TEE/dstack
 
 ### Getting Help
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -18,7 +18,7 @@ If any of these fail, the cryptographic proof won't verify.
 
 **Programmatic verification**: dstack provides several tools:
 
-- [dstack-verifier](https://github.com/Phala-Network/dstack-cloud/tree/master/verifier) - HTTP service with `/verify` endpoint, also runs as CLI
+- [dstack-verifier](https://github.com/Dstack-TEE/dstack/tree/master/verifier) - HTTP service with `/verify` endpoint, also runs as CLI
 - [dcap-qvl](https://github.com/Phala-Network/dcap-qvl) - Open source quote verification library (Rust, Python, JS/WASM, CLI)
 - [SDKs](../sdk/) - JavaScript and Python SDKs include `replayRtmrs()` for local RTMR verification
 

--- a/scripts/bin/dstack-cloud
+++ b/scripts/bin/dstack-cloud
@@ -72,7 +72,7 @@ logger = logging.getLogger(__name__)
 APP_CONFIG_FILE = "app.json"
 STATE_FILE = "state.json"
 GLOBAL_CONFIG_PATH = os.path.expanduser("~/.config/dstack-cloud/config.json")
-DEFAULT_OS_IMAGE = "dstack-cloud-0.6.0"
+DEFAULT_OS_IMAGE = "dstack-0.6.0"
 
 
 @dataclass
@@ -949,16 +949,16 @@ class CloudDeploymentManager:
                 os_image = url_filename
             download_tar = target_dir / url_filename
         else:
-            # Extract version from os_image (e.g., dstack-cloud-nvidia-0.6.0 -> 0.6.0)
+            # Extract version from os_image (e.g., dstack-nvidia-0.6.0 -> 0.6.0)
             # Version is the last component after the last hyphen followed by digits
             import re
             version_match = re.search(r'-(\d+\.\d+\.\d+)$', os_image)
             if not version_match:
                 logger.error(f"Could not extract version from image name: {os_image}")
-                logger.error("Expected format: dstack-cloud-<flavor>-<version> (e.g., dstack-cloud-nvidia-0.6.0)")
+                logger.error("Expected format: dstack-<flavor>-<version> (e.g., dstack-nvidia-0.6.0)")
                 return
             version = version_match.group(1)
-            download_url = f"https://github.com/Phala-Network/meta-dstack-cloud/releases/download/v{version}/{os_image}-uki.tar.gz"
+            download_url = f"https://github.com/Dstack-TEE/meta-dstack/releases/download/v{version}/{os_image}-uki.tar.gz"
             download_tar = target_dir / f"{os_image}-uki.tar.gz"
 
         if download_tar.exists():
@@ -1013,7 +1013,7 @@ class CloudDeploymentManager:
         # Derive GCP image name from app.os_image
         gcp_image = config.boot_image
         if not gcp_image:
-            # Convert OS image name (dstack-cloud-nvidia-0.6.0 -> dstack-cloud-nvidia-0-6-0)
+            # Convert OS image name (dstack-nvidia-0.6.0 -> dstack-nvidia-0-6-0)
             gcp_image = app.os_image.replace(".", "-")
 
         # If boot_image_tar is specified, use it (legacy config name, can be disk.raw or tar.gz)


### PR DESCRIPTION
## What

Restore the canonical **Dstack-TEE** GitHub URLs and repoint the `dstack-cloud` CLI's `pull` at `Dstack-TEE/meta-dstack`.

### Docs (`84163fad "Fix more links"` had redirected these to Phala's cloud repos)

| File | Before | After |
|------|--------|-------|
| `attestation.md` | `Phala-Network/meta-dstack-cloud.git` | `Dstack-TEE/meta-dstack.git` |
| `docs/deployment.md` (clone) | `Phala-Network/meta-dstack-cloud.git` | `Dstack-TEE/meta-dstack.git` |
| `docs/deployment.md` (vmm) | `Phala-Network/dstack-cloud` | `Dstack-TEE/dstack` |
| `docs/deployment.md` (releases x2) | `Phala-Network/meta-dstack-cloud/releases` | `Dstack-TEE/meta-dstack/releases` |
| `docs/verification.md` | `Phala-Network/dstack-cloud/tree/master/verifier` | `Dstack-TEE/dstack/tree/master/verifier` |
| `docs/tutorials/troubleshooting-host-setup.md` | `Phala-Network/dstack` | `Dstack-TEE/dstack` |

### `scripts/bin/dstack-cloud` — `pull`

`pull` now downloads UKI images from `Dstack-TEE/meta-dstack` releases, which use the `dstack-*-uki.tar.gz` naming (e.g. `dstack-nvidia-0.6.0.a1-uki.tar.gz`) — not `Phala-Network/meta-dstack-cloud`'s `dstack-cloud-*-uki.tar.gz`.

- pull URL → `https://github.com/Dstack-TEE/meta-dstack/releases/download/v{version}/{os_image}-uki.tar.gz`
- `DEFAULT_OS_IMAGE`: `dstack-cloud-0.6.0` → `dstack-0.6.0`
- format hint / comment examples: `dstack-cloud-<flavor>-<version>` → `dstack-<flavor>-<version>`

## Why

`dstack` / `meta-dstack` are now hosted under the **Dstack-TEE** org (`Phala-Network/dstack` is now a fork). The redirected doc links also broke the clone snippets — `git clone .../meta-dstack-cloud.git` was followed by `cd meta-dstack/`, and `git clone .../dstack-cloud` by `cd dstack`.

## Deliberately NOT changed

- **`dcap-qvl`** links and the Go module (`README.md`, `docs/verification.md`, `sdk/go/ratls/*`) stay on `Phala-Network` — `dcap-qvl` is a separate library with no Dstack-TEE counterpart.
