### PR TITLE
Empty TPM key-provider id for stable launch measurement

### DIFF
--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -33,7 +33,7 @@ This is the main configuration file for the application in JSON format:
 | kms_enabled | 0.3.1 | boolean | Enable/disable KMS |
 | gateway_enabled | 0.3.1 | boolean | Enable/disable gateway |
 | local_key_provider_enabled | 0.3.1 | boolean | Use a local key provider |
-| key_provider_id | 0.5.1 | string | Key provider ID. |
+| key_provider_id | 0.5.1 | string | Optional pin for the key provider identity. For `kms` this is the KMS CA public key; for `local` the sealing-provider MR. For `tpm` and `none` it is empty — the TPM app-root public key is instance-specific and is not used as a provider id or measured as one. |
 | public_logs | 0.3.3 | boolean | Whether logs are publicly visible |
 | public_sysinfo | 0.3.3 | boolean | Whether system info is public |
 | public_tcbinfo | 0.5.1 | boolean | Whether TCB info is public |

--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -33,7 +33,7 @@ This is the main configuration file for the application in JSON format:
 | kms_enabled | 0.3.1 | boolean | Enable/disable KMS |
 | gateway_enabled | 0.3.1 | boolean | Enable/disable gateway |
 | local_key_provider_enabled | 0.3.1 | boolean | Use a local key provider |
-| key_provider_id | 0.5.1 | string | Optional pin for the key provider identity. For `kms` this is the KMS CA public key; for `local` the sealing-provider MR. For `tpm` and `none` it is empty — the TPM app-root public key is instance-specific and is not used as a provider id or measured as one. |
+| key_provider_id | 0.5.1 | string | Optional pin for the key provider identity (hex-encoded bytes). For `kms` this is the KMS CA public key; for `local` the sealing-provider MR. For `tpm` and `none` it must be an empty string — the TPM app-root public key is instance-specific and is not used as a provider id or measured as one. |
 | public_logs | 0.3.3 | boolean | Whether logs are publicly visible |
 | public_sysinfo | 0.3.3 | boolean | Whether system info is public |
 | public_tcbinfo | 0.5.1 | boolean | Whether TCB info is public |

--- a/dstack/dstack-types/src/lib.rs
+++ b/dstack/dstack-types/src/lib.rs
@@ -1390,11 +1390,19 @@ impl KeyProvider {
         }
     }
 
+    /// Stable key-provider identity used for launch measurement and compose pins.
+    ///
+    /// - KMS: root CA public key
+    /// - Local: sealing-provider MR
+    /// - TPM: always empty — the derived app root pubkey is instance-specific
+    ///   (from a TPM-sealed seed) and must not be treated as a stable provider id
+    ///   or measured as one. Mode is already carried by [`Self::kind`].
+    /// - None: empty
     pub fn id(&self) -> &[u8] {
         match self {
             KeyProvider::None { .. } => &[],
             KeyProvider::Local { mr, .. } => mr,
-            KeyProvider::Tpm { pubkey, .. } => pubkey,
+            KeyProvider::Tpm { .. } => &[],
             KeyProvider::Kms { pubkey, .. } => pubkey,
         }
     }
@@ -1409,6 +1417,31 @@ pub struct KeyProviderInfo {
 impl KeyProviderInfo {
     pub fn new(name: String, id: String) -> Self {
         Self { name, id }
+    }
+}
+
+#[cfg(test)]
+mod key_provider_tests {
+    use super::*;
+
+    #[test]
+    fn tpm_key_provider_id_is_empty() {
+        let tpm = KeyProvider::Tpm {
+            key: "dummy".into(),
+            // Instance app-root pubkey may still be stored on the key handle, but
+            // it must not be reported as the stable provider id.
+            pubkey: vec![0x04; 65],
+        };
+        assert!(tpm.id().is_empty());
+        assert_eq!(tpm.kind(), KeyProviderKind::Tpm);
+
+        let kms = KeyProvider::Kms {
+            url: "https://kms.example".into(),
+            pubkey: vec![0xab; 32],
+            tmp_ca_key: String::new(),
+            tmp_ca_cert: String::new(),
+        };
+        assert_eq!(kms.id(), &[0xab; 32]);
     }
 }
 

--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -1901,16 +1901,16 @@ impl<'a> Stage0<'a> {
             keys.key_provider.id(),
         )?;
         self.verify_key_provider_id(keys.key_provider.id())?;
+        // TPM uses an empty id: the instance app-root pubkey is not a stable
+        // provider identity and must not enter the launch measurement chain.
         let kp_info = match &keys.key_provider {
             KeyProvider::None { .. } => KeyProviderInfo::new("none".into(), "".into()),
-            KeyProvider::Local { mr, .. } => {
-                KeyProviderInfo::new("local-sgx".into(), hex::encode(mr))
+            KeyProvider::Local { .. } => {
+                KeyProviderInfo::new("local-sgx".into(), hex::encode(keys.key_provider.id()))
             }
-            KeyProvider::Tpm { pubkey, .. } => {
-                KeyProviderInfo::new("tpm".into(), hex::encode(pubkey))
-            }
-            KeyProvider::Kms { pubkey, .. } => {
-                KeyProviderInfo::new("kms".into(), hex::encode(pubkey))
+            KeyProvider::Tpm { .. } => KeyProviderInfo::new("tpm".into(), "".into()),
+            KeyProvider::Kms { .. } => {
+                KeyProviderInfo::new("kms".into(), hex::encode(keys.key_provider.id()))
             }
         };
         emit_key_provider_info(&kp_info)?;

--- a/dstack/dstack-util/src/system_setup/config_id_verifier.rs
+++ b/dstack/dstack-util/src/system_setup/config_id_verifier.rs
@@ -62,7 +62,7 @@ fn read_snp_host_data() -> Result<[u8; 32]> {
 /// - compose_hash: [u8; 32]
 /// - app_id: [u8; 20]
 /// - key_provider_type: u8 // 0: none, 1: local, 2: kms, 3: tpm
-/// - key_provider_id: [u8] // the ca pubkey for KMS or the MR enclave for local-sgx provider, empty for none
+/// - key_provider_id: [u8] // KMS CA pubkey, local-sgx MR, or empty for none/tpm
 pub fn verify_mr_config_id(
     compose_hash: &[u8; 32],
     app_id: &[u8; 20],


### PR DESCRIPTION
## Summary

- For `key_provider = tpm`, stop using the instance app-root public key as the provider id.
- Launch event becomes `{"name":"tpm","id":""}` (mode only); `KeyProvider::id()` returns empty for TPM.
- KMS (CA pubkey) and local (sealing MR) ids are unchanged.

## Why

The TPM app-root key is derived from a per-instance sealed seed. Measuring its pubkey made `key-provider` → `mr_system` / `mr_aggregated` instance-bound and unsuitable as a precomputed allowlist identity. Empty id keeps the measured claim as “TPM mode” without an unusable instance fingerprint.

**Note:** This intentionally changes the TPM launch measurement / event payload. Existing quotes that included a non-empty TPM id will not match new replays. Pinning a non-empty `key_provider_id` in app-compose for TPM will now fail closed (runtime id is always empty).

## Test plan

- [x] `cargo test -p dstack-types key_provider`
- [x] Review that no deployment relies on compose-pinning a TPM app-root pubkey as `key_provider_id`
- [ ] Optional: boot a TPM-mode CVM and confirm key-provider event id is empty and MRs are stable across same-image instances when `no_instance_id` is set