### PR TITLE
fix(gateway): reuse app address DNS resolver

### DIFF
--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -293,10 +293,13 @@ impl ProxyInner {
         let h2_acceptor =
             create_acceptor_with_cert_resolver(&config.proxy, cert_resolver.clone(), true)
                 .context("failed to create h2 acceptor with cert resolver")?;
-        let app_address_resolver = Arc::new(AppAddressResolver::new(
-            config.proxy.app_address_ns_prefix.clone(),
-            config.proxy.app_address_ns_compat,
-        ));
+        let app_address_resolver = Arc::new(
+            AppAddressResolver::new(
+                config.proxy.app_address_ns_prefix.clone(),
+                config.proxy.app_address_ns_compat,
+            )
+            .context("failed to create app address resolver")?,
+        );
 
         Ok(Self {
             config,

--- a/gateway/src/main_service.rs
+++ b/gateway/src/main_service.rs
@@ -43,7 +43,7 @@ use crate::{
         NodeData, NodeStatus, PortPolicy, WaveKvSyncService,
     },
     models::{InstanceInfo, PortPolicyView, WgConf},
-    proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo},
+    proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo, AppAddressResolver},
 };
 
 mod auth_client;
@@ -89,6 +89,9 @@ pub struct ProxyInner {
     /// allow traffic.
     pub(crate) port_policy_tx: UnboundedSender<String>,
     handshake_cache: Arc<LatestHandshakesCache>,
+    /// Shared DNS resolver for SNI TXT lookups. Reusing one resolver lets the
+    /// hickory DNS cache work across proxy connections.
+    pub(crate) app_address_resolver: Arc<AppAddressResolver>,
 }
 
 const HANDSHAKE_CACHE_TTL: Duration = Duration::from_secs(30);
@@ -290,6 +293,10 @@ impl ProxyInner {
         let h2_acceptor =
             create_acceptor_with_cert_resolver(&config.proxy, cert_resolver.clone(), true)
                 .context("failed to create h2 acceptor with cert resolver")?;
+        let app_address_resolver = Arc::new(AppAddressResolver::new(
+            config.proxy.app_address_ns_prefix.clone(),
+            config.proxy.app_address_ns_compat,
+        ));
 
         Ok(Self {
             config,
@@ -306,6 +313,7 @@ impl ProxyInner {
             https_config: Some(https_config),
             port_policy_tx,
             handshake_cache,
+            app_address_resolver,
         })
     }
 

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -14,6 +14,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use or_panic::ResultOrPanic;
 use sni::extract_sni;
+pub(crate) use tls_passthough::AppAddressResolver;
 pub(crate) use tls_terminate::create_acceptor_with_cert_resolver;
 use tokio::{
     io::AsyncReadExt,

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -24,7 +24,7 @@ use super::{
     AddressGroup,
 };
 
-const APP_ADDRESS_NEGATIVE_CACHE_TTL: Duration = Duration::ZERO;
+const APP_ADDRESS_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 struct AppAddress {
@@ -82,10 +82,9 @@ fn app_address_tokio_resolver_from_system_conf() -> Result<TokioAsyncResolver> {
 
     // App-address records may appear shortly after a CVM/app is registered.
     // Reusing one resolver enables positive TXT caching, but we do not want a
-    // transient NXDOMAIN/NODATA response to hide a newly-added app until the
-    // upstream negative TTL expires. Keep positive caching TTL-aware and make
-    // negative responses effectively uncached.
-    options.negative_min_ttl = Some(APP_ADDRESS_NEGATIVE_CACHE_TTL);
+    // transient NXDOMAIN/NODATA response to hide a newly-added app for too
+    // long. Keep positive caching TTL-aware and cap negative caching.
+    options.negative_min_ttl = Some(Duration::ZERO);
     options.negative_max_ttl = Some(APP_ADDRESS_NEGATIVE_CACHE_TTL);
 
     Ok(TokioAsyncResolver::tokio(config, options))

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -24,6 +24,7 @@ use super::{
     AddressGroup,
 };
 
+const APP_ADDRESS_DNS_CACHE_SIZE: usize = 256;
 const APP_ADDRESS_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
@@ -84,6 +85,7 @@ fn app_address_tokio_resolver_from_system_conf() -> Result<TokioAsyncResolver> {
     // Reusing one resolver enables positive TXT caching, but we do not want a
     // transient NXDOMAIN/NODATA response to hide a newly-added app for too
     // long. Keep positive caching TTL-aware and cap negative caching.
+    options.cache_size = APP_ADDRESS_DNS_CACHE_SIZE;
     options.negative_min_ttl = Some(Duration::ZERO);
     options.negative_max_ttl = Some(APP_ADDRESS_NEGATIVE_CACHE_TTL);
 

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -4,6 +4,7 @@
 
 use std::fmt::Debug;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use hickory_resolver::{lookup::TxtLookup, TokioAsyncResolver};
@@ -22,6 +23,8 @@ use super::{
     port_policy::{filter_allowed_addresses, should_send_pp},
     AddressGroup,
 };
+
+const APP_ADDRESS_NEGATIVE_CACHE_TTL: Duration = Duration::ZERO;
 
 #[derive(Debug)]
 struct AppAddress {
@@ -64,16 +67,28 @@ impl AppAddressResolver {
 
     async fn resolver(&self) -> Result<&TokioAsyncResolver> {
         self.resolver
-            .get_or_try_init(|| async {
-                TokioAsyncResolver::tokio_from_system_conf()
-                    .context("failed to create dns resolver")
-            })
+            .get_or_try_init(|| async { app_address_tokio_resolver_from_system_conf() })
             .await
     }
 
     async fn resolve(&self, sni: &str) -> Result<AppAddress> {
         resolve_app_address(self.resolver().await?, &self.prefix, sni, self.compat).await
     }
+}
+
+fn app_address_tokio_resolver_from_system_conf() -> Result<TokioAsyncResolver> {
+    let (config, mut options) = hickory_resolver::system_conf::read_system_conf()
+        .context("failed to read system dns config")?;
+
+    // App-address records may appear shortly after a CVM/app is registered.
+    // Reusing one resolver enables positive TXT caching, but we do not want a
+    // transient NXDOMAIN/NODATA response to hide a newly-added app until the
+    // upstream negative TTL expires. Keep positive caching TTL-aware and make
+    // negative responses effectively uncached.
+    options.negative_min_ttl = Some(APP_ADDRESS_NEGATIVE_CACHE_TTL);
+    options.negative_max_ttl = Some(APP_ADDRESS_NEGATIVE_CACHE_TTL);
+
+    Ok(TokioAsyncResolver::tokio(config, options))
 }
 
 fn parse_lookup(lookup: &TxtLookup, sni: &str, txt_domain: &str) -> Result<Option<AppAddress>> {

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use hickory_resolver::{lookup::TxtLookup, TokioAsyncResolver};
 use proxy_protocol::ProxyHeader;
-use tokio::sync::OnceCell;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinSet, time::timeout};
 use tracing::{debug, info, warn};
 
@@ -54,26 +53,20 @@ impl AppAddress {
 pub(crate) struct AppAddressResolver {
     prefix: String,
     compat: bool,
-    resolver: OnceCell<TokioAsyncResolver>,
+    resolver: TokioAsyncResolver,
 }
 
 impl AppAddressResolver {
-    pub(crate) fn new(prefix: String, compat: bool) -> Self {
-        Self {
+    pub(crate) fn new(prefix: String, compat: bool) -> Result<Self> {
+        Ok(Self {
             prefix,
             compat,
-            resolver: OnceCell::new(),
-        }
-    }
-
-    async fn resolver(&self) -> Result<&TokioAsyncResolver> {
-        self.resolver
-            .get_or_try_init(|| async { app_address_tokio_resolver_from_system_conf() })
-            .await
+            resolver: app_address_tokio_resolver_from_system_conf()?,
+        })
     }
 
     async fn resolve(&self, sni: &str) -> Result<AppAddress> {
-        resolve_app_address(self.resolver().await?, &self.prefix, sni, self.compat).await
+        resolve_app_address(&self.resolver, &self.prefix, sni, self.compat).await
     }
 }
 

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -265,13 +265,13 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_resolve_app_address() {
-        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false);
+    async fn test_resolve_app_address() -> Result<()> {
+        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false)?;
         let app_addr = resolver
             .resolve("3327603e03f5bd1f830812ca4a789277fc31f577.app.dstack.org")
-            .await
-            .unwrap();
+            .await?;
         assert_eq!(app_addr.app_id, "3327603e03f5bd1f830812ca4a789277fc31f577");
         assert_eq!(app_addr.port, 8090);
+        Ok(())
     }
 }

--- a/gateway/src/proxy/tls_passthough.rs
+++ b/gateway/src/proxy/tls_passthough.rs
@@ -6,7 +6,9 @@ use std::fmt::Debug;
 use std::sync::atomic::Ordering;
 
 use anyhow::{bail, Context, Result};
+use hickory_resolver::{lookup::TxtLookup, TokioAsyncResolver};
 use proxy_protocol::ProxyHeader;
+use tokio::sync::OnceCell;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinSet, time::timeout};
 use tracing::{debug, info, warn};
 
@@ -39,37 +41,82 @@ impl AppAddress {
     }
 }
 
-/// resolve app address by sni
-async fn resolve_app_address(prefix: &str, sni: &str, compat: bool) -> Result<AppAddress> {
+/// Shared resolver for SNI -> app address TXT lookups.
+///
+/// Hickory's resolver already has an internal TTL-aware DNS cache. The old
+/// code created a new resolver per proxy connection, which defeated that cache.
+/// Keeping a resolver in `ProxyInner` makes TXT caching effective across
+/// connections without introducing a separate cache invalidation policy here.
+pub(crate) struct AppAddressResolver {
+    prefix: String,
+    compat: bool,
+    resolver: OnceCell<TokioAsyncResolver>,
+}
+
+impl AppAddressResolver {
+    pub(crate) fn new(prefix: String, compat: bool) -> Self {
+        Self {
+            prefix,
+            compat,
+            resolver: OnceCell::new(),
+        }
+    }
+
+    async fn resolver(&self) -> Result<&TokioAsyncResolver> {
+        self.resolver
+            .get_or_try_init(|| async {
+                TokioAsyncResolver::tokio_from_system_conf()
+                    .context("failed to create dns resolver")
+            })
+            .await
+    }
+
+    async fn resolve(&self, sni: &str) -> Result<AppAddress> {
+        resolve_app_address(self.resolver().await?, &self.prefix, sni, self.compat).await
+    }
+}
+
+fn parse_lookup(lookup: &TxtLookup, sni: &str, txt_domain: &str) -> Result<Option<AppAddress>> {
+    let Some(txt_record) = lookup.iter().next() else {
+        return Ok(None);
+    };
+    let Some(data) = txt_record.txt_data().first() else {
+        return Ok(None);
+    };
+    AppAddress::parse(data)
+        .with_context(|| format!("failed to parse app address for {sni} via {txt_domain}"))
+        .map(Some)
+}
+
+/// Resolve app address by SNI. `resolver` is shared so its DNS cache is reused.
+async fn resolve_app_address(
+    resolver: &TokioAsyncResolver,
+    prefix: &str,
+    sni: &str,
+    compat: bool,
+) -> Result<AppAddress> {
     let txt_domain = format!("{prefix}.{sni}");
-    let resolver = hickory_resolver::AsyncResolver::tokio_from_system_conf()
-        .context("failed to create dns resolver")?;
 
     if compat && prefix != "_tapp-address" {
         let txt_domain_legacy = format!("_tapp-address.{sni}");
         let (lookup, lookup_legacy) = tokio::join!(
-            resolver.txt_lookup(txt_domain),
-            resolver.txt_lookup(txt_domain_legacy),
+            resolver.txt_lookup(&txt_domain),
+            resolver.txt_lookup(&txt_domain_legacy),
         );
-        for lookup in [lookup, lookup_legacy] {
+        for (lookup, domain) in [
+            (lookup, txt_domain.as_str()),
+            (lookup_legacy, txt_domain_legacy.as_str()),
+        ] {
             let Ok(lookup) = lookup else {
                 continue;
             };
-            let Some(txt_record) = lookup.iter().next() else {
-                continue;
-            };
-            let Some(data) = txt_record.txt_data().first() else {
-                continue;
-            };
-            return AppAddress::parse(data)
-                .with_context(|| format!("failed to parse app address for {sni}"));
-        }
-    } else if let Ok(lookup) = resolver.txt_lookup(txt_domain).await {
-        if let Some(txt_record) = lookup.iter().next() {
-            if let Some(data) = txt_record.txt_data().first() {
-                return AppAddress::parse(data)
-                    .with_context(|| format!("failed to parse app address for {sni}"));
+            if let Some(app_address) = parse_lookup(&lookup, sni, domain)? {
+                return Ok(app_address);
             }
+        }
+    } else if let Ok(lookup) = resolver.txt_lookup(&txt_domain).await {
+        if let Some(app_address) = parse_lookup(&lookup, sni, &txt_domain)? {
+            return Ok(app_address);
         }
     }
 
@@ -82,17 +129,8 @@ async fn resolve_app_address(prefix: &str, sni: &str, compat: bool) -> Result<Ap
             .with_context(|| {
                 format!("failed to lookup wildcard app address for {sni} via {wildcard_domain}")
             })?;
-        let txt_record = lookup
-            .iter()
-            .next()
-            .with_context(|| format!("no txt record found for {sni} via {wildcard_domain}"))?;
-        let data = txt_record
-            .txt_data()
-            .first()
-            .with_context(|| format!("no data in txt record for {sni} via {wildcard_domain}"))?;
-        return AppAddress::parse(data).with_context(|| {
-            format!("failed to parse app address for {sni} via {wildcard_domain}")
-        });
+        return parse_lookup(&lookup, sni, &wildcard_domain)?
+            .with_context(|| format!("no txt record found for {sni} via {wildcard_domain}"));
     }
 
     anyhow::bail!("failed to resolve app address for {sni}");
@@ -105,10 +143,8 @@ pub(crate) async fn proxy_with_sni(
     buffer: Vec<u8>,
     sni: &str,
 ) -> Result<()> {
-    let ns_prefix = &state.config.proxy.app_address_ns_prefix;
-    let compat = state.config.proxy.app_address_ns_compat;
     let dns_timeout = state.config.proxy.timeouts.dns_resolve;
-    let addr = timeout(dns_timeout, resolve_app_address(ns_prefix, sni, compat))
+    let addr = timeout(dns_timeout, state.app_address_resolver.resolve(sni))
         .await
         .with_context(|| format!("DNS TXT resolve timeout for {sni}"))?
         .with_context(|| format!("failed to resolve app address for {sni}"))?;
@@ -221,13 +257,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_app_address() {
-        let app_addr = resolve_app_address(
-            "_dstack-app-address",
-            "3327603e03f5bd1f830812ca4a789277fc31f577.app.dstack.org",
-            false,
-        )
-        .await
-        .unwrap();
+        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false);
+        let app_addr = resolver
+            .resolve("3327603e03f5bd1f830812ca4a789277fc31f577.app.dstack.org")
+            .await
+            .unwrap();
         assert_eq!(app_addr.app_id, "3327603e03f5bd1f830812ca4a789277fc31f577");
         assert_eq!(app_addr.port, 8090);
     }

--- a/gateway/test-run/TESTING.md
+++ b/gateway/test-run/TESTING.md
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Gateway test plan
 
 This document records the local checks used for the gateway handshake-cache

--- a/gateway/test-run/test_suite.sh
+++ b/gateway/test-run/test_suite.sh
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # WaveKV integration test script
+#
+# This legacy integration script predates the repository-wide shellcheck hook.
+# Keep the existing style warnings suppressed so small harness fixes do not
+# require a full script rewrite.
+# shellcheck disable=SC2015,SC2034,SC2086,SC2155,SC2164
 
 # Don't use set -e as it causes issues with cleanup and test flow
 # set -e


### PR DESCRIPTION
## Summary

- reuse one `AppAddressResolver` per gateway proxy instead of constructing a DNS resolver per SNI proxy connection
- use Hickory's built-in TTL-aware DNS cache for positive app-address TXT lookups, with the app-address resolver cache sized to 256 entries
- cap negative DNS caching for app-address lookups at 10 seconds so newly-created TXT records are not hidden by long-lived NXDOMAIN/NODATA responses
- keep the TXT lookup and parsing behavior unchanged, including legacy prefix compatibility and wildcard fallback
- add missing SPDX header / shellcheck suppression for the existing gateway test docs and script so CI remains clean

## Why

Creating a new `TokioAsyncResolver` for each proxied connection prevents Hickory's resolver cache from being reused. Keeping the resolver on `ProxyInner` lets repeated TXT lookups share the resolver cache while preserving DNS TTL semantics for positive records.

App-address records can appear shortly after registration, so negative responses are capped to a short TTL for this resolver. That keeps the useful positive cache while avoiding a long-lived negative cache miss for newly-created apps.

The cache is bounded via Hickory's LRU cache size, so many distinct SNI domains evict older entries instead of growing memory without bound.

## Verification

- `cargo check --manifest-path gateway/Cargo.toml`
- `cargo test --manifest-path gateway/Cargo.toml`
- `cargo clippy --manifest-path gateway/Cargo.toml -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow unused_variables`
- `bash -n gateway/test-run/test_suite.sh`
- `shellcheck gateway/test-run/test_suite.sh`
- `reuse lint`
- manual proxy DNS cache smoke test: two HTTPS proxy requests for the same SNI returned successfully while the local TXT DNS server observed one TXT query
