### PR TITLE
fix(verifier): make VerificationRequest fields optional

### DIFF
--- a/verifier/src/types.rs
+++ b/verifier/src/types.rs
@@ -87,3 +87,41 @@ pub enum RtmrEventStatus {
     Extra,
     Missing,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // the README documents sending either `attestation` or
+    // (`quote` + `event_log` + `vm_config`); every field is optional, so any
+    // documented subset must deserialize without a "missing field" error.
+
+    #[test]
+    fn deserializes_quote_subset_without_attestation() {
+        let json = r#"{"quote":"00","event_log":"[]","vm_config":"{}"}"#;
+        let req: VerificationRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.quote, Some(vec![0u8]));
+        assert_eq!(req.event_log.as_deref(), Some("[]"));
+        assert_eq!(req.vm_config.as_deref(), Some("{}"));
+        assert_eq!(req.attestation, None);
+        assert_eq!(req.debug, None);
+    }
+
+    #[test]
+    fn deserializes_attestation_subset_without_quote() {
+        let json = r#"{"attestation":"00"}"#;
+        let req: VerificationRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.attestation, Some(vec![0u8]));
+        assert_eq!(req.quote, None);
+        assert_eq!(req.event_log, None);
+        assert_eq!(req.vm_config, None);
+    }
+
+    #[test]
+    fn deserializes_empty_object() {
+        let req: VerificationRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.quote, None);
+        assert_eq!(req.attestation, None);
+        assert_eq!(req.debug, None);
+    }
+}

--- a/verifier/src/types.rs
+++ b/verifier/src/types.rs
@@ -9,12 +9,15 @@ use serde_human_bytes as serde_bytes;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerificationRequest {
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "serde_bytes", default)]
     pub quote: Option<Vec<u8>>,
+    #[serde(default)]
     pub event_log: Option<String>,
+    #[serde(default)]
     pub vm_config: Option<String>,
-    #[serde(with = "serde_bytes")]
+    #[serde(with = "serde_bytes", default)]
     pub attestation: Option<Vec<u8>>,
+    #[serde(default)]
     pub debug: Option<bool>,
 }
 


### PR DESCRIPTION
## Problem

The verifier's `POST /verify` handler rejects requests with **HTTP 422** unless **all** of `quote`, `event_log`, `vm_config`, `attestation`, and `debug` are present — even though every field is an `Option<...>` and the [README](../blob/master/verifier/README.md) documents sending only a subset:

> Provide either `attestation` or (`quote` + `event_log` + `vm_config`).

Sending exactly what the README shows fails:

```
parse error: missing field `attestation`
```

Root cause: the fields are `Option`, but without `#[serde(default)]` serde treats a *missing* field as a hard parse error rather than `None`.

## Fix

Add `#[serde(default)]` to every field of `VerificationRequest` so any documented subset deserializes and absent fields default to `None`.

## Verification

Built the verifier and POSTed a request containing only the documented `quote` + `event_log` + `vm_config`:

- **Before:** `HTTP 422 Unprocessable Entity` (`missing field \`attestation\``)
- **After:** `HTTP 200`, `is_valid: true`, `quote_verified: true`, `os_image_hash_verified: true`