### PR TITLE
ci: avoid npx cache races in Foundry tests

### DIFF
--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -56,6 +56,9 @@ jobs:
           forge build --sizes
         id: build
 
+      - name: Install OpenZeppelin upgrades validator
+        run: npm install --no-save --package-lock=false @openzeppelin/upgrades-core@^1.37.0
+
       - name: Run Forge tests
         run: |
           forge test --ffi -vvv


### PR DESCRIPTION
## Summary

- preinstall the OpenZeppelin upgrades validator before running Foundry tests
- prevent parallel Forge FFI calls from racing while `npx` installs the same package into its cache
- keep the validator version range aligned with `openzeppelin-foundry-upgrades`

## Context

PR #812 exposed a flaky failure where concurrent validation calls shared the same `~/.npm/_npx` directory and one failed with `ENOTEMPTY` while removing a package directory.

## Testing

- `npx --no-install @openzeppelin/upgrades-core validate --help`
- Full Foundry tests will run in CI (Foundry is not installed in the local environment).