### PR TITLE
fix(e2e): unblock production TDX rolling-upgrade coverage

### DIFF
--- a/test-suites/full-stack-compose/.env.example
+++ b/test-suites/full-stack-compose/.env.example
@@ -50,8 +50,9 @@ DSTACK_E2E_CID_START=15000
 DSTACK_E2E_QGS_PORT=4050
 DSTACK_E2E_QEMU_PATH=/usr/bin/qemu-system-x86_64
 
-# SGX QCNL config used by the Local-Key-Provider that seals each KMS CVM disk.
-DSTACK_E2E_QCNL_CONF=../../dstack/local-key-provider/build/sgx_default_qcnl.conf
+# Host SGX QCNL config used by the Local-Key-Provider that seals each KMS CVM disk.
+# It should point at a PCCS provisioned for this physical platform.
+DSTACK_E2E_QCNL_CONF=/etc/sgx_default_qcnl.conf
 
 # Runner behaviour.
 DSTACK_E2E_CLEAN_START=true

--- a/test-suites/full-stack-compose/README.md
+++ b/test-suites/full-stack-compose/README.md
@@ -63,7 +63,10 @@ would make a passing result irrelevant to production:
 
    - `/dev/kvm`, `/dev/vhost-vsock`, Intel TDX, and QGS (default port `4050`)
    - `/dev/sgx_enclave` and `/dev/sgx_provision`
-   - a working SGX QCNL/PCCS configuration
+   - a working host SGX QCNL configuration at `/etc/sgx_default_qcnl.conf`
+     whose PCCS is provisioned for this physical platform; override its path
+     with `DSTACK_E2E_QCNL_CONF` when needed. A public PCCS only works after
+     this platform's PCK certificate has been registered there.
    - an IPv4/DNS name for the host that is reachable from both the host-side
      deployment client and QEMU user-networked CVMs; the suite derives
      `<default-route-ip>.nip.io`, or accepts `DSTACK_E2E_KMS_RPC_DOMAIN`

--- a/test-suites/full-stack-compose/compose.yml
+++ b/test-suites/full-stack-compose/compose.yml
@@ -109,7 +109,7 @@ services:
       - "/dev/sgx_enclave:/dev/sgx_enclave"
       - "/dev/sgx_provision:/dev/sgx_provision"
     volumes:
-      - ${DSTACK_E2E_QCNL_CONF:-../../dstack/local-key-provider/build/sgx_default_qcnl.conf}:/etc/sgx_default_qcnl.conf:ro
+      - ${DSTACK_E2E_QCNL_CONF:-/etc/sgx_default_qcnl.conf}:/etc/sgx_default_qcnl.conf:ro
       - aesmd-sock:/var/run/aesmd/
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

- use the host `/etc/sgx_default_qcnl.conf` by default so AESMD reaches a PCCS provisioned for the physical SGX platform
- wait for an explicit stopped/exited VM state before restarting during upgrades
- exercise the released meta-dstack v0.5.11 guest alongside the current guest and publish both measured OS archives to KMS verifiers
- ignore transient WireGuard route addresses when comparing durable Gateway state across rolling restarts

## Failures reproduced

1. The bundled public PCCS lacked this host's PCK certificate, causing `AESM_NO_PLATFORM_CERT_DATA` (44).
2. `wait_vm_stopped` treated the transitional `stopping` state as complete, so a replacement QEMU raced the old process and exited.
3. Gateway host IPs legitimately move to the surviving node's subnet during failover; comparing them as durable state rejected a healthy rolling restart.

## Validation

- production Local-Key-Provider SGX enclave loads and becomes healthy with the host QCNL config
- real TDX Local-Key-Provider provisioning succeeds and reports `local-sgx` with the enclave measurement
- KMS 0.5.8 to current quote-attested replication preserves CA SPKI, root k256 key, and per-app environment key
- legacy app restart on latest KMS succeeds after waiting for actual VM shutdown
- mixed-image renderer verifies and packages current v0.6.0 plus released v0.5.11 (`c2aa0186...`) artifacts
- full mixed v0.5.11/current hardware run is in progress
- `prek run --all-files` passes