### PR TITLE
Serve KMS ClearImageCache on a dedicated authenticated admin listener

### DIFF
--- a/dstack/crates/dstack-cli-core/src/config.rs
+++ b/dstack/crates/dstack-cli-core/src/config.rs
@@ -135,7 +135,6 @@ mandatory = false
 
 [core]
 cert_dir = "/kms/certs"
-admin_token_hash = ""
 # single-node: the KMS does not self-attest to its own auth API before
 # bootstrap (it still attests the genesis keys via the guest agent, and app
 # auth + per-app quote checks are unaffected).

--- a/dstack/kms/README.md
+++ b/dstack/kms/README.md
@@ -30,6 +30,41 @@ CVMs running in dstack support three boot modes:
 - `key-provider` in RTMR: `{"type": "kms", "id": "<kms-root-pubkey>"}`
 - `app-id` is equal to the address of the deployed App Smart Contract.
 
+## Admin API authentication
+
+The KMS public RPCs authenticate callers by RA-TLS attestation. Operator-facing
+admin RPCs (currently `ClearImageCache`) are instead served on a **separate admin
+listener** (`[core.admin]` in `kms.toml`) behind the same shared HTTP
+authenticator used by the VMM and gateway, configured identically to the gateway
+admin API, so the credential travels in the `Authorization: Bearer <token>` or
+`X-Admin-Token: <token>` header:
+
+```toml
+[core.admin]
+enabled = true
+address = "127.0.0.1"
+port = 8001
+# generate with: openssl rand -hex 32
+auth_token = "<token>"
+# htpasswd_file = "/etc/kms/admin.htpasswd"   # bcrypt (htpasswd -B), optional
+insecure_no_auth = false
+```
+
+The token can also be supplied via the `DSTACK_KMS_ADMIN_TOKEN` or
+`ADMIN_API_TOKEN` environment variables instead of the config file. The admin
+listener fails closed: enabled with neither `auth_token` nor `htpasswd_file`
+(and `insecure_no_auth = false`) refuses to start. Call it with, for example:
+
+```bash
+curl -X POST "http://127.0.0.1:8001/prpc/Admin.ClearImageCache?json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"image_hash": "<hash>", "config_hash": "<hash>"}'
+```
+
+This admin authentication is separate from the on-chain / webhook authorization
+below, which decides whether a CVM may boot and receive keys.
+
 ## KMS Implementation
 
 ### Components

--- a/dstack/kms/dstack-app/compose-dev.yaml
+++ b/dstack/kms/dstack-app/compose-dev.yaml
@@ -63,7 +63,6 @@ configs:
 
       [core]
       cert_dir = "/kms/certs"
-      admin_token_hash = "${ADMIN_TOKEN_HASH}"
 
       [core.image]
       verify = true

--- a/dstack/kms/dstack-app/compose-simple.yaml
+++ b/dstack/kms/dstack-app/compose-simple.yaml
@@ -39,7 +39,6 @@ configs:
 
       [core]
       cert_dir = "/kms/certs"
-      admin_token_hash = "${ADMIN_TOKEN_HASH}"
 
       [core.image]
       verify = true

--- a/dstack/kms/dstack-app/entrypoint.sh
+++ b/dstack/kms/dstack-app/entrypoint.sh
@@ -8,9 +8,6 @@
 set -e
 
 cat <<EOF > ./kms.toml
-[core]
-admin_token_hash = "${ADMIN_TOKEN_HASH}"
-
 [core.image]
 verify = ${VERIFY_IMAGE}
 cache_dir = "./images"

--- a/dstack/kms/kms.toml
+++ b/dstack/kms/kms.toml
@@ -25,7 +25,6 @@ mandatory = false
 [core]
 cert_dir = "/etc/kms/certs"
 subject_postfix = ".dstack"
-admin_token_hash = ""
 site_name = ""
 # Whether trusted RPCs require the KMS to first attest itself to its own
 # auth API. Defaults to true (strict). Set to false ONLY when running KMS
@@ -52,6 +51,25 @@ verify = true
 cache_dir = "/usr/share/dstack/images"
 download_url = "http://localhost:8000/{OS_IMAGE_HASH}.tar.gz"
 download_timeout = "2m"
+
+# Admin API: serves operator RPCs (e.g. ClearImageCache) on a dedicated
+# listener behind the shared HTTP authenticator. Disabled by default; when
+# enabled it fails closed unless auth_token or htpasswd_file is set.
+[core.admin]
+enabled = false
+# Bind address/port for the admin listener (keep it off the public network).
+address = "127.0.0.1"
+port = 8001
+# Shared admin token required by every admin RPC. Can also be supplied via the
+# `DSTACK_KMS_ADMIN_TOKEN` or `ADMIN_API_TOKEN` env vars. Clients send it as
+# `Authorization: Bearer <token>` or the `X-Admin-Token: <token>` header.
+# Required unless insecure_no_auth = true. Generate with: openssl rand -hex 32
+auth_token = ""
+# Optional Apache bcrypt htpasswd file (create with `htpasswd -B -c file admin`).
+htpasswd_file = ""
+# Development/testing escape hatch only. Never enable this on an admin
+# interface that is reachable from the network.
+insecure_no_auth = false
 
 [core.metrics]
 # Expose unauthenticated Prometheus metrics on /metrics.

--- a/dstack/kms/rpc/proto/kms_rpc.proto
+++ b/dstack/kms/rpc/proto/kms_rpc.proto
@@ -105,14 +105,20 @@ service KMS {
   rpc GetTempCaCert(google.protobuf.Empty) returns (GetTempCaCertResponse);
   // Sign a certificate
   rpc SignCert(SignCertRequest) returns (SignCertResponse);
+}
+
+// The KMS admin RPC service. Served on a separate admin listener
+// (`[core.admin]`) behind the shared HTTP authenticator, so the credential
+// travels in the `Authorization`/`X-Admin-Token` header rather than the
+// request body.
+service Admin {
   // Clear the image cache
   rpc ClearImageCache(ClearImageCacheRequest) returns (google.protobuf.Empty);
 }
 
 message ClearImageCacheRequest {
-  string token = 1;
-  string image_hash = 2;
-  string config_hash = 3;
+  string image_hash = 1;
+  string config_hash = 2;
 }
 
 message BootstrapRequest {

--- a/dstack/kms/src/admin_auth.rs
+++ b/dstack/kms/src/admin_auth.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! KMS adapter for the shared API authenticator, guarding the admin listener.
+//!
+//! Unlike the KMS public RPC surface (which authenticates callers by RA-TLS
+//! attestation), the admin API is reached by operators/tooling, so it uses the
+//! same shared-token/htpasswd HTTP mechanism as the VMM and gateway. The token
+//! is configured via `core.admin.auth_token`, or the `DSTACK_KMS_ADMIN_TOKEN` /
+//! `ADMIN_API_TOKEN` environment variables.
+
+use anyhow::{bail, Result};
+use dstack_api_auth::{Authenticator, HttpAuthConfig, HttpAuthFairing};
+use rocket::Route;
+
+use crate::config::AdminConfig;
+
+const ENV_ADMIN_TOKEN: &str = "DSTACK_KMS_ADMIN_TOKEN";
+const ENV_ADMIN_TOKEN_COMPAT: &str = "ADMIN_API_TOKEN";
+
+pub struct AdminAuthFairing(HttpAuthFairing);
+
+impl AdminAuthFairing {
+    pub fn from_config(config: &AdminConfig) -> Result<Self> {
+        if config.insecure_no_auth {
+            return Ok(Self(HttpAuthFairing::new(
+                Authenticator::disabled(),
+                http_config(),
+            )));
+        }
+        let token = if !config.auth_token.is_empty() {
+            config.auth_token.trim().to_owned()
+        } else {
+            std::env::var(ENV_ADMIN_TOKEN)
+                .or_else(|_| std::env::var(ENV_ADMIN_TOKEN_COMPAT))
+                .unwrap_or_default()
+                .trim()
+                .to_owned()
+        };
+        if token.is_empty() && config.htpasswd_file.as_os_str().is_empty() {
+            bail!(
+                "admin API is enabled but neither auth_token nor htpasswd_file is configured; \
+                 set core.admin.auth_token, {ENV_ADMIN_TOKEN}, {ENV_ADMIN_TOKEN_COMPAT}, \
+                 core.admin.htpasswd_file, or insecure_no_auth = true (testing only)"
+            );
+        }
+        let mut auth = Authenticator::from_tokens([token]);
+        if !config.htpasswd_file.as_os_str().is_empty() {
+            auth = auth.with_htpasswd_file(&config.htpasswd_file)?;
+        }
+        Ok(Self(HttpAuthFairing::new(auth, http_config())))
+    }
+}
+
+fn http_config() -> HttpAuthConfig {
+    HttpAuthConfig {
+        realm: "dstack-kms admin".into(),
+        token_header: Some("X-Admin-Token".into()),
+        allow_get_query_token: false,
+    }
+}
+
+#[rocket::async_trait]
+impl rocket::fairing::Fairing for AdminAuthFairing {
+    fn info(&self) -> rocket::fairing::Info {
+        self.0.info()
+    }
+    async fn on_request(&self, req: &mut rocket::Request<'_>, data: &mut rocket::Data<'_>) {
+        self.0.on_request(req, data).await
+    }
+}
+
+pub fn routes() -> Vec<Route> {
+    dstack_api_auth::routes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_without_credentials_fails_closed() {
+        // the token can also come from the environment; make sure neither var is
+        // set so this exercises the missing-credential path.
+        std::env::remove_var(ENV_ADMIN_TOKEN);
+        std::env::remove_var(ENV_ADMIN_TOKEN_COMPAT);
+        let cfg = AdminConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        assert!(AdminAuthFairing::from_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn insecure_no_auth_is_allowed() {
+        let cfg = AdminConfig {
+            enabled: true,
+            insecure_no_auth: true,
+            ..Default::default()
+        };
+        assert!(AdminAuthFairing::from_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn configured_token_builds() {
+        let cfg = AdminConfig {
+            enabled: true,
+            auth_token: "secret".into(),
+            ..Default::default()
+        };
+        assert!(AdminAuthFairing::from_config(&cfg).is_ok());
+    }
+}

--- a/dstack/kms/src/admin_service.rs
+++ b/dstack/kms/src/admin_service.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! KMS admin RPC service, served on the `[core.admin]` listener behind the
+//! shared HTTP authenticator. Callers are authenticated by the admin token /
+//! htpasswd via `Authorization`/`X-Admin-Token`, so the handlers do no token
+//! checks of their own.
+
+use anyhow::Result;
+use dstack_kms_rpc::{
+    admin_server::{AdminRpc, AdminServer},
+    ClearImageCacheRequest,
+};
+use ra_rpc::{CallContext, RpcCall};
+
+use crate::main_service::KmsState;
+
+pub struct AdminRpcHandler {
+    state: KmsState,
+}
+
+impl AdminRpc for AdminRpcHandler {
+    async fn clear_image_cache(self, request: ClearImageCacheRequest) -> Result<()> {
+        self.state
+            .clear_image_cache(&request.image_hash, &request.config_hash)
+    }
+}
+
+impl RpcCall<KmsState> for AdminRpcHandler {
+    type PrpcService = AdminServer<Self>;
+
+    fn construct(context: CallContext<'_, KmsState>) -> Result<Self> {
+        Ok(AdminRpcHandler {
+            state: context.state.clone(),
+        })
+    }
+}

--- a/dstack/kms/src/config.rs
+++ b/dstack/kms/src/config.rs
@@ -59,8 +59,6 @@ pub(crate) struct KmsConfig {
     /// mirroring `sev_snp_key_release`.
     #[serde(default)]
     pub aws_nitro_tpm_key_release: bool,
-    #[serde(with = "serde_human_bytes")]
-    pub admin_token_hash: Vec<u8>,
     #[serde(default)]
     pub site_name: String,
     /// Whether trusted RPCs require the KMS to first attest itself to its
@@ -70,12 +68,39 @@ pub(crate) struct KmsConfig {
     #[serde(default = "default_true")]
     pub enforce_self_authorization: bool,
     pub metrics: MetricsConfig,
+    /// Admin API listener + authentication. The admin RPCs (e.g.
+    /// `ClearImageCache`) are served here, behind the shared HTTP authenticator.
+    #[serde(default)]
+    pub admin: AdminConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct MetricsConfig {
     /// Whether to expose the unauthenticated Prometheus `/metrics` endpoint.
     pub enabled: bool,
+}
+
+/// Admin API listener + authentication, mirroring the gateway `[core.admin]`
+/// section. The listen `address`/`port` are read from the same `[core.admin]`
+/// section by Rocket. The token travels in the `Authorization`/`X-Admin-Token`
+/// header.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct AdminConfig {
+    /// Whether to serve the admin API at all.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Shared admin token required to call any admin RPC. Can also be supplied
+    /// via `DSTACK_KMS_ADMIN_TOKEN` / `ADMIN_API_TOKEN`. Required unless
+    /// `insecure_no_auth = true`.
+    #[serde(default)]
+    pub auth_token: String,
+    /// Optional Apache bcrypt htpasswd file, accepted in addition to the token.
+    #[serde(default)]
+    pub htpasswd_file: PathBuf,
+    /// Development-only escape hatch: serve the admin API with no auth. Never
+    /// enable on a network-reachable listener.
+    #[serde(default)]
+    pub insecure_no_auth: bool,
 }
 
 fn default_true() -> bool {
@@ -159,4 +184,24 @@ pub(crate) struct Dev {
 pub(crate) struct OnboardConfig {
     pub enabled: bool,
     pub auto_bootstrap_domain: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_parses_with_admin_disabled_and_no_hash() {
+        let figment = load_config_figment(None);
+        let config: KmsConfig = figment
+            .focus("core")
+            .extract()
+            .expect("kms.toml must parse into KmsConfig");
+        assert!(!config.admin.enabled, "admin must be off by default");
+        assert!(
+            config.admin.auth_token.is_empty(),
+            "default admin token must be empty (fail-closed)"
+        );
+        assert!(!config.admin.insecure_no_auth);
+    }
 }

--- a/dstack/kms/src/main.rs
+++ b/dstack/kms/src/main.rs
@@ -15,6 +15,8 @@ use rocket::{
 };
 use tracing::{info, warn};
 
+mod admin_auth;
+mod admin_service;
 mod config;
 // mod ct_log;
 mod crypto;
@@ -147,6 +149,21 @@ async fn main() -> Result<()> {
     let pccs_url = config.pccs_url.clone();
     let amd_kds_base_url = config.amd_kds_base_url.clone();
     let metrics_enabled = config.metrics.enabled;
+    let admin_config = config.admin.clone();
+    // build the admin listener figment from `[core.admin]` before `config` is
+    // moved into the state; the fairing is built now so a misconfigured admin
+    // (enabled but no credential) fails fast before we start serving.
+    let admin_setup = if admin_config.enabled {
+        let admin_value = figment
+            .find_value("core.admin")
+            .context("core.admin section not found")?;
+        let admin_figment =
+            Figment::from(rocket::Config::default()).merge(Serialized::defaults(admin_value));
+        let admin_fairing = admin_auth::AdminAuthFairing::from_config(&admin_config)?;
+        Some((admin_figment, admin_fairing))
+    } else {
+        None
+    };
     let state = main_service::KmsState::new(config).context("Failed to initialize KMS state")?;
     let figment = figment
         .clone()
@@ -161,7 +178,7 @@ async fn main() -> Result<()> {
             "/prpc",
             ra_rpc::prpc_routes!(KmsState, RpcHandler, trim: "KMS."),
         )
-        .manage(state);
+        .manage(state.clone());
 
     if metrics_enabled {
         info!("Prometheus metrics endpoint enabled at /metrics");
@@ -176,9 +193,33 @@ async fn main() -> Result<()> {
     let verifier = QuoteVerifier::new_with_amd_kds_base(pccs_url, amd_kds_base_url);
     rocket = rocket.manage(verifier);
 
-    rocket
-        .launch()
-        .await
-        .map_err(|err| anyhow!(err.to_string()))?;
+    let main_srv = rocket.launch();
+    match admin_setup {
+        Some((admin_figment, admin_fairing)) => {
+            if admin_config.insecure_no_auth {
+                warn!(
+                    "admin API is served with insecure_no_auth = true; the admin RPCs are exposed without authentication"
+                );
+            } else {
+                info!("admin API authentication enabled");
+            }
+            let admin_srv = rocket::custom(admin_figment)
+                .attach(admin_fairing)
+                .mount("/", admin_auth::routes())
+                .mount(
+                    "/prpc",
+                    ra_rpc::prpc_routes!(KmsState, admin_service::AdminRpcHandler, trim: "Admin."),
+                )
+                .manage(state)
+                .launch();
+            tokio::try_join!(
+                async { main_srv.await.map_err(|err| anyhow!(err.to_string())) },
+                async { admin_srv.await.map_err(|err| anyhow!(err.to_string())) },
+            )?;
+        }
+        None => {
+            main_srv.await.map_err(|err| anyhow!(err.to_string()))?;
+        }
+    }
     Ok(())
 }

--- a/dstack/kms/src/main_service.rs
+++ b/dstack/kms/src/main_service.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    path::{Path, PathBuf},
+    path::Path,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -13,9 +13,9 @@ use std::{
 use anyhow::{bail, Context, Result};
 use dstack_kms_rpc::{
     kms_server::{KmsRpc, KmsServer},
-    AppId, AppKeyResponse, ClearImageCacheRequest, GetAppKeyRequest, GetKmsKeyRequest,
-    GetMetaResponse, GetTempCaCertResponse, KmsKeyResponse, KmsKeys, PublicKeyResponse,
-    SignCertRequest, SignCertResponse,
+    AppId, AppKeyResponse, GetAppKeyRequest, GetKmsKeyRequest, GetMetaResponse,
+    GetTempCaCertResponse, KmsKeyResponse, KmsKeys, PublicKeyResponse, SignCertRequest,
+    SignCertResponse,
 };
 use dstack_verifier::{CvmVerifier, VerificationDetails};
 use fs_err as fs;
@@ -94,7 +94,44 @@ impl KmsMetrics {
     }
 }
 
+/// remove a single cache entry (a hex-named subdir/file) under `parent_dir`, or
+/// everything when `sub_dir == "all"`. A non-hex key is rejected to keep the
+/// deletion confined to the cache.
+fn remove_cache(parent_dir: &Path, sub_dir: &str) -> Result<()> {
+    if sub_dir.is_empty() {
+        return Ok(());
+    }
+    if sub_dir == "all" {
+        if parent_dir.exists() {
+            fs::remove_dir_all(parent_dir)?;
+        }
+        return Ok(());
+    }
+    if !sub_dir.chars().all(|c| c.is_ascii_hexdigit()) {
+        bail!("invalid cache key");
+    }
+    let path = parent_dir.join(sub_dir);
+    if path.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else if path.is_file() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
 impl KmsState {
+    /// clear cached image and measurement material for the given hashes. Used by
+    /// the admin `ClearImageCache` RPC; authorization is enforced by the admin
+    /// listener's HTTP authenticator, not here.
+    pub(crate) fn clear_image_cache(&self, image_hash: &str, config_hash: &str) -> Result<()> {
+        let images_dir = self.config.image.cache_dir.join("images");
+        remove_cache(&images_dir, image_hash).context("failed to clear image cache")?;
+        // measurement cache is kept by the verifier under measurements/.
+        let mr_cache_dir = self.config.image.cache_dir.join("measurements");
+        remove_cache(&mr_cache_dir, config_hash).context("failed to clear measurement cache")?;
+        Ok(())
+    }
+
     pub fn new(config: KmsConfig) -> Result<Self> {
         let root_ca = CaCert::load(config.root_ca_cert(), config.root_ca_key())
             .context("Failed to load root CA certificate")?;
@@ -233,42 +270,6 @@ impl RpcHandler {
         let att = self.ensure_attested()?;
         self.ensure_app_attestation_allowed(att, false, false, vm_config)
             .await
-    }
-
-    fn image_cache_dir(&self) -> PathBuf {
-        self.state.config.image.cache_dir.join("images")
-    }
-
-    fn remove_cache(&self, parent_dir: &Path, sub_dir: &str) -> Result<()> {
-        if sub_dir.is_empty() {
-            return Ok(());
-        }
-
-        if sub_dir == "all" {
-            fs::remove_dir_all(parent_dir)?;
-            return Ok(());
-        }
-
-        if !sub_dir.chars().all(|c| c.is_ascii_hexdigit()) {
-            bail!("Invalid cache key");
-        }
-
-        let path = parent_dir.join(sub_dir);
-
-        if path.is_dir() {
-            fs::remove_dir_all(path)?;
-        } else if path.is_file() {
-            fs::remove_file(path)?;
-        }
-
-        Ok(())
-    }
-
-    fn ensure_admin(&self, token: &str) -> Result<()> {
-        if !dstack_api_auth::verify_sha256_token(token, &self.state.config.admin_token_hash) {
-            bail!("invalid token");
-        }
-        Ok(())
     }
 
     async fn verify_os_image_hash(
@@ -548,17 +549,6 @@ impl KmsRpc for RpcHandler {
             ],
         })
     }
-
-    async fn clear_image_cache(self, request: ClearImageCacheRequest) -> Result<()> {
-        self.ensure_admin(&request.token)?;
-        self.remove_cache(&self.image_cache_dir(), &request.image_hash)
-            .context("Failed to clear image cache")?;
-        // Clear measurement cache (now handled by verifier's cache in measurements/ dir)
-        let mr_cache_dir = self.state.config.image.cache_dir.join("measurements");
-        self.remove_cache(&mr_cache_dir, &request.config_hash)
-            .context("Failed to clear measurement cache")?;
-        Ok(())
-    }
 }
 
 impl RpcCall<KmsState> for RpcHandler {
@@ -584,6 +574,29 @@ mod tests {
     };
     use cc_eventlog::RuntimeEvent;
     use sha2::{Digest, Sha256, Sha384};
+
+    #[test]
+    fn remove_cache_only_deletes_the_named_hex_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let keep = root.join("cafe");
+        let drop = root.join("beef");
+        fs::create_dir_all(&keep).unwrap();
+        fs::create_dir_all(&drop).unwrap();
+
+        remove_cache(root, "beef").unwrap();
+        assert!(!drop.exists(), "named entry must be removed");
+        assert!(keep.exists(), "other entries must be kept");
+
+        // empty key is a no-op; a non-hex key is rejected before touching disk.
+        remove_cache(root, "").unwrap();
+        assert!(remove_cache(root, "../escape").is_err());
+        assert!(keep.exists());
+
+        // "all" clears the whole cache dir.
+        remove_cache(root, "all").unwrap();
+        assert!(!root.exists());
+    }
     use std::collections::BTreeMap;
 
     fn hex_of(byte: u8, len: usize) -> String {

--- a/dstack/test-scripts/snp-e2e-smoke.sh
+++ b/dstack/test-scripts/snp-e2e-smoke.sh
@@ -367,7 +367,6 @@ mandatory = false
 
 [core]
 cert_dir = "/dstack/kms-certs"
-admin_token_hash = "00"
 pccs_url = ""
 enforce_self_authorization = true
 amd_kds_base_url = "${DSTACK_SNP_SMOKE_KDS_BASE_URL:-}"


### PR DESCRIPTION
## Problem

The KMS admin RPC `ClearImageCache` was authenticated differently from every other admin surface in dstack, and in a way that is easy to get wrong:

- It rode on the **public** KMS RPC service (the same `[rpc]` listener as `GetAppKey`/`SignCert`), gated only by a hand-rolled `ensure_admin` check inside the handler.
- The credential was passed as a **field in the request body** (`ClearImageCacheRequest.token`), compared against `[core] admin_token_hash`. It did **not** use the shared `dstack-api-auth` HTTP authenticator, so — unlike VMM and gateway — `Authorization: Bearer` / `X-Admin-Token` headers were ignored.
- The auth was per-RPC and opt-in: any future admin RPC that forgot to call `ensure_admin` would be unauthenticated, with no framework backstop.

This divergence already caused a documentation error (a sibling PR initially documented the KMS admin token as an `Authorization: Bearer` header, which the server silently ignored).

## Fix

Move `ClearImageCache` onto a dedicated admin listener that reuses the same shared HTTP authenticator as the gateway, so all three services (VMM, gateway, KMS) authenticate admin/management traffic the same way.

- **Proto**: split `ClearImageCache` out of `service KMS` into a new `service KmsAdmin`, and drop the `token` field from `ClearImageCacheRequest` (the credential now travels in the HTTP header).
- **Config**: replace `[core] admin_token_hash` with a gateway-style `[core.admin]` section, configured **identically to the gateway** — `enabled`, `address`/`port`, `admin_token` (plaintext, or the `DSTACK_KMS_ADMIN_TOKEN` / `ADMIN_API_TOKEN` env vars), `htpasswd_file`, `insecure_no_auth`.
- **Auth**: new `kms/src/admin_auth.rs` mirrors the gateway `AdminAuthFairing` — resolves the token from config or env, adds optional bcrypt htpasswd, and **fails closed** (enabled with no credential and `insecure_no_auth = false` refuses to start).
- **Service/launch**: `ClearImageCache` moves to a new `AdminRpcHandler` served on a second Rocket instance bound to `[core.admin]`, behind the `HttpAuthFairing`. `ensure_admin` and the in-handler token check are deleted; the cache-clearing logic moves to `KmsState`.
- **Configs/templates**: drop the now-dead `[core] admin_token_hash` from `kms.toml`, the KMS dstack-app templates, the dstackup KMS template, and the SNP smoke test. The admin API is **disabled by default**; operators opt in via `[core.admin]`.

No backward-compat shim: the RPC had no known callers.

## Verification

- `cargo build` (full workspace), `cargo clippy -p dstack-kms`, `cargo fmt --all --check` — all clean.
- `cargo test -p dstack-kms` (37) / `-p dstack-cli-core` (12) pass, including new tests:
  - `admin_auth`: fail-closed when enabled with no credential (config or env); `insecure_no_auth` allowed; a configured token builds.
  - `config`: the default `kms.toml` parses with `[core.admin]` disabled and an empty token (fail-closed).
  - `main_service::remove_cache_only_deletes_the_named_hex_entry`: the relocated cache-clear logic keeps its hex-key guard and `all` behavior.
- The admin listener's 401/200 enforcement is the shared `dstack-api-auth` `HttpAuthFairing`, which already has passing Rocket integration tests (`protects_all_methods_and_accepts_compatible_credentials`, `enabled_with_no_credentials_denies_access`).

**Not covered:** a live HTTP round-trip against a running KMS admin listener. That needs a fully bootstrapped KMS keyset (genesis attestation), which this change does not stand up. The auth enforcement is exercised by the shared fairing's own tests; the KMS-specific wiring is covered by the unit tests above. Happy to add a fixture-based `rocket::local` integration test if desired.

## Coordination

Supersedes the KMS-admin-token documentation in the docs/tooling PR (which described the old request-field mechanism). If that PR lands first, its `kms/README.md` / `deployment.md` / `security-best-practices.md` KMS-admin notes should be reconciled to the header-based mechanism documented here.

