### PR TITLE
dstack-util: bound LUKS2 keyslot area to the metadata region

### DIFF
--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -2946,6 +2946,16 @@ fn validate_single_luks2_header(mut reader: impl std::io::Read, hdr_ind: u64) ->
         if area.encryption() != "aes-xts-plain64" {
             bail!("Invalid LUKS keyslot encryption: {}", area.encryption());
         }
+        // Pin where the encrypted key material is read from. The binary area
+        // must sit between the two header copies and the encrypted payload;
+        // otherwise a host with raw disk access could redirect it elsewhere.
+        if area.offset() < 2 * hdr_size || area.offset() + area.size() > PAYLOAD_OFFSET {
+            bail!(
+                "Invalid LUKS keyslot area: offset={} size={}",
+                area.offset(),
+                area.size()
+            );
+        }
         if *key_size != 64 {
             bail!("Invalid LUKS keyslot key size: {key_size}");
         }
@@ -2956,6 +2966,9 @@ fn validate_single_luks2_header(mut reader: impl std::io::Read, hdr_ind: u64) ->
             let LuksKdf::pbkdf2 {
                 hash,
                 iterations: _,
+                // Salts are left unchecked on purpose: the passphrase is
+                // high-entropy and KMS-derived, so an attacker-chosen salt
+                // buys nothing without it (see security report #552).
                 salt: _,
             } = kdf
             else {
@@ -3044,6 +3057,30 @@ fn test_validate_luks2_header() {
     assert!(error
         .to_string()
         .contains("Invalid LUKS keyslot encryption"));
+}
+
+#[test]
+fn test_validate_luks2_header_rejects_out_of_range_keyslot_area() {
+    // Redirect the keyslot binary area below the header region. Same length
+    // so the surrounding header stays intact; "00768" parses to 768, which is
+    // inside the header copies (< 2 * hdr_size) rather than the metadata gap.
+    let mut header = include_bytes!("../tests/fixtures/luks_header_good").to_vec();
+    let needle = br#""offset":"32768""#;
+    let replacement = br#""offset":"00768""#;
+    let mut patched = 0;
+    let mut i = 0;
+    while i + needle.len() <= header.len() {
+        if &header[i..i + needle.len()] == needle {
+            header[i..i + needle.len()].copy_from_slice(replacement);
+            patched += 1;
+            i += needle.len();
+        } else {
+            i += 1;
+        }
+    }
+    assert_eq!(patched, 2, "expected to patch both header copies");
+    let error = validate_luks2_headers(&mut &header[..]).unwrap_err();
+    assert!(error.to_string().contains("Invalid LUKS keyslot area"));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The in-memory LUKS2 header validator checks the cipher and KDF shape exhaustively, but never bounds the keyslot `area.offset`/`area.size` — the on-disk byte range the encrypted key material is read from. This adds a bounds check.

## Why

A malicious host has raw read/write access to the disk. Without this check it can point the keyslot area anywhere inside an otherwise fully-conforming header, and the validator still accepts it.

It's **not exploitable on its own**: cryptsetup decrypts the keyslot under the KMS-derived passphrase and verifies the recovered key against the digest, so a redirected area just yields the wrong key and `luksOpen` aborts (a DoS a host with disk write already has). But a validator whose whole job is to pin the header shouldn't let the key material come from an arbitrary offset. This closes the gap as defense-in-depth.

## Change

- Reject a keyslot area outside `[2 * hdr_size, PAYLOAD_OFFSET)` — after both header copies, before the payload.
- Test that a header with the area redirected below the header region is rejected.
- Comment noting salts stay unchecked on purpose (high-entropy KMS passphrase, per report #552), so the gap doesn't read as an oversight later.

No cross-copy comparison is added: both copies already pass the same strict whitelist independently, so once the area is bounded they can't meaningfully diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)