### PR TITLE
dstack-cloud: add no_public_ip (--no-address) for network-isolated VMs

### DIFF
--- a/scripts/bin/dstack-cloud
+++ b/scripts/bin/dstack-cloud
@@ -209,6 +209,7 @@ class GcpConfig:
     network: str = "default"
     subnet: str = ""
     private_ip: str = ""  # static internal IP to bind (--private-network-ip)
+    no_public_ip: bool = False  # network-isolated: no external IP (--no-address); reach via IAP
 
     # Identity settings
     service_account: str = ""
@@ -250,6 +251,7 @@ class GcpConfig:
             "network": "default",
             "subnet": "",
             "private_ip": "",
+            "no_public_ip": False,
             "service_account": "",
             "scopes": [],
             "tags": [],
@@ -1458,6 +1460,12 @@ class CloudDeploymentManager:
             if not config.subnet:
                 create_args.append("--subnet=default")
             create_args.append(f"--private-network-ip={config.private_ip}")
+        if config.no_public_ip:
+            # Network-isolated CVM: no ephemeral external IP. With no Cloud NAT on
+            # the subnet, this also means no internet egress. Reaching the VM still
+            # works over IAP TCP forwarding (ingress via Google's edge to the
+            # internal IP), so SSH / the on-prem courier are unaffected.
+            create_args.append("--no-address")
         if config.service_account:
             create_args.append(f"--service-account={config.service_account}")
         if config.scopes:


### PR DESCRIPTION
## What

`GcpConfig` gains a `no_public_ip` flag. When set, `gcloud compute instances create` is given `--no-address`, so the VM is created with **no ephemeral external IP**.

## Why

The on-prem (KMS-less sca) operator tooling deploys confidential workloads that should be **network-isolated** — no public IP, reachable only over IAP TCP forwarding. The operator already writes `no_public_ip: true` into the deploy sys-config, but upstream `dstack-cloud` had no such field, so it was **silently ignored** and the VM got a public IP — i.e. an 'isolated' deploy was actually internet-exposed.

With `--no-address` (and no Cloud NAT on the subnet) the VM also has no egress; SSH and the launcher's courier still work because both go over IAP (ingress via Google's edge to the internal IP) regardless.

## Change

3 small additions to `scripts/bin/dstack-cloud` (+8 lines): the dataclass field, its config-template default, and the `--no-address` arg when the flag is set. No behavior change when unset (default `False`).