### PR TITLE
ci(verifier): also tag and push :latest on release

### DIFF
--- a/.github/workflows/verifier-release.yml
+++ b/.github/workflows/verifier-release.yml
@@ -51,7 +51,9 @@ jobs:
           context: verifier
           file: verifier/builder/Dockerfile
           push: true
-          tags: ${{ vars.DOCKERHUB_ORG }}/dstack-verifier:${{ env.VERSION }}
+          tags: |
+            ${{ vars.DOCKERHUB_ORG }}/dstack-verifier:${{ env.VERSION }}
+            ${{ vars.DOCKERHUB_ORG }}/dstack-verifier:latest
           platforms: linux/amd64
           provenance: false
           build-contexts: |


### PR DESCRIPTION
## Problem

The verifier release workflow only pushes the version tag (`dstacktee/dstack-verifier:${VERSION}`), so `:latest` is never updated. As a result `latest` is stale — it still points to the old `0.5.4` image (digest `3f36162…`), which fails verification on certain attestations and also predates the request-field fix in #722.

## Fix

Add `:latest` to the `tags:` list of the build-push step so every release keeps `latest` current.

## Rollout for 0.5.11

After merge, re-pushing the `verifier-v0.5.11` tag re-runs the workflow. The build is reproducible (`SOURCE_DATE_EPOCH` pinned to the commit timestamp), so the `0.5.11` digest stays `a000ade…` and `latest` is pushed pointing to the same image.