### PR TITLE
guest: enforce app compose version policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "safe-write",
  "schnorrkel",
  "scopeguard",
+ "semver 1.0.28",
  "serde",
  "serde-human-bytes",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ scale = { version = "3.7.4", package = "parity-scale-codec", features = [
 ] }
 serde = { version = "1.0.228", features = ["derive"], default-features = false }
 serde-human-bytes = "0.1.2"
+semver = "1.0.28"
 serde_jcs = "0.2.0"
 rmp-serde = "1.3.1"
 serde_json = { version = "1.0.140", default-features = false }

--- a/dstack-attest/src/attestation.rs
+++ b/dstack-attest/src/attestation.rs
@@ -1048,6 +1048,21 @@ mod compatibility_tests {
     }
 
     #[test]
+    fn attestation_mode_deserializes_canonical_names() {
+        let parse = |value| serde_json::from_str::<AttestationMode>(value).unwrap();
+        assert_eq!(parse(r#""dstack-tdx""#), AttestationMode::DstackTdx);
+        assert_eq!(parse(r#""dstack-gcp-tdx""#), AttestationMode::DstackGcpTdx);
+        assert_eq!(
+            parse(r#""dstack-amd-sev-snp""#),
+            AttestationMode::DstackAmdSevSnp
+        );
+        assert_eq!(
+            parse(r#""dstack-nitro-enclave""#),
+            AttestationMode::DstackNitroEnclave
+        );
+    }
+
+    #[test]
     fn attestation_quote_scale_discriminants_preserve_existing_wire_values() {
         let gcp = AttestationQuote::DstackGcpTdx(DstackGcpTdxQuote {
             tdx_quote: TdxQuote {

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -67,7 +67,8 @@ impl TdxAttestationVariant {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct AppCompose {
-    pub manifest_version: u32,
+    #[serde(deserialize_with = "deserialize_manifest_version")]
+    pub manifest_version: String,
     pub name: String,
     // Deprecated
     #[serde(default)]
@@ -105,6 +106,98 @@ pub struct AppCompose {
     /// optional port whitelist).
     #[serde(default)]
     pub port_policy: PortPolicy,
+    /// Guest-side requirements enforced by guests that understand this field.
+    ///
+    /// Use manifest_version "3" (string) when setting this field so older
+    /// guests, which only accept numeric manifest versions, fail closed instead
+    /// of silently ignoring the requirements.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements: Option<Requirements>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Requirements {
+    /// OS-version requirement parsed with Rust semver requirement semantics,
+    /// e.g. `">=0.6.0"` or `">=0.6.0, <0.7.0"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os_version: Option<String>,
+    /// Allowed attestation platforms. Omitted means any supported platform;
+    /// an explicit empty list means no platform is allowed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platforms: Option<Vec<String>>,
+}
+
+impl Requirements {
+    pub fn is_empty(&self) -> bool {
+        self.os_version.is_none() && self.platforms.is_none()
+    }
+}
+
+fn deserialize_manifest_version<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ManifestVersionVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ManifestVersionVisitor {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a string manifest version, or legacy numeric 1/2")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            parse_manifest_version_string(value).map_err(E::custom)
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            self.visit_str(&value)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            match value {
+                1 | 2 => Ok(value.to_string()),
+                _ => Err(E::custom(
+                    "numeric manifest_version is only supported for legacy versions 1 and 2; use a string for newer versions",
+                )),
+            }
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            let value = u64::try_from(value)
+                .map_err(|_| E::custom("manifest_version must be a positive integer"))?;
+            self.visit_u64(value)
+        }
+    }
+
+    deserializer.deserialize_any(ManifestVersionVisitor)
+}
+
+fn parse_manifest_version_string(value: &str) -> Result<String, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("manifest_version must not be empty".to_string());
+    }
+    let parsed = value.parse::<u32>().map_err(|_| {
+        format!("manifest_version must be a positive integer string, got {value:?}")
+    })?;
+    if parsed == 0 {
+        return Err("manifest_version must be greater than 0".to_string());
+    }
+    Ok(parsed.to_string())
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -180,6 +273,10 @@ pub struct DockerConfig {
 }
 
 impl AppCompose {
+    pub fn manifest_version_u32(&self) -> Option<u32> {
+        self.manifest_version.parse().ok()
+    }
+
     pub fn feature_enabled(&self, feature: &str) -> bool {
         self.features.contains(&feature.to_string())
     }
@@ -205,6 +302,106 @@ impl AppCompose {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod app_compose_tests {
+    use super::*;
+
+    fn parse_compose(manifest_version: serde_json::Value) -> serde_json::Result<AppCompose> {
+        serde_json::from_value(serde_json::json!({
+            "manifest_version": manifest_version,
+            "name": "test",
+            "runner": "docker-compose"
+        }))
+    }
+
+    #[test]
+    fn manifest_version_accepts_string_versions() {
+        let compose = parse_compose(serde_json::json!("3")).unwrap();
+        assert_eq!(compose.manifest_version, "3");
+        assert_eq!(compose.manifest_version_u32(), Some(3));
+    }
+
+    #[test]
+    fn manifest_version_accepts_legacy_numeric_1_and_2() {
+        assert_eq!(
+            parse_compose(serde_json::json!(1))
+                .unwrap()
+                .manifest_version,
+            "1"
+        );
+        assert_eq!(
+            parse_compose(serde_json::json!(2))
+                .unwrap()
+                .manifest_version,
+            "2"
+        );
+    }
+
+    #[test]
+    fn manifest_version_rejects_new_numeric_versions() {
+        let err = parse_compose(serde_json::json!(3)).unwrap_err();
+        assert!(err.to_string().contains("legacy versions 1 and 2"));
+    }
+
+    #[test]
+    fn requirements_support_os_version_and_platforms() {
+        let compose: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {
+                "os_version": ">=0.6.1",
+                "platforms": ["dstack-gcp-tdx", "dstack-tdx"]
+            }
+        }))
+        .unwrap();
+        let requirements = compose.requirements.as_ref().unwrap();
+        assert_eq!(requirements.os_version.as_deref(), Some(">=0.6.1"));
+        assert_eq!(
+            requirements.platforms,
+            Some(vec!["dstack-gcp-tdx".to_string(), "dstack-tdx".to_string()])
+        );
+
+        let err = serde_json::from_value::<AppCompose>(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {
+                "os_version_policy": ">=0.6.1"
+            }
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn requirements_distinguish_omitted_and_empty_platforms() {
+        let omitted: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {}
+        }))
+        .unwrap();
+        let requirements = omitted.requirements.as_ref().unwrap();
+        assert_eq!(requirements.platforms, None);
+        assert!(requirements.is_empty());
+
+        let explicit_empty: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {
+                "platforms": []
+            }
+        }))
+        .unwrap();
+        let requirements = explicit_empty.requirements.as_ref().unwrap();
+        assert_eq!(requirements.platforms, Some(vec![]));
+        assert!(!requirements.is_empty());
     }
 }
 

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -197,6 +197,11 @@ fn parse_manifest_version_string(value: &str) -> Result<String, String> {
     if parsed == 0 {
         return Err("manifest_version must be greater than 0".to_string());
     }
+    if parsed.to_string() != value {
+        return Err(format!(
+            "manifest_version must be a canonical integer string, got {value:?}"
+        ));
+    }
     Ok(parsed.to_string())
 }
 
@@ -344,6 +349,28 @@ mod app_compose_tests {
     fn manifest_version_rejects_new_numeric_versions() {
         let err = parse_compose(serde_json::json!(3)).unwrap_err();
         assert!(err.to_string().contains("legacy versions 1 and 2"));
+    }
+
+    #[test]
+    fn manifest_version_rejects_invalid_numeric_values() {
+        let err = parse_compose(serde_json::json!(0)).unwrap_err();
+        assert!(err.to_string().contains("legacy versions 1 and 2"));
+        let err = parse_compose(serde_json::json!(-1)).unwrap_err();
+        assert!(err.to_string().contains("positive integer"));
+        assert!(parse_compose(serde_json::json!(2.5)).is_err());
+    }
+
+    #[test]
+    fn manifest_version_rejects_non_canonical_strings() {
+        let err = parse_compose(serde_json::json!("0")).unwrap_err();
+        assert!(err.to_string().contains("greater than 0"));
+        let err = parse_compose(serde_json::json!("03")).unwrap_err();
+        assert!(err.to_string().contains("canonical integer string"));
+        let err = parse_compose(serde_json::json!("+3")).unwrap_err();
+        assert!(err.to_string().contains("canonical integer string"));
+        let err = parse_compose(serde_json::json!("")).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+        assert!(parse_compose(serde_json::json!("3.0")).is_err());
     }
 
     #[test]

--- a/dstack-util/Cargo.toml
+++ b/dstack-util/Cargo.toml
@@ -23,6 +23,7 @@ scale = { workspace = true, features = ["derive"] }
 schnorrkel.workspace = true
 serde.workspace = true
 serde-human-bytes.workspace = true
+semver.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -797,9 +797,9 @@ fn verify_app_compose_policy(app_compose: &AppCompose) -> Result<()> {
 
 fn verify_manifest_feature_requirements(app_compose: &AppCompose) -> Result<()> {
     let manifest_version = verify_manifest_version(app_compose)?;
-    if app_compose.requirements.is_some() && manifest_version != MANIFEST_VERSION_3 {
+    if app_compose.requirements.is_some() && manifest_version < MANIFEST_VERSION_3 {
         bail!(
-            "requirements requires manifest_version == {MANIFEST_VERSION_3}; use string manifest_version \"{MANIFEST_VERSION_3}\" so older guests fail closed"
+            "requirements requires manifest_version >= {MANIFEST_VERSION_3}; use string manifest_version \"{MANIFEST_VERSION_3}\" so older guests fail closed"
         );
     }
     Ok(())
@@ -900,16 +900,21 @@ fn os_release_value(content: &str, key: &str) -> Option<String> {
 
 fn unquote_os_release_value(value: &str) -> String {
     let value = value.trim();
-    let bytes = value.as_bytes();
-    if bytes.len() >= 2
-        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
-            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
-    {
-        let inner = &value[1..value.len() - 1];
-        return inner
-            .replace("\\\"", "\"")
-            .replace("\\'", "'")
-            .replace("\\\\", "\\");
+    if let Some(inner) = value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
+        // Double-quoted: a backslash escapes the next character.
+        let mut unescaped = String::with_capacity(inner.len());
+        let mut chars = inner.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '\\' => unescaped.push(chars.next().unwrap_or('\\')),
+                _ => unescaped.push(c),
+            }
+        }
+        return unescaped;
+    }
+    if let Some(inner) = value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')) {
+        // Single-quoted: shell single quotes have no escape sequences.
+        return inner.to_string();
     }
     value.to_string()
 }
@@ -2203,4 +2208,20 @@ VERSION_ID="0.6.1"
         os_release_value(content, "VERSION_ID").as_deref(),
         Some("0.6.1")
     );
+}
+
+#[test]
+fn test_unquote_os_release_value_handles_quoting_styles() {
+    assert_eq!(unquote_os_release_value("0.6.1"), "0.6.1");
+    assert_eq!(unquote_os_release_value("\"0.6.1\""), "0.6.1");
+    assert_eq!(unquote_os_release_value("'0.6.1'"), "0.6.1");
+    // Double-quoted: backslash escapes the next character.
+    assert_eq!(unquote_os_release_value(r#""a\"b""#), "a\"b");
+    assert_eq!(unquote_os_release_value(r#""a\\b""#), r"a\b");
+    assert_eq!(unquote_os_release_value(r#""a\\\"b""#), r#"a\"b"#);
+    // Single-quoted: no escape sequences.
+    assert_eq!(unquote_os_release_value(r"'a\\b'"), r"a\\b");
+    // Unbalanced/degenerate quotes are returned verbatim.
+    assert_eq!(unquote_os_release_value("\""), "\"");
+    assert_eq!(unquote_os_release_value("\"a"), "\"a");
 }

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -38,6 +38,7 @@ use ra_tls::{
 use rand::Rng as _;
 use safe_write::safe_write;
 use scopeguard::defer;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -372,6 +373,8 @@ const GATEWAY_CACHE_PATH: &str = "/run/dstack/gateway-cache.json";
 const WG_CONFIG_PATH: &str = "/etc/wireguard/dstack-wg0.conf";
 /// Certificate validity period in seconds (10 days)
 const CERT_VALIDITY_SECS: u64 = 10 * 24 * 3600;
+const MAX_SUPPORTED_MANIFEST_VERSION: u32 = 3;
+const MANIFEST_VERSION_3: u32 = 3;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct GatewayKeyStore {
@@ -759,6 +762,158 @@ fn emit_key_provider_info(provider_info: &KeyProviderInfo) -> Result<()> {
     Ok(())
 }
 
+fn verify_manifest_version(app_compose: &AppCompose) -> Result<u32> {
+    let manifest_version = app_compose
+        .manifest_version_u32()
+        .context("Invalid manifest_version")?;
+    if manifest_version > MAX_SUPPORTED_MANIFEST_VERSION {
+        bail!(
+            "Unsupported manifest_version: {manifest_version}, max supported: {MAX_SUPPORTED_MANIFEST_VERSION}"
+        );
+    }
+    Ok(manifest_version)
+}
+
+fn verify_app_compose_policy(app_compose: &AppCompose) -> Result<()> {
+    verify_manifest_feature_requirements(app_compose)?;
+    let Some(requirements) = app_compose.requirements.as_ref() else {
+        return Ok(());
+    };
+    if requirements.os_version.is_some() {
+        let current_os_version =
+            read_current_os_version().context("Failed to read current dstack OS version")?;
+        verify_os_version_requirement(app_compose, &current_os_version)?;
+    }
+    if let Some(platforms) = requirements.platforms.as_deref() {
+        if platforms.is_empty() {
+            bail!("Unsupported attestation platform: requirements.platforms is empty");
+        }
+        let current_platform =
+            AttestationMode::detect().context("Failed to detect current attestation platform")?;
+        verify_platform_requirements(app_compose, current_platform)?;
+    }
+    Ok(())
+}
+
+fn verify_manifest_feature_requirements(app_compose: &AppCompose) -> Result<()> {
+    let manifest_version = verify_manifest_version(app_compose)?;
+    if app_compose.requirements.is_some() && manifest_version != MANIFEST_VERSION_3 {
+        bail!(
+            "requirements requires manifest_version == {MANIFEST_VERSION_3}; use string manifest_version \"{MANIFEST_VERSION_3}\" so older guests fail closed"
+        );
+    }
+    Ok(())
+}
+
+fn verify_os_version_requirement(app_compose: &AppCompose, current_os_version: &str) -> Result<()> {
+    let Some(requirements) = app_compose.requirements.as_ref() else {
+        return Ok(());
+    };
+    let Some(os_version) = requirements.os_version.as_deref() else {
+        return Ok(());
+    };
+    let os_version_req = VersionReq::parse(os_version)
+        .with_context(|| format!("Invalid requirements.os_version: {os_version}"))?;
+    let current_os_version = Version::parse(current_os_version)
+        .with_context(|| format!("Invalid current dstack OS version: {current_os_version}"))?;
+    if !os_version_req.matches(&current_os_version) {
+        bail!(
+            "Unsupported dstack OS version: current {current_os_version}, required {os_version_req}"
+        );
+    }
+    info!(
+        "dstack OS version requirement satisfied: current={}, requirement={}",
+        current_os_version, os_version_req
+    );
+    Ok(())
+}
+
+fn verify_platform_requirements(
+    app_compose: &AppCompose,
+    current_platform: AttestationMode,
+) -> Result<()> {
+    let Some(requirements) = app_compose.requirements.as_ref() else {
+        return Ok(());
+    };
+    let Some(allowed_platforms) = requirements.platforms.as_deref() else {
+        return Ok(());
+    };
+    let allowed_modes = allowed_platforms
+        .iter()
+        .enumerate()
+        .map(|(index, platform)| parse_requirement_platform(platform, index))
+        .collect::<Result<Vec<_>>>()?;
+    if allowed_modes.contains(&current_platform) {
+        info!(
+            "platform requirement satisfied: current={}, allowed=[{}]",
+            current_platform.as_str(),
+            format_requirement_platforms(allowed_platforms)
+        );
+        return Ok(());
+    }
+    bail!(
+        "Unsupported attestation platform: current {}, allowed [{}]",
+        current_platform.as_str(),
+        format_requirement_platforms(allowed_platforms)
+    );
+}
+
+fn parse_requirement_platform(platform: &str, index: usize) -> Result<AttestationMode> {
+    serde_json::from_value(serde_json::Value::String(platform.to_string()))
+        .with_context(|| format!("Invalid requirements.platforms[{index}]: {platform}"))
+}
+
+fn format_requirement_platforms(platforms: &[String]) -> String {
+    platforms.join(", ")
+}
+
+fn read_current_os_version() -> Result<String> {
+    const OS_RELEASE_PATHS: &[&str] = &["/etc/os-release", "/usr/lib/os-release"];
+    for path in OS_RELEASE_PATHS {
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err).with_context(|| format!("Failed to read {path}")),
+        };
+        if let Some(version) = os_release_value(&content, "VERSION_ID") {
+            return Ok(version);
+        }
+    }
+    bail!("VERSION_ID not found in /etc/os-release or /usr/lib/os-release")
+}
+
+fn os_release_value(content: &str, key: &str) -> Option<String> {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        if k == key {
+            return Some(unquote_os_release_value(v));
+        }
+    }
+    None
+}
+
+fn unquote_os_release_value(value: &str) -> String {
+    let value = value.trim();
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        let inner = &value[1..value.len() - 1];
+        return inner
+            .replace("\\\"", "\"")
+            .replace("\\'", "'")
+            .replace("\\\\", "\\");
+    }
+    value.to_string()
+}
+
 pub async fn cmd_sys_setup(args: SetupArgs) -> Result<()> {
     let stage0 = Stage0::load(&args)?;
     let vmm = stage0.host_api();
@@ -770,6 +925,8 @@ pub async fn cmd_sys_setup(args: SetupArgs) -> Result<()> {
 }
 
 async fn do_sys_setup(stage0: Stage0<'_>) -> Result<()> {
+    verify_app_compose_policy(&stage0.shared.app_compose)
+        .context("Failed to verify app-compose policy")?;
     if stage0.shared.app_compose.secure_time {
         info!("Waiting for the system time to be synchronized");
         cmd! {
@@ -1901,4 +2058,149 @@ fn test_validate_luks2_header() {
     assert!(error
         .to_string()
         .contains("Invalid LUKS keyslot encryption"));
+}
+
+#[cfg(test)]
+fn test_app_compose(
+    manifest_version: serde_json::Value,
+    os_version: Option<&str>,
+    platforms: Option<&[&str]>,
+) -> AppCompose {
+    let mut value = serde_json::json!({
+        "manifest_version": manifest_version,
+        "name": "test",
+        "runner": "docker-compose"
+    });
+    if os_version.is_some() || platforms.is_some() {
+        value["requirements"] = serde_json::json!({});
+    }
+    if let Some(os_version) = os_version {
+        value["requirements"]["os_version"] = serde_json::json!(os_version);
+    }
+    if let Some(platforms) = platforms {
+        value["requirements"]["platforms"] = serde_json::json!(platforms);
+    }
+    serde_json::from_value(value).unwrap()
+}
+
+#[test]
+fn test_manifest_version_policy_rejects_above_guest_max() {
+    let app_compose = test_app_compose(serde_json::json!("4"), None, None);
+    let err = verify_manifest_version(&app_compose).unwrap_err();
+    assert!(err.to_string().contains("Unsupported manifest_version"));
+}
+
+#[test]
+fn test_os_version_requirement_requires_v3_manifest() {
+    let app_compose = test_app_compose(serde_json::json!("2"), Some(">=0.6.1"), None);
+    let err = verify_manifest_feature_requirements(&app_compose).unwrap_err();
+    assert!(err.to_string().contains("requires manifest_version"));
+}
+
+#[test]
+fn test_os_version_requirement_rejects_too_old_os() {
+    let app_compose = test_app_compose(serde_json::json!("3"), Some(">=0.6.1"), None);
+    let err = verify_os_version_requirement(&app_compose, "0.6.0").unwrap_err();
+    assert!(err.to_string().contains("Unsupported dstack OS version"));
+    verify_os_version_requirement(&app_compose, "0.6.1").unwrap();
+    verify_os_version_requirement(&app_compose, "0.6.2").unwrap();
+}
+
+#[test]
+fn test_os_version_requirement_accepts_semver_requirement_ranges() {
+    let app_compose = test_app_compose(serde_json::json!("3"), Some(">=0.6.0, <0.7.0"), None);
+    verify_os_version_requirement(&app_compose, "0.6.0").unwrap();
+    verify_os_version_requirement(&app_compose, "0.6.9").unwrap();
+    let err = verify_os_version_requirement(&app_compose, "0.7.0").unwrap_err();
+    assert!(err.to_string().contains("Unsupported dstack OS version"));
+}
+
+#[test]
+fn test_os_version_requirement_rejects_invalid_semver_strings() {
+    let app_compose = test_app_compose(serde_json::json!("3"), Some(">=0.6.0.a0"), None);
+    let err = verify_os_version_requirement(&app_compose, "0.6.0").unwrap_err();
+    assert!(err.to_string().contains("Invalid requirements.os_version"));
+
+    let app_compose = test_app_compose(serde_json::json!("3"), Some(">=0.6.0-a0"), None);
+    let err = verify_os_version_requirement(&app_compose, "0.6.0.a0").unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("Invalid current dstack OS version"));
+}
+
+#[test]
+fn test_platform_requirements_accept_matching_platform() {
+    let app_compose = test_app_compose(
+        serde_json::json!("3"),
+        None,
+        Some(&["dstack-gcp-tdx", "dstack-tdx"]),
+    );
+    verify_platform_requirements(&app_compose, AttestationMode::DstackGcpTdx).unwrap();
+    verify_platform_requirements(&app_compose, AttestationMode::DstackTdx).unwrap();
+}
+
+#[test]
+fn test_platform_requirements_reject_non_matching_platform() {
+    let app_compose = test_app_compose(serde_json::json!("3"), None, Some(&["dstack-gcp-tdx"]));
+    let err =
+        verify_platform_requirements(&app_compose, AttestationMode::DstackAmdSevSnp).unwrap_err();
+    assert!(err.to_string().contains("Unsupported attestation platform"));
+}
+
+#[test]
+fn test_platform_requirements_require_v3_manifest() {
+    let app_compose = test_app_compose(serde_json::json!("2"), None, Some(&["dstack-gcp-tdx"]));
+    let err = verify_manifest_feature_requirements(&app_compose).unwrap_err();
+    assert!(err.to_string().contains("requires manifest_version"));
+}
+
+#[test]
+fn test_empty_requirements_require_v3_manifest() {
+    let app_compose: AppCompose = serde_json::from_value(serde_json::json!({
+        "manifest_version": "2",
+        "name": "test",
+        "runner": "docker-compose",
+        "requirements": {}
+    }))
+    .unwrap();
+    let err = verify_manifest_feature_requirements(&app_compose).unwrap_err();
+    assert!(err.to_string().contains("requires manifest_version"));
+}
+
+#[test]
+fn test_platform_requirements_omitted_accepts_any_platform() {
+    let app_compose = test_app_compose(serde_json::json!("3"), None, None);
+    verify_platform_requirements(&app_compose, AttestationMode::DstackAmdSevSnp).unwrap();
+}
+
+#[test]
+fn test_platform_requirements_explicit_empty_rejects_all_platforms() {
+    let app_compose = test_app_compose(serde_json::json!("3"), None, Some(&[]));
+    let err = verify_platform_requirements(&app_compose, AttestationMode::DstackTdx).unwrap_err();
+    assert!(err.to_string().contains("Unsupported attestation platform"));
+
+    let app_compose = test_app_compose(serde_json::json!("2"), None, Some(&[]));
+    let err = verify_manifest_feature_requirements(&app_compose).unwrap_err();
+    assert!(err.to_string().contains("requires manifest_version"));
+}
+
+#[test]
+fn test_platform_requirements_reject_invalid_platform_value() {
+    let app_compose = test_app_compose(serde_json::json!("3"), None, Some(&["gcptdx"]));
+    let err = verify_platform_requirements(&app_compose, AttestationMode::DstackTdx).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("Invalid requirements.platforms[0]"));
+}
+
+#[test]
+fn test_os_release_value_parses_quoted_version_id() {
+    let content = r#"
+NAME="DStack"
+VERSION_ID="0.6.1"
+"#;
+    assert_eq!(
+        os_release_value(content, "VERSION_ID").as_deref(),
+        Some("0.6.1")
+    );
 }

--- a/guest-agent/src/rpc_service.rs
+++ b/guest-agent/src/rpc_service.rs
@@ -700,7 +700,7 @@ mod tests {
         temp_attestation_file.flush().unwrap();
 
         let dummy_appcompose = AppCompose {
-            manifest_version: 0,
+            manifest_version: "2".to_string(),
             name: String::new(),
             features: Vec::new(),
             runner: String::new(),
@@ -719,6 +719,7 @@ mod tests {
             storage_fs: None,
             swap_size: 0,
             port_policy: Default::default(),
+            requirements: None,
         };
 
         let dummy_appcompose_wrapper = AppComposeWrapper {

--- a/sdk/go/dstack/compose_hash.go
+++ b/sdk/go/dstack/compose_hash.go
@@ -27,28 +27,45 @@ type DockerConfig struct {
 	TokenKey string `json:"token_key,omitempty"`
 }
 
+// RequirementPlatform represents an allowed guest attestation platform.
+type RequirementPlatform string
+
+const (
+	RequirementPlatformTdx       RequirementPlatform = "dstack-tdx"
+	RequirementPlatformGcpTdx    RequirementPlatform = "dstack-gcp-tdx"
+	RequirementPlatformAmdSevSnp RequirementPlatform = "dstack-amd-sev-snp"
+	RequirementPlatformNitro     RequirementPlatform = "dstack-nitro-enclave"
+)
+
+// Requirements represents guest-side requirements.
+type Requirements struct {
+	OsVersion string                 `json:"os_version,omitempty"`
+	Platforms *[]RequirementPlatform `json:"platforms,omitempty"`
+}
+
 // AppCompose represents the application composition structure
 type AppCompose struct {
-	ManifestVersion             *int             `json:"manifest_version,omitempty"`
-	Name                        string           `json:"name,omitempty"`
-	Features                    []string         `json:"features,omitempty"` // Deprecated
-	Runner                      string           `json:"runner"`
-	DockerComposeFile           string           `json:"docker_compose_file,omitempty"`
-	DockerConfig                *DockerConfig    `json:"docker_config,omitempty"`
-	PublicLogs                  *bool            `json:"public_logs,omitempty"`
-	PublicSysinfo               *bool            `json:"public_sysinfo,omitempty"`
-	PublicTcbinfo               *bool            `json:"public_tcbinfo,omitempty"`
-	KmsEnabled                  *bool            `json:"kms_enabled,omitempty"`
-	GatewayEnabled              *bool            `json:"gateway_enabled,omitempty"`
-	TproxyEnabled               *bool            `json:"tproxy_enabled,omitempty"` // For backward compatibility
-	LocalKeyProviderEnabled     *bool            `json:"local_key_provider_enabled,omitempty"`
-	KeyProvider                 KeyProviderKind  `json:"key_provider,omitempty"`
-	KeyProviderID               string           `json:"key_provider_id,omitempty"` // hex string
-	AllowedEnvs                 []string         `json:"allowed_envs,omitempty"`
-	NoInstanceID                *bool            `json:"no_instance_id,omitempty"`
-	SecureTime                  *bool            `json:"secure_time,omitempty"`
-	BashScript                  string           `json:"bash_script,omitempty"`          // Legacy
-	PreLaunchScript             string           `json:"pre_launch_script,omitempty"`    // Legacy
+	ManifestVersion         interface{}     `json:"manifest_version,omitempty"`
+	Name                    string          `json:"name,omitempty"`
+	Features                []string        `json:"features,omitempty"` // Deprecated
+	Runner                  string          `json:"runner"`
+	DockerComposeFile       string          `json:"docker_compose_file,omitempty"`
+	DockerConfig            *DockerConfig   `json:"docker_config,omitempty"`
+	PublicLogs              *bool           `json:"public_logs,omitempty"`
+	PublicSysinfo           *bool           `json:"public_sysinfo,omitempty"`
+	PublicTcbinfo           *bool           `json:"public_tcbinfo,omitempty"`
+	KmsEnabled              *bool           `json:"kms_enabled,omitempty"`
+	GatewayEnabled          *bool           `json:"gateway_enabled,omitempty"`
+	TproxyEnabled           *bool           `json:"tproxy_enabled,omitempty"` // For backward compatibility
+	LocalKeyProviderEnabled *bool           `json:"local_key_provider_enabled,omitempty"`
+	KeyProvider             KeyProviderKind `json:"key_provider,omitempty"`
+	KeyProviderID           string          `json:"key_provider_id,omitempty"` // hex string
+	AllowedEnvs             []string        `json:"allowed_envs,omitempty"`
+	NoInstanceID            *bool           `json:"no_instance_id,omitempty"`
+	SecureTime              *bool           `json:"secure_time,omitempty"`
+	Requirements            *Requirements   `json:"requirements,omitempty"`
+	BashScript              string          `json:"bash_script,omitempty"`       // Legacy
+	PreLaunchScript         string          `json:"pre_launch_script,omitempty"` // Legacy
 }
 
 // preprocessAppCompose removes conflicting fields based on runner type
@@ -58,11 +75,11 @@ func preprocessAppCompose(appCompose AppCompose) AppCompose {
 	} else if appCompose.Runner == "docker-compose" {
 		appCompose.BashScript = ""
 	}
-	
+
 	if appCompose.PreLaunchScript == "" {
 		// Remove empty pre_launch_script field for deterministic output
 	}
-	
+
 	return appCompose
 }
 
@@ -104,27 +121,27 @@ func toDeterministicJSON(v interface{}) (string, error) {
 // GetComposeHash computes the SHA256 hash of the application composition
 func GetComposeHash(appCompose AppCompose, normalize ...bool) (string, error) {
 	shouldNormalize := len(normalize) > 0 && normalize[0]
-	
+
 	if shouldNormalize {
 		appCompose = preprocessAppCompose(appCompose)
 	}
-	
+
 	// Convert to generic map for sorting
 	jsonBytes, err := json.Marshal(appCompose)
 	if err != nil {
 		return "", err
 	}
-	
+
 	var genericMap interface{}
 	if err := json.Unmarshal(jsonBytes, &genericMap); err != nil {
 		return "", err
 	}
-	
+
 	manifestStr, err := toDeterministicJSON(genericMap)
 	if err != nil {
 		return "", err
 	}
-	
+
 	hash := sha256.Sum256([]byte(manifestStr))
 	return hex.EncodeToString(hash[:]), nil
 }

--- a/sdk/js/src/get-compose-hash.ts
+++ b/sdk/js/src/get-compose-hash.ts
@@ -36,6 +36,11 @@ function sortObject(obj: SortableValue): SortableValue {
 }
 
 export type KeyProviderKind = "none" | "kms" | "local" | "tpm";
+export type RequirementPlatform =
+  | "dstack-tdx"
+  | "dstack-gcp-tdx"
+  | "dstack-amd-sev-snp"
+  | "dstack-nitro-enclave";
 
 export interface DockerConfig extends SortableObject {
   registry?: string;
@@ -43,8 +48,13 @@ export interface DockerConfig extends SortableObject {
   token_key?: string;
 }
 
+export interface Requirements extends SortableObject {
+  os_version?: string;
+  platforms?: RequirementPlatform[];
+}
+
 export interface AppCompose extends SortableObject {
-  manifest_version?: number;
+  manifest_version?: number | string;
   name?: string;
   // Deprecated
   features?: string[];
@@ -64,6 +74,7 @@ export interface AppCompose extends SortableObject {
   allowed_envs?: string[];
   no_instance_id?: boolean;
   secure_time?: boolean;
+  requirements?: Requirements;
   // Legacy fields for backward compatibility
   bash_script?: string;
   pre_launch_script?: string;

--- a/sdk/python/src/dstack_sdk/__init__.py
+++ b/sdk/python/src/dstack_sdk/__init__.py
@@ -21,6 +21,7 @@ from .encrypt_env_vars import encrypt_env_vars
 from .encrypt_env_vars import encrypt_env_vars_sync
 from .get_compose_hash import AppCompose
 from .get_compose_hash import DockerConfig
+from .get_compose_hash import Requirements
 from .get_compose_hash import get_compose_hash
 from .verify_env_encrypt_public_key import verify_env_encrypt_public_key
 from .verify_env_encrypt_public_key import verify_env_encrypt_public_key_legacy
@@ -47,6 +48,7 @@ __all__ = [
     "get_compose_hash",
     "AppCompose",
     "DockerConfig",
+    "Requirements",
     "verify_env_encrypt_public_key",
     "verify_env_encrypt_public_key_legacy",
 ]

--- a/sdk/python/src/dstack_sdk/get_compose_hash.py
+++ b/sdk/python/src/dstack_sdk/get_compose_hash.py
@@ -46,13 +46,35 @@ class DockerConfig:
         return result
 
 
+class Requirements:
+    """Guest-side requirements for app compose."""
+
+    def __init__(
+        self,
+        os_version: Optional[str] = None,
+        platforms: Optional[List[str]] = None,
+    ) -> None:
+        """Initialize a new ``Requirements`` instance."""
+        self.os_version = os_version
+        self.platforms = platforms
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation excluding ``None`` fields."""
+        result: Dict[str, Any] = {}
+        if self.os_version is not None:
+            result["os_version"] = self.os_version
+        if self.platforms is not None:
+            result["platforms"] = self.platforms
+        return result
+
+
 class AppCompose:
     """App compose configuration."""
 
     def __init__(
         self,
         runner: str,
-        manifest_version: Optional[int] = None,
+        manifest_version: Optional[Union[int, str]] = None,
         name: Optional[str] = None,
         features: Optional[List[str]] = None,  # Deprecated
         docker_compose_file: Optional[str] = None,
@@ -69,6 +91,7 @@ class AppCompose:
         allowed_envs: Optional[List[str]] = None,
         no_instance_id: Optional[bool] = None,
         secure_time: Optional[bool] = None,
+        requirements: Optional[Union[Requirements, Dict[str, Any]]] = None,
         bash_script: Optional[str] = None,  # Legacy
         pre_launch_script: Optional[str] = None,  # Legacy
         **kwargs: Any,
@@ -92,6 +115,7 @@ class AppCompose:
         self.allowed_envs = allowed_envs
         self.no_instance_id = no_instance_id
         self.secure_time = secure_time
+        self.requirements = requirements
         self.bash_script = bash_script
         self.pre_launch_script = pre_launch_script
 
@@ -108,7 +132,7 @@ class AppCompose:
             if not attr_name.startswith("_") and not callable(getattr(self, attr_name)):
                 value = getattr(self, attr_name)
                 if value is not None:
-                    if isinstance(value, DockerConfig):
+                    if isinstance(value, (DockerConfig, Requirements)):
                         result[attr_name] = value.to_dict()
                     else:
                         # Handle special float values
@@ -133,6 +157,12 @@ class AppCompose:
             dc = data.pop("docker_config")
             docker_config = DockerConfig(**dc)
 
+        # Handle requirements
+        requirements: Optional[Requirements] = None
+        if "requirements" in data and data["requirements"] is not None:
+            req = data.pop("requirements")
+            requirements = Requirements(**req)
+
         # Handle special float values
         processed_data: Dict[str, Any] = {}
         for key, value in data.items():
@@ -148,7 +178,12 @@ class AppCompose:
 
         runner_value = processed_data.pop("runner")
         runner: str = str(runner_value)
-        return cls(runner=runner, docker_config=docker_config, **processed_data)
+        return cls(
+            runner=runner,
+            docker_config=docker_config,
+            requirements=requirements,
+            **processed_data,
+        )
 
 
 def sort_object(obj: Any) -> Any:

--- a/vmm/src/console_v0.html
+++ b/vmm/src/console_v0.html
@@ -1733,8 +1733,9 @@ fi
                 };
 
                 const makeAppComposeFile = async () => {
+                    const osVersion = imageVersion(vmForm.value.image);
                     const app_compose = {
-                        "manifest_version": 2,
+                        "manifest_version": appComposeManifestVersion(osVersion),
                         "name": vmForm.value.name,
                         "runner": "docker-compose",
                         "docker_compose_file": vmForm.value.dockerComposeFile,
@@ -1773,7 +1774,7 @@ fi
                         app_compose.launch_token_hash = await calcComposeHash(launchToken.value);
                     }
 
-                    const imgFeatures = imageVersionFeatures(imageVersion(vmForm.value.image));
+                    const imgFeatures = imageVersionFeatures(osVersion);
                     if (imgFeatures.compose_version < 2) {
                         // Compatibility with old images
                         const features = [];
@@ -2181,6 +2182,10 @@ fi
                         ...currentAppCompose,
                         docker_compose_file: upgradeDialog.value.dockerComposeFile || currentAppCompose.docker_compose_file
                     };
+                    const targetManifestVersion = appComposeManifestVersion(imageVersion(upgradeDialog.value.image));
+                    if (targetManifestVersion === "3") {
+                        app_compose.manifest_version = targetManifestVersion;
+                    }
                     if (upgradeDialog.value.resetSecrets) {
                         const launchToken = upgradeDialog.value.encryptedEnvs.find(env => env.key == 'APP_LAUNCH_TOKEN');
                         if (launchToken) {
@@ -2449,6 +2454,13 @@ fi
                     const version = versionStr.split('.').map(Number);
                     const otherVersion = otherVersionStr.split('.').map(Number);
                     return version[0] > otherVersion[0] || (version[0] == otherVersion[0] && version[1] > otherVersion[1]) || (version[0] == otherVersion[0] && version[1] == otherVersion[1] && version[2] >= otherVersion[2]);
+                };
+
+                const appComposeManifestVersion = (versionStr) => {
+                    if (versionStr && verGE(versionStr, '0.6.0')) {
+                        return "3";
+                    }
+                    return 2;
                 };
 
                 const imageVersionFeatures = (versionStr) => {

--- a/vmm/ui/src/composables/useVmManager.ts
+++ b/vmm/ui/src/composables/useVmManager.ts
@@ -9,7 +9,7 @@ import type { vmm as VmmTypes } from '../proto/vmm_rpc';
 type VmConfiguration = VmmTypes.IVmConfiguration;
 
 type AppCompose = {
-  manifest_version: number;
+  manifest_version: number | string;
   name: string;
   features: string[];
   runner: string;
@@ -26,6 +26,7 @@ type AppCompose = {
   allowed_envs: string[];
   no_instance_id: boolean;
   secure_time: boolean;
+  requirements?: Requirements;
   storage_fs?: string;
   swap_size: number;
   launch_token_hash?: string;
@@ -34,6 +35,15 @@ type AppCompose = {
 };
 
 type KeyProviderKind = 'none' | 'kms' | 'local' | 'tpm';
+type RequirementPlatform =
+  | 'dstack-tdx'
+  | 'dstack-gcp-tdx'
+  | 'dstack-amd-sev-snp'
+  | 'dstack-nitro-enclave';
+type Requirements = {
+  os_version?: string;
+  platforms?: RequirementPlatform[];
+};
 
 const x25519 = require('../lib/x25519.js');
 const { getVmmRpcClient } = require('../lib/vmmRpcClient');
@@ -642,6 +652,13 @@ type CreateVmPayloadSource = {
     );
   };
 
+  const appComposeManifestVersion = (versionStr: string | undefined): number | string => {
+    if (versionStr && verGE(versionStr, '0.6.0')) {
+      return '3';
+    }
+    return 2;
+  };
+
   const imageVersionFeatures = (versionStr: string | undefined) => {
     const features = {
       progress: false,
@@ -710,8 +727,9 @@ type CreateVmPayloadSource = {
   }
 
   async function makeAppComposeFile() {
+    const osVersion = imageVersion(vmForm.value.image);
     const appCompose: Record<string, unknown> = {
-      manifest_version: 2,
+      manifest_version: appComposeManifestVersion(osVersion),
       name: vmForm.value.name,
       runner: 'docker-compose',
       docker_compose_file: vmForm.value.dockerComposeFile,
@@ -759,7 +777,7 @@ type CreateVmPayloadSource = {
       appCompose.launch_token_hash = await calcComposeHash(launchToken.value);
     }
 
-    const imgFeatures = imageVersionFeatures(imageVersion(vmForm.value.image));
+    const imgFeatures = imageVersionFeatures(osVersion);
     if (imgFeatures.compose_version < 3) {
       appCompose.tproxy_enabled = appCompose.gateway_enabled;
       delete appCompose.gateway_enabled;
@@ -773,6 +791,10 @@ type CreateVmPayloadSource = {
       ...currentAppCompose,
       docker_compose_file: updateDialog.value.dockerComposeFile || currentAppCompose.docker_compose_file,
     };
+    const targetManifestVersion = appComposeManifestVersion(imageVersion(updateDialog.value.image));
+    if (targetManifestVersion === '3') {
+      appCompose.manifest_version = targetManifestVersion;
+    }
     if (updateDialog.value.resetSecrets) {
       // Update allowed_envs with the new environment variable keys
       appCompose.allowed_envs = updateDialog.value.encryptedEnvs.map(env => env.key);


### PR DESCRIPTION
## Summary
- Parse `app-compose.json` `manifest_version` as a string, while keeping legacy numeric `1`/`2` compatibility and rejecting numeric `3+`.
- Add guest-side manifest gating:
  - reject manifests above guest `MAX_SUPPORTED_MANIFEST_VERSION`
  - reject any manifest that contains `requirements` unless `manifest_version == "3"`
- Add `requirements` support:
  - `requirements.os_version` uses Rust semver requirement syntax, e.g. `">=0.6.0, <0.7.0"`
  - `requirements.platforms` reuses existing `AttestationMode` deserialize values, e.g. `"dstack-gcp-tdx"`
  - omitted `platforms` means any platform; explicit `platforms: []` means no platform is supported
- Update dstack-vmm to emit string manifest version `"3"` for OS images `>= 0.6.0`, while preserving legacy numeric `2` for older images.
- Update Rust/Go/JS/Python SDK and UI AppCompose types for `manifest_version` and `requirements`.

## Example
```json
{
  "manifest_version": "3",
  "requirements": {
    "os_version": ">=0.6.0",
    "platforms": ["dstack-gcp-tdx"]
  }
}
```

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p dstack-types`
- `cargo test -p dstack-util`
- `cargo test -p dstack-attest compatibility_tests::attestation_mode_deserializes_canonical_names`
- `cargo check -p dstack-vmm -p dstack-guest-agent`
- `cargo clippy -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow unused_variables`
- `cargo test --all-features --no-run`
- `cd vmm/ui && npm run build`
- `cd sdk/go && go test ./dstack -run '^$'`
- `python3 -m py_compile sdk/python/src/dstack_sdk/get_compose_hash.py sdk/python/src/dstack_sdk/__init__.py`
- GitHub CI: all checks passing
