### PR TITLE
guest: gate boot on GPU TEE attestation via requirements.attest_gpu

### DIFF
--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -143,6 +143,16 @@ pub struct Requirements {
     /// (e.g. 32 random alphanumeric characters).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub launch_token_hash: Option<String>,
+    /// GPU TEE attestation requirement, defaults to `true` when omitted.
+    ///
+    /// On guests with an NVIDIA GPU attached, `true` means the guest runs
+    /// local GPU attestation (nvattest) during system setup and refuses to
+    /// boot — before key provisioning — if the GPU fails to attest (e.g. a
+    /// non-CC GPU or CC mode disabled by the host). `false` skips attestation
+    /// and sets the GPU ready state directly. Guests without a GPU attached
+    /// are unaffected either way.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_gpu: Option<bool>,
 }
 
 impl Requirements {
@@ -151,6 +161,7 @@ impl Requirements {
             && self.platforms.is_none()
             && self.tdx_measure_acpi_tables.is_none()
             && self.launch_token_hash.is_none()
+            && self.verify_gpu.is_none()
     }
 }
 
@@ -345,6 +356,24 @@ impl AppCompose {
             }
         }
     }
+
+    /// Whether an attached GPU must pass local TEE attestation before the
+    /// guest continues booting. Defaults to `true` when
+    /// `requirements.verify_gpu` is omitted.
+    ///
+    /// `requirements` are only valid on manifest_version >= 3 (guests reject
+    /// older manifests carrying them); the opt-out is additionally ignored on
+    /// legacy manifests here so a caller that skipped that validation still
+    /// fails closed.
+    pub fn verify_gpu(&self) -> bool {
+        if !matches!(self.manifest_version_u32(), Some(v) if v >= 3) {
+            return true;
+        }
+        self.requirements
+            .as_ref()
+            .and_then(|r| r.verify_gpu)
+            .unwrap_or(true)
+    }
 }
 
 #[cfg(test)]
@@ -499,6 +528,54 @@ mod app_compose_tests {
         let requirements = launch_token.requirements.as_ref().unwrap();
         assert!(requirements.launch_token_hash.is_some());
         assert!(!requirements.is_empty());
+    }
+
+    #[test]
+    fn verify_gpu_defaults_to_true() {
+        let no_requirements: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": 2,
+            "name": "test",
+            "runner": "docker-compose"
+        }))
+        .unwrap();
+        assert!(no_requirements.verify_gpu());
+
+        let omitted: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {}
+        }))
+        .unwrap();
+        assert!(omitted.verify_gpu());
+        assert!(omitted.requirements.as_ref().unwrap().is_empty());
+
+        let disabled: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {
+                "verify_gpu": false
+            }
+        }))
+        .unwrap();
+        assert!(!disabled.verify_gpu());
+        let requirements = disabled.requirements.as_ref().unwrap();
+        assert_eq!(requirements.verify_gpu, Some(false));
+        assert!(!requirements.is_empty());
+
+        // The opt-out is ignored on legacy manifests (requirements are only
+        // valid on manifest_version >= 3; guests reject such composes anyway).
+        let legacy_optout: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": 2,
+            "name": "test",
+            "runner": "docker-compose",
+            "requirements": {
+                "verify_gpu": false
+            }
+        }))
+        .unwrap();
+        assert!(legacy_optout.verify_gpu());
     }
 
     #[test]

--- a/dstack-types/src/lib.rs
+++ b/dstack-types/src/lib.rs
@@ -152,7 +152,7 @@ pub struct Requirements {
     /// and sets the GPU ready state directly. Guests without a GPU attached
     /// are unaffected either way.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verify_gpu: Option<bool>,
+    pub attest_gpu: Option<bool>,
 }
 
 impl Requirements {
@@ -161,7 +161,7 @@ impl Requirements {
             && self.platforms.is_none()
             && self.tdx_measure_acpi_tables.is_none()
             && self.launch_token_hash.is_none()
-            && self.verify_gpu.is_none()
+            && self.attest_gpu.is_none()
     }
 }
 
@@ -359,19 +359,19 @@ impl AppCompose {
 
     /// Whether an attached GPU must pass local TEE attestation before the
     /// guest continues booting. Defaults to `true` when
-    /// `requirements.verify_gpu` is omitted.
+    /// `requirements.attest_gpu` is omitted.
     ///
     /// `requirements` are only valid on manifest_version >= 3 (guests reject
     /// older manifests carrying them); the opt-out is additionally ignored on
     /// legacy manifests here so a caller that skipped that validation still
     /// fails closed.
-    pub fn verify_gpu(&self) -> bool {
+    pub fn attest_gpu(&self) -> bool {
         if !matches!(self.manifest_version_u32(), Some(v) if v >= 3) {
             return true;
         }
         self.requirements
             .as_ref()
-            .and_then(|r| r.verify_gpu)
+            .and_then(|r| r.attest_gpu)
             .unwrap_or(true)
     }
 }
@@ -531,14 +531,14 @@ mod app_compose_tests {
     }
 
     #[test]
-    fn verify_gpu_defaults_to_true() {
+    fn attest_gpu_defaults_to_true() {
         let no_requirements: AppCompose = serde_json::from_value(serde_json::json!({
             "manifest_version": 2,
             "name": "test",
             "runner": "docker-compose"
         }))
         .unwrap();
-        assert!(no_requirements.verify_gpu());
+        assert!(no_requirements.attest_gpu());
 
         let omitted: AppCompose = serde_json::from_value(serde_json::json!({
             "manifest_version": "3",
@@ -547,7 +547,7 @@ mod app_compose_tests {
             "requirements": {}
         }))
         .unwrap();
-        assert!(omitted.verify_gpu());
+        assert!(omitted.attest_gpu());
         assert!(omitted.requirements.as_ref().unwrap().is_empty());
 
         let disabled: AppCompose = serde_json::from_value(serde_json::json!({
@@ -555,13 +555,13 @@ mod app_compose_tests {
             "name": "test",
             "runner": "docker-compose",
             "requirements": {
-                "verify_gpu": false
+                "attest_gpu": false
             }
         }))
         .unwrap();
-        assert!(!disabled.verify_gpu());
+        assert!(!disabled.attest_gpu());
         let requirements = disabled.requirements.as_ref().unwrap();
-        assert_eq!(requirements.verify_gpu, Some(false));
+        assert_eq!(requirements.attest_gpu, Some(false));
         assert!(!requirements.is_empty());
 
         // The opt-out is ignored on legacy manifests (requirements are only
@@ -571,11 +571,11 @@ mod app_compose_tests {
             "name": "test",
             "runner": "docker-compose",
             "requirements": {
-                "verify_gpu": false
+                "attest_gpu": false
             }
         }))
         .unwrap();
-        assert!(legacy_optout.verify_gpu());
+        assert!(legacy_optout.attest_gpu());
     }
 
     #[test]

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1047,8 +1047,177 @@ async fn do_sys_setup(stage0: Stage0<'_>) -> Result<()> {
     } else {
         info!("System time will be synchronized by chronyd in background");
     }
+    stage0
+        .setup_gpu()
+        .await
+        .context("Failed to verify GPU TEE attestation")?;
     let stage1 = stage0.setup_fs().await?;
     stage1.setup().await
+}
+
+/// GPU TEE attestation gate (`requirements.verify_gpu`, defaults to true).
+///
+/// Runs before key provisioning so a CVM whose GPU cannot prove it is a
+/// genuine, CC-enabled NVIDIA TEE never gets its app keys. The GPU
+/// "ready" state (`nvidia-smi conf-compute -srs 1`) is only set from here —
+/// nvidia-persistenced deliberately does not set it — so CUDA work cannot be
+/// submitted to an unverified GPU either.
+mod gpu {
+    use super::*;
+
+    const NVATTEST: &str = "/usr/bin/nvattest";
+    const NVIDIA_SMI: &str = "/usr/bin/nvidia-smi";
+    const ATTESTATION_OUTPUT: &str = "/run/nvidia-gpu-attestation/attestation.out";
+    const ATTESTATION_TIMEOUT: Duration = Duration::from_secs(300);
+    const NVIDIA_SMI_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// True if a passed-through NVIDIA GPU is present, detected via sysfs PCI
+    /// (vendor 0x10de, class VGA 0x0300xx or 3D controller 0x0302xx) so it
+    /// works even before the nvidia driver is loaded. Fails (rather than
+    /// reporting "no GPU") when the PCI bus cannot be enumerated, so a broken
+    /// /sys cannot bypass the attestation gate.
+    pub(super) fn nvidia_gpu_present() -> Result<bool> {
+        let entries =
+            fs::read_dir("/sys/bus/pci/devices").context("failed to enumerate PCI devices")?;
+        Ok(entries.filter_map(|e| e.ok()).any(|dev| {
+            let read = |name: &str| {
+                fs::read_to_string(dev.path().join(name))
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string()
+            };
+            read("vendor") == "0x10de"
+                && matches!(read("class").get(..6), Some("0x0300") | Some("0x0302"))
+        }))
+    }
+
+    /// Run a GPU tool with a bounded timeout so a wedged driver/GPU cannot
+    /// hang the boot indefinitely (dstack-prepare is a oneshot unit with no
+    /// start timeout of its own).
+    async fn run_command(
+        program: &str,
+        args: &[&str],
+        timeout: Duration,
+    ) -> Result<std::process::Output> {
+        tokio::time::timeout(
+            timeout,
+            tokio::process::Command::new(program).args(args).output(),
+        )
+        .await
+        .with_context(|| format!("{program} timed out"))?
+        .with_context(|| format!("failed to run {program}"))
+    }
+
+    /// Mark the GPU as ready to accept work. Only meaningful (and only
+    /// succeeds) when the GPU runs in CC mode.
+    pub(super) async fn set_gpu_ready_state() -> Result<()> {
+        let output = run_command(
+            NVIDIA_SMI,
+            &["conf-compute", "-srs", "1"],
+            NVIDIA_SMI_TIMEOUT,
+        )
+        .await?;
+        if !output.status.success() {
+            bail!(
+                "nvidia-smi conf-compute -srs 1 failed ({}): {}",
+                output.status,
+                truncated_lossy(&output.stderr, 512),
+            );
+        }
+        info!("GPU ready state set");
+        Ok(())
+    }
+
+    /// Run local GPU attestation via nvattest with a fresh nonce, keeping the
+    /// verifier output in /run for debugging. Fails on any non-zero exit —
+    /// including a GPU that cannot produce an attestation report at all (a
+    /// non-CC GPU, or CC mode left off by the host).
+    pub(super) async fn attest_gpu() -> Result<()> {
+        if !Path::new(NVATTEST).exists() {
+            bail!("nvattest is not available in this image");
+        }
+        // Certificate/OCSP validation needs a sane clock even when
+        // secure_time is off; best-effort step chrony before attesting.
+        if let Err(err) = cmd!(chronyc makestep) {
+            warn!("failed to step system clock: {err:?}");
+        }
+        let nonce = hex::encode(rand::thread_rng().gen::<[u8; 32]>());
+        let output = run_command(
+            NVATTEST,
+            &[
+                "attest",
+                "--device",
+                "gpu",
+                "--verifier",
+                "local",
+                "--nonce",
+                &nonce,
+            ],
+            ATTESTATION_TIMEOUT,
+        )
+        .await?;
+        if !output.stderr.is_empty() {
+            info!("nvattest: {}", truncated_lossy(&output.stderr, 2048));
+        }
+        if !output.status.success() {
+            bail!(
+                "nvattest exited with {}: {}",
+                output.status,
+                truncated_lossy(&output.stderr, 512),
+            );
+        }
+        if let Err(err) = save_attestation_output(&output.stdout) {
+            warn!("failed to save GPU attestation output: {err:?}");
+        }
+        Ok(())
+    }
+
+    fn save_attestation_output(stdout: &[u8]) -> Result<()> {
+        let output_path = Path::new(ATTESTATION_OUTPUT);
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        safe_write(output_path, stdout)?;
+        fs::set_permissions(
+            output_path,
+            std::os::unix::fs::PermissionsExt::from_mode(0o600),
+        )?;
+        Ok(())
+    }
+
+    fn truncated_lossy(bytes: &[u8], limit: usize) -> String {
+        let text = String::from_utf8_lossy(bytes);
+        let text = text.trim();
+        match text.char_indices().nth(limit) {
+            Some((idx, _)) => format!("{}...", &text[..idx]),
+            None => text.to_string(),
+        }
+    }
+}
+
+impl Stage0<'_> {
+    /// Enforce `requirements.verify_gpu` (default true): attest an attached
+    /// NVIDIA GPU before continuing to key provisioning, or — when explicitly
+    /// disabled — set the GPU ready state without verification.
+    async fn setup_gpu(&self) -> Result<()> {
+        if !gpu::nvidia_gpu_present()? {
+            return Ok(());
+        }
+        if !self.shared.app_compose.verify_gpu() {
+            warn!("requirements.verify_gpu is false; setting GPU ready state without attestation");
+            // Best-effort: a GPU with CC mode off has no ready state to set.
+            if let Err(err) = gpu::set_gpu_ready_state().await {
+                warn!("failed to set GPU ready state: {err:?}");
+            }
+            return Ok(());
+        }
+        self.vmm.notify_q("boot.progress", "attesting GPU").await;
+        info!("verifying GPU TEE attestation");
+        gpu::attest_gpu().await?;
+        gpu::set_gpu_ready_state().await?;
+        info!("GPU TEE attestation succeeded");
+        Ok(())
+    }
 }
 
 pub async fn cmd_gateway_refresh(args: GatewayRefreshArgs) -> Result<()> {

--- a/dstack-util/src/system_setup.rs
+++ b/dstack-util/src/system_setup.rs
@@ -1055,7 +1055,7 @@ async fn do_sys_setup(stage0: Stage0<'_>) -> Result<()> {
     stage1.setup().await
 }
 
-/// GPU TEE attestation gate (`requirements.verify_gpu`, defaults to true).
+/// GPU TEE attestation gate (`requirements.attest_gpu`, defaults to true).
 ///
 /// Runs before key provisioning so a CVM whose GPU cannot prove it is a
 /// genuine, CC-enabled NVIDIA TEE never gets its app keys. The GPU
@@ -1196,15 +1196,15 @@ mod gpu {
 }
 
 impl Stage0<'_> {
-    /// Enforce `requirements.verify_gpu` (default true): attest an attached
+    /// Enforce `requirements.attest_gpu` (default true): attest an attached
     /// NVIDIA GPU before continuing to key provisioning, or — when explicitly
     /// disabled — set the GPU ready state without verification.
     async fn setup_gpu(&self) -> Result<()> {
         if !gpu::nvidia_gpu_present()? {
             return Ok(());
         }
-        if !self.shared.app_compose.verify_gpu() {
-            warn!("requirements.verify_gpu is false; setting GPU ready state without attestation");
+        if !self.shared.app_compose.attest_gpu() {
+            warn!("requirements.attest_gpu is false; setting GPU ready state without attestation");
             // Best-effort: a GPU with CC mode off has no ready state to set.
             if let Err(err) = gpu::set_gpu_ready_state().await {
                 warn!("failed to set GPU ready state: {err:?}");


### PR DESCRIPTION
## Problem

On NVIDIA images the GPU conf-compute ready state is set unconditionally by `nvidia-persistenced.service` (`ExecStartPost=nvidia-smi conf-compute -srs 1`), so CUDA work can be submitted to a GPU that never proved it is a genuine, CC-enabled NVIDIA TEE. A malicious host can attach a non-CC GPU (or leave CC mode off) and the CVM boots, gets its app keys, and runs the workload anyway.

An earlier iteration of meta-dstack#83 gated this with a dedicated `nvidia-gpu-attestation.service` plus `Requires=` drop-ins on five units — more moving parts, and the policy was baked into the image with no per-app control.

## Fix

Move the whole gate into `dstack-util setup` (`system_setup.rs`) and make it an app-compose requirement:

- `requirements.attest_gpu` (new, defaults to **true** when omitted): whether an attached GPU must pass local TEE attestation before boot continues.
- In `do_sys_setup`, after time sync and **before key provisioning**:
  - no NVIDIA GPU on the PCI bus (sysfs vendor `0x10de`, class `0x0300xx`/`0x0302xx`) → skip; GPU-less CVMs are unaffected.
  - `attest_gpu=true` → run `nvattest attest --device gpu --verifier local --nonce <32 random bytes>` (5 min timeout, verifier output kept in `/run/nvidia-gpu-attestation/attestation.out`, 0600), then set the ready state. Any failure — a non-CC GPU, CC mode left off by the host, or a missing `nvattest` binary — aborts setup, so the CVM fails closed before app keys are provisioned (`boot.error` reported to the VMM, dstack-prepare reboots).
  - `attest_gpu=false` → skip attestation and set the ready state directly (best-effort: a GPU without CC mode has no ready state to set).

The companion meta-dstack change (meta-dstack#83) drops the systemd service/wrapper/drop-ins and ships only the nvattest CLI plus an ordering drop-in (`dstack-prepare.service` after `nvidia-persistenced`/`nvidia-fabricmanager`).

Like the other `requirements` fields, `attest_gpu` needs `manifest_version: "3"`, so older guests fail closed instead of silently ignoring the opt-out.

## Verification

- `cargo test -p dstack-types -p dstack-util` (new tests: `attest_gpu_defaults_to_true`; 23 + 34 pass), `cargo fmt --check`, clippy clean.
- End-to-end on a GCP a3-highgpu-1g (TDX + H100) is pending the meta-dstack image rebuild with this commit; the same nvattest invocation (nonce + local verifier) was previously verified there via the systemd variant of this gate (successful attestation in the serial log, ready state set only afterwards).