### PR TITLE
dstack-cloud: allow DSTACK_CLOUD_CONFIG to override the global config path

### DIFF
--- a/scripts/bin/dstack-cloud
+++ b/scripts/bin/dstack-cloud
@@ -71,7 +71,12 @@ logger = logging.getLogger(__name__)
 # Configuration file names
 APP_CONFIG_FILE = "app.json"
 STATE_FILE = "state.json"
-GLOBAL_CONFIG_PATH = os.path.expanduser("~/.config/dstack-cloud/config.json")
+# Global config location. Overridable via DSTACK_CLOUD_CONFIG so a caller can use
+# a local/throwaway config (e.g. a vendor computing an OS-image hash) without
+# polluting the user's global ~/.config/dstack-cloud.
+GLOBAL_CONFIG_PATH = os.path.expanduser(
+    os.environ.get("DSTACK_CLOUD_CONFIG") or "~/.config/dstack-cloud/config.json"
+)
 DEFAULT_OS_IMAGE = "dstack-0.6.0"
 
 


### PR DESCRIPTION
## What

`dstack-cloud`'s config path is hardcoded to `~/.config/dstack-cloud/config.json`. Honor a `DSTACK_CLOUD_CONFIG` env var to override it.

## Why

Some callers only need `image_search_paths` to run `dstack-cloud pull` — e.g. a tool that downloads an OS image just to read its `auth_hash.txt`. Today that forces writing the user's **global** config as a side effect. With `DSTACK_CLOUD_CONFIG` pointing at a throwaway file, such a caller can configure `pull` locally and leave `~/.config` untouched:

```bash
tmp=$(mktemp -d)
echo '{"image_search_paths":["'$tmp'/images"]}' > $tmp/config.json
DSTACK_CLOUD_CONFIG=$tmp/config.json dstack-cloud pull <url>   # no global pollution
```

## Change

One spot: `GLOBAL_CONFIG_PATH` now resolves from `DSTACK_CLOUD_CONFIG` when set, falling back to the existing default. No behavior change when the env var is unset.