### PR TITLE
fix(gateway): refresh WireGuard handshakes off hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached-cell"
+version = "0.5.11"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2399,7 @@ dependencies = [
  "arc-swap",
  "base64 0.22.1",
  "bytes",
+ "cached-cell",
  "certbot",
  "clap",
  "cmd_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "key-provider-client",
     "dstack-types",
     "cert-client",
+    "cached-cell",
     "lspci",
     "sodiumbox",
     "serde-duration",
@@ -97,6 +98,7 @@ load_config = { path = "load_config" }
 key-provider-client = { path = "key-provider-client" }
 dstack-types = { path = "dstack-types" }
 cert-client = { path = "cert-client" }
+cached-cell = { path = "cached-cell" }
 lspci = { path = "lspci" }
 sodiumbox = { path = "sodiumbox" }
 serde-duration = { path = "serde-duration" }

--- a/cached-cell/Cargo.toml
+++ b/cached-cell/Cargo.toml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "cached-cell"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+tokio = { workspace = true, features = ["rt", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/cached-cell/src/lib.rs
+++ b/cached-cell/src/lib.rs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! A small `OnceCell`-like cache cell for values that are refreshed by a
+//! caller-provided blocking producer.
+//!
+//! The cell owns the common mechanics: snapshot storage, TTL checks,
+//! `spawn_blocking` refreshes, and optional periodic refresh scheduling. The
+//! caller owns domain-specific value generation and error handling.
+
+use std::{
+    error::Error,
+    fmt,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    time::{Duration, Instant},
+};
+
+/// A TTL-bound cell containing the latest successfully produced value.
+pub struct TtlCell<T> {
+    ttl: Duration,
+    entry: RwLock<Option<Entry<T>>>,
+    refresh_task_started: AtomicBool,
+}
+
+struct Entry<T> {
+    value: Arc<T>,
+    refreshed_at: Instant,
+}
+
+impl<T> Clone for Entry<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: Arc::clone(&self.value),
+            refreshed_at: self.refreshed_at,
+        }
+    }
+}
+
+/// A point-in-time view of a cached value.
+#[derive(Debug)]
+pub struct Snapshot<T> {
+    value: Arc<T>,
+    refreshed_at: Instant,
+    age: Duration,
+}
+
+impl<T> Clone for Snapshot<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: Arc::clone(&self.value),
+            refreshed_at: self.refreshed_at,
+            age: self.age,
+        }
+    }
+}
+
+impl<T> Snapshot<T> {
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn into_value(self) -> Arc<T> {
+        self.value
+    }
+
+    pub fn refreshed_at(&self) -> Instant {
+        self.refreshed_at
+    }
+
+    pub fn age(&self) -> Duration {
+        self.age
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GetError {
+    Empty,
+    Expired { age: Duration, ttl: Duration },
+}
+
+impl fmt::Display for GetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "cached cell is empty"),
+            Self::Expired { age, ttl } => {
+                write!(f, "cached cell value expired: age={age:?}, ttl={ttl:?}")
+            }
+        }
+    }
+}
+
+impl Error for GetError {}
+
+#[derive(Debug)]
+pub enum RefreshError<E> {
+    Join(tokio::task::JoinError),
+    Produce(E),
+}
+
+impl<E: fmt::Display> fmt::Display for RefreshError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Join(err) => write!(f, "blocking refresh task failed: {err}"),
+            Self::Produce(err) => write!(f, "cached cell producer failed: {err}"),
+        }
+    }
+}
+
+impl<E> Error for RefreshError<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Join(err) => Some(err),
+            Self::Produce(err) => Some(err),
+        }
+    }
+}
+
+impl<T> TtlCell<T> {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entry: RwLock::new(None),
+            refresh_task_started: AtomicBool::new(false),
+        }
+    }
+
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+
+    /// Returns the cached value only if it has not expired.
+    pub fn get(&self) -> Result<Snapshot<T>, GetError> {
+        let snapshot = self.get_allow_stale()?;
+        if snapshot.age() >= self.ttl {
+            return Err(GetError::Expired {
+                age: snapshot.age(),
+                ttl: self.ttl,
+            });
+        }
+        Ok(snapshot)
+    }
+
+    /// Returns the last cached value even if it is older than the TTL.
+    pub fn get_allow_stale(&self) -> Result<Snapshot<T>, GetError> {
+        let entry = match self.entry.read() {
+            Ok(entry) => entry,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+        .clone()
+        .ok_or(GetError::Empty)?;
+        Ok(snapshot(entry))
+    }
+
+    pub fn set(&self, value: T) -> Snapshot<T> {
+        let entry = Entry {
+            value: Arc::new(value),
+            refreshed_at: Instant::now(),
+        };
+        let mut current = match self.entry.write() {
+            Ok(entry) => entry,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *current = Some(entry.clone());
+        snapshot(entry)
+    }
+}
+
+impl<T> TtlCell<T>
+where
+    T: Send + Sync + 'static,
+{
+    /// Runs a blocking producer on Tokio's blocking pool and stores the result.
+    pub async fn refresh_blocking<F, E>(&self, producer: F) -> Result<Snapshot<T>, RefreshError<E>>
+    where
+        F: FnOnce() -> Result<T, E> + Send + 'static,
+        E: Send + 'static,
+    {
+        let value = tokio::task::spawn_blocking(producer)
+            .await
+            .map_err(RefreshError::Join)?
+            .map_err(RefreshError::Produce)?;
+        Ok(self.set(value))
+    }
+
+    /// Starts one periodic refresh task. Returns `false` if already started.
+    pub fn spawn_refresh_task<F, E, H>(
+        self: Arc<Self>,
+        interval: Duration,
+        producer: F,
+        on_error: H,
+    ) -> bool
+    where
+        F: Fn() -> Result<T, E> + Send + Sync + 'static,
+        E: Send + 'static,
+        H: Fn(RefreshError<E>) + Send + Sync + 'static,
+    {
+        if self.refresh_task_started.swap(true, Ordering::Relaxed) {
+            return false;
+        }
+
+        let producer = Arc::new(producer);
+        let on_error = Arc::new(on_error);
+        tokio::spawn(async move {
+            loop {
+                let producer = Arc::clone(&producer);
+                if let Err(err) = self.refresh_blocking(move || producer()).await {
+                    on_error(err);
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+        true
+    }
+}
+
+fn snapshot<T>(entry: Entry<T>) -> Snapshot<T> {
+    Snapshot {
+        age: entry.refreshed_at.elapsed(),
+        refreshed_at: entry.refreshed_at,
+        value: entry.value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_empty_before_first_set() {
+        let cell = TtlCell::<u32>::new(Duration::from_secs(1));
+        assert_eq!(cell.get().unwrap_err(), GetError::Empty);
+    }
+
+    #[test]
+    fn returns_cached_value() {
+        let cell = TtlCell::new(Duration::from_secs(1));
+        cell.set(42);
+        assert_eq!(*cell.get().unwrap().value(), 42);
+    }
+
+    #[test]
+    fn enforces_ttl() {
+        let cell = TtlCell::new(Duration::ZERO);
+        cell.set(42);
+        assert!(matches!(cell.get(), Err(GetError::Expired { .. })));
+        assert_eq!(*cell.get_allow_stale().unwrap().value(), 42);
+    }
+
+    #[tokio::test]
+    async fn refreshes_with_blocking_producer() {
+        let cell = TtlCell::new(Duration::from_secs(1));
+        let snapshot = cell.refresh_blocking(|| Ok::<_, ()>(7)).await.unwrap();
+        assert_eq!(*snapshot.value(), 7);
+        assert_eq!(*cell.get().unwrap().value(), 7);
+    }
+}

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -63,6 +63,7 @@ rmp-serde.workspace = true
 or-panic.workspace = true
 base64.workspace = true
 subtle.workspace = true
+cached-cell.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["resource"] }

--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -47,6 +47,9 @@ use crate::{
 };
 
 mod auth_client;
+mod handshakes;
+
+use handshakes::LatestHandshakesCache;
 
 #[derive(Clone)]
 pub struct Proxy {
@@ -85,7 +88,11 @@ pub struct ProxyInner {
     /// known policy, `restrict_mode` is indeterminate and we cannot safely
     /// allow traffic.
     pub(crate) port_policy_tx: UnboundedSender<String>,
+    handshake_cache: Arc<LatestHandshakesCache>,
 }
+
+const HANDSHAKE_CACHE_TTL: Duration = Duration::from_secs(30);
+const HANDSHAKE_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct ProxyStateMut {
@@ -101,6 +108,7 @@ pub(crate) struct ProxyState {
     pub(crate) state: ProxyStateMut,
     /// Reference to KvStore for syncing changes
     kv_store: Arc<KvStore>,
+    handshake_cache: Arc<LatestHandshakesCache>,
 }
 
 /// Options for creating a Proxy instance
@@ -220,10 +228,19 @@ impl ProxyInner {
             None
         };
 
+        let handshake_cache = Arc::new(LatestHandshakesCache::new(
+            config.wg.interface.clone(),
+            HANDSHAKE_CACHE_TTL,
+        ));
+        if let Err(err) = handshake_cache.refresh().await {
+            warn!("failed to preload WireGuard latest-handshakes cache: {err:?}");
+        }
+
         let state = Mutex::new(ProxyState {
             config: config.clone(),
             state,
             kv_store: kv_store.clone(),
+            handshake_cache: handshake_cache.clone(),
         });
         let auth_client = AuthClient::new(config.auth.clone());
         // Bootstrap WaveKV first if sync is enabled, so certbot can load certs from peers
@@ -288,6 +305,7 @@ impl ProxyInner {
             wavekv_sync,
             https_config: Some(https_config),
             port_policy_tx,
+            handshake_cache,
         })
     }
 
@@ -302,6 +320,12 @@ impl ProxyInner {
 
 impl Proxy {
     pub(crate) async fn start_bg_tasks(&self) -> Result<()> {
+        if let Err(err) = self.handshake_cache.refresh().await {
+            warn!("failed to refresh WireGuard latest-handshakes cache before starting background tasks: {err:?}");
+        }
+        self.handshake_cache
+            .clone()
+            .spawn_refresh_task(HANDSHAKE_REFRESH_INTERVAL);
         start_recycle_thread(self.clone());
         // Start WaveKV periodic sync (bootstrap already done in new())
         if let Some(ref wavekv_sync) = self.wavekv_sync {
@@ -1188,47 +1212,7 @@ impl ProxyState {
         &self,
         stale_timeout: Option<Duration>,
     ) -> Result<BTreeMap<String, (u64, Duration)>> {
-        /*
-        $wg show ds-gw-kvin1 latest-handshakes
-        eHBq6OjihPy1IZ2cFDomSesjeD+new7KNdWn9MHdQC8=    1730190589
-        SRuIdjZ1CkR54jJ1g7JC4cy9nxHPezXf2bZlkZHjFxE=    1732085583
-        YobeKV6YpmuTAQd0+Tx30Pe4JP12fPFwftC04Umt6Bw=    1731214390
-        9pgMHikM4onpoiNPJkya003BFAdzRMiD2WMDSMb64zo=    1731213050
-        oZppF/Rk7NgnuPkkfGUiBpY9HbThJvq3jACNGW2vnVA=    1731213485
-        3OxwGWcnC+4TZ31rnmDpfgbLBi8DCWdEk4k/7gFG5HU=    1732085521
-        */
-        let ifname = &self.config.wg.interface;
-        let output = cmd_lib::run_fun!(wg show $ifname latest-handshakes)?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .context("system time before Unix epoch")?;
-        let mut handshakes = BTreeMap::new();
-        for line in output.lines() {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() != 2 {
-                continue;
-            }
-
-            let pubkey = parts[0].trim().to_string();
-            let timestamp = parts[1]
-                .trim()
-                .parse::<u64>()
-                .context("invalid timestamp")?;
-            let timestamp_duration = Duration::from_secs(timestamp);
-
-            if timestamp == 0 {
-                handshakes.insert(pubkey, (0, Duration::MAX));
-            } else {
-                let elapsed = now.checked_sub(timestamp_duration).unwrap_or_default();
-                match stale_timeout {
-                    Some(min_duration) if elapsed < min_duration => continue,
-                    _ => (),
-                }
-                handshakes.insert(pubkey, (timestamp, elapsed));
-            }
-        }
-
-        Ok(handshakes)
+        self.handshake_cache.latest(stale_timeout)
     }
 
     fn remove_instance(&mut self, id: &str) -> Result<()> {

--- a/gateway/src/main_service/handshakes.rs
+++ b/gateway/src/main_service/handshakes.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2024-2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use anyhow::{bail, Context, Result};
+use cached_cell::TtlCell;
+use tracing::warn;
+
+type HandshakeTimestamps = BTreeMap<String, u64>;
+type HandshakesWithAge = BTreeMap<String, (u64, Duration)>;
+
+/// Domain-specific wrapper around the generic TTL cell.
+///
+/// The cache framework lives in `cached-cell`; this type only knows how to
+/// produce and interpret WireGuard `latest-handshakes` snapshots.
+pub(crate) struct LatestHandshakesCache {
+    interface: String,
+    cell: Arc<TtlCell<HandshakeTimestamps>>,
+}
+
+impl LatestHandshakesCache {
+    pub(crate) fn new(interface: String, ttl: Duration) -> Self {
+        Self {
+            interface,
+            cell: Arc::new(TtlCell::new(ttl)),
+        }
+    }
+
+    pub(crate) fn spawn_refresh_task(self: Arc<Self>, interval: Duration) {
+        let interface = self.interface.clone();
+        self.cell.clone().spawn_refresh_task(
+            interval,
+            move || fetch_latest_handshake_timestamps(&interface),
+            |err| warn!("failed to refresh WireGuard latest-handshakes cache: {err}"),
+        );
+    }
+
+    pub(crate) async fn refresh(&self) -> Result<()> {
+        let interface = self.interface.clone();
+        self.cell
+            .refresh_blocking(move || fetch_latest_handshake_timestamps(&interface))
+            .await
+            .map_err(|err| anyhow::anyhow!("{err}"))?;
+        Ok(())
+    }
+
+    pub(crate) fn latest(&self, stale_timeout: Option<Duration>) -> Result<HandshakesWithAge> {
+        let snapshot = self.cell.get()?;
+        add_elapsed_time(snapshot.value(), stale_timeout)
+    }
+}
+
+fn fetch_latest_handshake_timestamps(interface: &str) -> Result<HandshakeTimestamps> {
+    /*
+    $wg show ds-gw-kvin1 latest-handshakes
+    eHBq6OjihPy1IZ2cFDomSesjeD+new7KNdWn9MHdQC8=    1730190589
+    SRuIdjZ1CkR54jJ1g7JC4cy9nxHPezXf2bZlkZHjFxE=    1732085583
+    YobeKV6YpmuTAQd0+Tx30Pe4JP12fPFwftC04Umt6Bw=    1731214390
+    9pgMHikM4onpoiNPJkya003BFAdzRMiD2WMDSMb64zo=    1731213050
+    oZppF/Rk7NgnuPkkfGUiBpY9HbThJvq3jACNGW2vnVA=    1731213485
+    3OxwGWcnC+4TZ31rnmDpfgbLBi8DCWdEk4k/7gFG5HU=    1732085521
+    */
+    let output = cmd_lib::run_fun!(wg show $interface latest-handshakes)?;
+    parse_latest_handshake_timestamps(&output)
+}
+
+fn parse_latest_handshake_timestamps(output: &str) -> Result<HandshakeTimestamps> {
+    let mut handshakes = BTreeMap::new();
+
+    for line in output.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.is_empty() {
+            continue;
+        }
+        if parts.len() != 2 {
+            bail!("invalid latest-handshakes line: {line:?}");
+        }
+
+        let pubkey = parts[0].trim().to_string();
+        let timestamp = parts[1]
+            .trim()
+            .parse::<u64>()
+            .context("invalid WireGuard latest-handshake timestamp")?;
+        handshakes.insert(pubkey, timestamp);
+    }
+
+    Ok(handshakes)
+}
+
+fn add_elapsed_time(
+    timestamps: &HandshakeTimestamps,
+    stale_timeout: Option<Duration>,
+) -> Result<HandshakesWithAge> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system time before Unix epoch")?;
+    let mut handshakes = BTreeMap::new();
+
+    for (pubkey, timestamp) in timestamps {
+        if *timestamp == 0 {
+            handshakes.insert(pubkey.clone(), (0, Duration::MAX));
+            continue;
+        }
+
+        let timestamp_duration = Duration::from_secs(*timestamp);
+        let elapsed = now.checked_sub(timestamp_duration).unwrap_or_default();
+        match stale_timeout {
+            Some(min_duration) if elapsed < min_duration => continue,
+            _ => (),
+        }
+        handshakes.insert(pubkey.clone(), (*timestamp, elapsed));
+    }
+
+    Ok(handshakes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_latest_handshake_timestamps() {
+        let handshakes = parse_latest_handshake_timestamps(
+            "pubkey-a 1730190589\n\
+             pubkey-b 0\n",
+        )
+        .unwrap();
+
+        assert_eq!(handshakes.get("pubkey-a"), Some(&1730190589));
+        assert_eq!(handshakes.get("pubkey-b"), Some(&0));
+    }
+}

--- a/gateway/test-run/TESTING.md
+++ b/gateway/test-run/TESTING.md
@@ -1,0 +1,187 @@
+# Gateway test plan
+
+This document records the local checks used for the gateway handshake-cache
+change. The goal is to verify three things:
+
+1. the generic `cached-cell` crate behaves correctly;
+2. existing gateway control-plane and WaveKV flows still work;
+3. the proxy data path does not call blocking `wg show latest-handshakes` per
+   request.
+
+## Prerequisites
+
+Run on Linux with:
+
+- Rust toolchain;
+- `sudo`, `ip`, `wg` / `wireguard-tools`;
+- `curl`, `openssl`, `python3`;
+- `wrk` for the performance test.
+
+The integration script creates temporary WireGuard interfaces named
+`wavekv-test1`, `wavekv-test2`, and `wavekv-test3`, so it needs root privileges.
+
+## Unit and build checks
+
+From the repository root:
+
+```bash
+cargo test -p cached-cell
+cargo test --manifest-path gateway/Cargo.toml
+cargo check --manifest-path gateway/Cargo.toml
+cargo clippy -- \
+  -D warnings \
+  -D clippy::expect_used \
+  -D clippy::unwrap_used \
+  --allow unused_variables
+```
+
+Expected result: all commands pass.
+
+## WaveKV / gateway integration test
+
+Build the gateway binary first:
+
+```bash
+cargo build --release --manifest-path gateway/Cargo.toml
+```
+
+Then run the integration suite:
+
+```bash
+cd gateway/test-run
+sudo -E GATEWAY_BIN="$(pwd)/../../target/release/dstack-gateway" ./test_suite.sh
+```
+
+The suite starts real gateway processes and exercises:
+
+- CVM registration through `POST /prpc/RegisterCvm` on the debug service;
+- admin RPCs such as `Admin.SetNodeUrl`, `Admin.SetNodeStatus`, and
+  `Admin.WaveKvStatus`;
+- WaveKV persistent and ephemeral sync between gateway nodes;
+- node restart, network partition recovery, periodic persistence, and node
+  up/down filtering.
+
+Expected result:
+
+```text
+Tests passed: 19
+```
+
+Important request paths covered by this suite:
+
+| Path | Purpose |
+| --- | --- |
+| `POST /prpc/RegisterCvm` | Register a CVM, allocate a WireGuard IP, update gateway state. |
+| `POST /prpc/Debug.Info` | Verify the debug service is available. |
+| `POST /prpc/Debug.GetSyncData` | Inspect peer/node/instance data synced through WaveKV. |
+| `POST /prpc/GetProxyState` | Compare in-memory proxy state with WaveKV state. |
+| `POST /prpc/Admin.SetNodeUrl` | Register peer gateway URLs. |
+| `POST /prpc/Admin.SetNodeStatus` | Mark nodes up/down and verify registration filtering. |
+| `POST /prpc/Admin.WaveKvStatus` | Inspect WaveKV store status. |
+| `POST /wavekv/sync/persistent` | Gateway-to-gateway persistent data sync. |
+| `POST /wavekv/sync/ephemeral` | Gateway-to-gateway last-seen/handshake/connection sync. |
+
+## Real proxy data-path smoke test
+
+The integration suite above validates registration and sync, but it does not
+open a client connection through the gateway proxy. For the proxy data path, use
+this shape:
+
+1. Start one `dstack-gateway` with debug/admin enabled and `insecure_skip_attestation = true`.
+2. Register a test CVM through the debug `RegisterCvm` RPC.
+3. Bind a local HTTPS backend to the allocated CVM IP, for example
+   `10.0.51.2:23143`.
+4. Serve a local DNS TXT response:
+
+   ```text
+   _dstack-app-address.proxy-flow.local TXT "proxyflow:23143"
+   ```
+
+5. Allow the backend port with `Admin.SetInstancePortPolicy` so the proxy data
+   path is not blocked by port-policy fail-close.
+6. Send a request through the proxy:
+
+   ```bash
+   curl -skf \
+     --connect-to proxy-flow.local:13114:127.0.0.1:13114 \
+     https://proxy-flow.local:13114/proxy-e2e
+   ```
+
+Expected response from the backend:
+
+```text
+proxy-e2e-ok path=/proxy-e2e
+```
+
+Expected gateway log shape:
+
+```text
+got sni: proxy-flow.local
+target address is proxyflow:23143
+connecting to 10.0.51.2:23143
+connected to 10.0.51.2:23143
+```
+
+This confirms the real data flow:
+
+```text
+client -> gateway proxy -> SNI parse -> DNS TXT lookup -> ProxyState selection -> backend TLS service
+```
+
+## Proxy performance / hot-path check
+
+The performance test uses the same real proxy data flow as the smoke test, with
+one extra control: put a temporary `wg` wrapper earlier in `PATH` for the gateway
+process. The wrapper delegates normal commands to `/usr/bin/wg`, but for
+
+```text
+wg show <iface> latest-handshakes
+```
+
+it returns a fixed test public key and records the call. This verifies that the
+proxy hot path does not execute blocking `wg show` for every request.
+
+Use `wrk` for three measurements:
+
+```bash
+# Direct backend baseline.
+wrk -t4 -c64 -d15s https://10.0.62.2:23243/bench
+
+# Gateway proxy with keep-alive.
+wrk -t4 -c64 -d15s https://proxy-perf.local:13214/bench
+
+# Gateway proxy with new TLS connections.
+wrk -t4 -c32 -d10s -H 'Connection: close' \
+  https://proxy-perf.local:13214/bench-close
+```
+
+Reference result from the local PR run:
+
+```text
+direct backend keep-alive:        71507 req/s, avg latency 1.14ms
+gateway proxy keep-alive:         33842 req/s, avg latency 8.83ms
+gateway proxy connection-close:     874 req/s, avg latency 33.45ms
+```
+
+The same run handled more than 500k proxy keep-alive requests. The `wg` wrapper
+recorded:
+
+```text
+wg show latest-handshakes: 7
+wg syncconf: 3
+```
+
+The important assertion is the call count: `wg show latest-handshakes` is only
+used by startup/preload and the periodic refresh task, not once per proxied
+request.
+
+## PR CI
+
+Check GitHub Actions before merging:
+
+```bash
+gh pr checks <PR_NUMBER> --repo Dstack-TEE/dstack --watch=false
+```
+
+Expected result: all required checks pass, including `gateway`, `rust-checks`,
+`prek`, `reuse-lint`, and CodeQL.

--- a/gateway/test-run/test_suite.sh
+++ b/gateway/test-run/test_suite.sh
@@ -18,7 +18,7 @@ stty -echoctl 2>/dev/null || true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-GATEWAY_BIN="/home/kvin/sdc/home/wavekv/dstack/target/release/dstack-gateway"
+GATEWAY_BIN="${GATEWAY_BIN:-${SCRIPT_DIR}/../../target/release/dstack-gateway}"
 RUN_DIR="run"
 CERTS_DIR="$RUN_DIR/certs"
 CA_CERT="$CERTS_DIR/gateway-ca.cert"
@@ -95,6 +95,7 @@ address = "127.0.0.1:${debug_port}"
 [core.admin]
 enabled = true
 address = "127.0.0.1:${admin_port}"
+insecure_no_auth = true
 
 [core.sync]
 enabled = true
@@ -357,7 +358,7 @@ import sys, json
 try:
     d = json.load(sys.stdin)
     print(len(d.get('peer_addrs', [])))
-except:
+except Exception:
     print(0)
 " 2>/dev/null
 }
@@ -372,7 +373,7 @@ import sys, json
 try:
     d = json.load(sys.stdin)
     print(len(d.get('nodes', [])))
-except:
+except Exception:
     print(0)
 " 2>/dev/null
 }
@@ -387,7 +388,7 @@ import sys, json
 try:
     d = json.load(sys.stdin)
     print(len(d.get('instances', [])))
-except:
+except Exception:
     print(0)
 " 2>/dev/null
 }
@@ -411,7 +412,7 @@ import sys, json
 try:
     d = json.load(sys.stdin)
     print(len(d.get('instances', [])))
-except:
+except Exception:
     print(0)
 " 2>/dev/null
 }
@@ -1547,7 +1548,7 @@ try:
             print(pa.get('url', ''))
             sys.exit(0)
     print('')
-except:
+except Exception:
     print('')
 " 2>/dev/null
 }
@@ -1722,7 +1723,7 @@ try:
         if gw.get('id') == 2:
             sys.exit(0)
     sys.exit(1)
-except:
+except Exception:
     sys.exit(1)
 " && echo "yes" || echo "no")
 
@@ -1753,7 +1754,7 @@ try:
         if gw.get('id') == 2:
             sys.exit(0)
     sys.exit(1)
-except:
+except Exception:
     sys.exit(1)
 " && echo "yes" || echo "no")
 


### PR DESCRIPTION
## Summary
- Add a reusable `cached-cell` crate with `TtlCell<T>`: a small OnceCell/LazyCell-style abstraction for TTL-bound cached snapshots.
- `TtlCell` owns the generic mechanics: storage, freshness checks, stale reads, `spawn_blocking` refresh, and one-shot periodic refresh scheduling.
- Keep WireGuard-specific logic in gateway: `LatestHandshakesCache` now only defines how to fetch/parse `wg show <iface> latest-handshakes` and delegates caching/expiration to `cached-cell`.
- Gateway hot path reads a fresh snapshot instead of running the blocking `wg show` command under `ProxyState` lock.

## Tests
- `cargo check --manifest-path gateway/Cargo.toml`
- `cargo test -p cached-cell`
- `cargo test --manifest-path gateway/Cargo.toml handshakes -- --nocapture`
