### PR TITLE
fix: enable kernel quota and loop support

### DIFF
--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
@@ -19,6 +19,14 @@ CONFIG_ISO9660_FS=y
 CONFIG_WIREGUARD=y
 CONFIG_TMPFS_POSIX_ACL=y
 CONFIG_TMPFS_XATTR=y
+
+# Enforce per-directory limits on shared ext4 data disks.
+CONFIG_QUOTA=y
+CONFIG_QFMT_V2=y
+
+# Support filesystem images used to isolate workload storage.
+CONFIG_BLK_DEV_LOOP=y
+
 CONFIG_NR_CPUS=512
 
 # BPF


### PR DESCRIPTION
## Summary

- enable VFS quota and v2 quota format support for ext4 project quotas
- build the loop block driver into the kernel for filesystem-image workloads
- keep both generic facilities in the base `dstack.cfg` kernel fragment rather than the Sysbox-specific fragment

## Testing

- `bitbake -c kernel_configcheck virtual/kernel`
- `bitbake virtual/kernel`
- verified the generated kernel config contains `CONFIG_QUOTA=y`, `CONFIG_QFMT_V2=y`, `CONFIG_QUOTA_TREE=y`, `CONFIG_QUOTACTL=y`, and `CONFIG_BLK_DEV_LOOP=y`

Fixes Dstack-TEE/meta-dstack#80
