### PR TITLE
test(e2e): complete mixed-image rolling-upgrade coverage

### DIFF
--- a/test-suites/full-stack-compose/.env.example
+++ b/test-suites/full-stack-compose/.env.example
@@ -5,6 +5,7 @@
 # <store>/<image-name>/{bzImage,initramfs...,rootfs...,digest.txt,sha256sum.txt}
 DSTACK_E2E_IMAGE_STORE=../../../meta-dstack/build/images
 DSTACK_E2E_IMAGE_NAME=dstack-0.6.0
+DSTACK_E2E_OLD_IMAGE_NAME=dstack-0.5.11
 DSTACK_E2E_PLATFORM=tdx
 
 # Exact released upgrade sources. Both are digest-pinned on Docker Hub and

--- a/test-suites/full-stack-compose/README.md
+++ b/test-suites/full-stack-compose/README.md
@@ -73,7 +73,9 @@ would make a passing result irrelevant to production:
    - Docker and WireGuard kernel support
 
 3. Provide an unpacked dstack image directory containing `digest.txt` and
-   `sha256sum.txt`. Copy `.env.example` to `.env` when paths or ports differ.
+   `sha256sum.txt` for both the current image (`DSTACK_E2E_IMAGE_NAME`) and the
+   v0.5.11 compatibility image (`DSTACK_E2E_OLD_IMAGE_NAME`). Copy
+   `.env.example` to `.env` when paths or ports differ.
 
 ## Run
 

--- a/test-suites/full-stack-compose/scripts/render-config.sh
+++ b/test-suites/full-stack-compose/scripts/render-config.sh
@@ -127,7 +127,7 @@ GATEWAY_ADMIN_TOKEN=$(tr -d '[:space:]' < "$token_file")
 
 cat > "$CONFIG_DIR/auth-allowlist.json" <<JSON
 {
-  "osImages": ["$OS_IMAGE_HASH"],
+  "osImages": ["$OS_IMAGE_HASH", "$OLD_OS_IMAGE_HASH"],
   "gatewayAppId": "$GATEWAY_APP_ID",
   "kms": {
     "mrAggregated": [],

--- a/test-suites/full-stack-compose/scripts/render-config.sh
+++ b/test-suites/full-stack-compose/scripts/render-config.sh
@@ -11,6 +11,7 @@ VOLUMES_DIR=${DSTACK_E2E_VOLUMES_DIR:-$STATE_DIR/volumes}
 ARTIFACT_DIR=${DSTACK_E2E_ARTIFACT_DIR:-$STATE_DIR/artifacts}
 IMAGE_ROOT=${DSTACK_E2E_IMAGE_ROOT:-/images}
 IMAGE_NAME=${DSTACK_E2E_IMAGE_NAME:-dstack-0.6.0}
+OLD_IMAGE_NAME=${DSTACK_E2E_OLD_IMAGE_NAME:-dstack-0.5.11}
 PLATFORM=${DSTACK_E2E_PLATFORM:-tdx}
 
 VMM_PORT=${DSTACK_E2E_VMM_PORT:-29080}
@@ -65,13 +66,6 @@ if ! getent ahostsv4 "$KMS_RPC_DOMAIN" >/dev/null 2>&1; then
   exit 1
 fi
 
-image_dir="$IMAGE_ROOT/$IMAGE_NAME"
-if [[ ! -d "$image_dir" ]]; then
-  echo "ERROR: image directory not found: $image_dir" >&2
-  echo "Set DSTACK_E2E_IMAGE_STORE to a host directory containing $IMAGE_NAME/" >&2
-  exit 1
-fi
-
 digest_file=digest.txt
 if [[ "$PLATFORM" == "amd-sev-snp" || "$PLATFORM" == "sev-snp" || "$PLATFORM" == "snp" ]]; then
   PLATFORM=amd-sev-snp
@@ -81,33 +75,49 @@ elif [[ "$PLATFORM" != tdx ]]; then
   exit 1
 fi
 
-if [[ ! -s "$image_dir/$digest_file" ]]; then
-  echo "ERROR: missing $image_dir/$digest_file; production-compatible E2E never permits an unpinned OS image" >&2
-  exit 1
-fi
-OS_IMAGE_HASH=$(tr -d '[:space:]' < "$image_dir/$digest_file")
-if [[ ! "$OS_IMAGE_HASH" =~ ^[0-9a-f]{64}$ ]]; then
-  echo "ERROR: invalid OS image digest: $OS_IMAGE_HASH" >&2
-  exit 1
-fi
+package_os_image() {
+  local name=$1 image_dir="$IMAGE_ROOT/$1" image_hash
+  if [[ ! -d "$image_dir" ]]; then
+    echo "ERROR: image directory not found: $image_dir" >&2
+    echo "Set DSTACK_E2E_IMAGE_STORE to a host directory containing $name/" >&2
+    exit 1
+  fi
+  if [[ ! -s "$image_dir/$digest_file" ]]; then
+    echo "ERROR: missing $image_dir/$digest_file; production-compatible E2E never permits an unpinned OS image" >&2
+    exit 1
+  fi
+  image_hash=$(tr -d '[:space:]' < "$image_dir/$digest_file")
+  if [[ ! "$image_hash" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "ERROR: invalid OS image digest for $name: $image_hash" >&2
+    exit 1
+  fi
 
-# Build the exact flat archive consumed by the KMS verifier. Verify the source
-# first and include only the measured files named by sha256sum.txt.
-(
-  cd "$image_dir"
-  sha256sum -c sha256sum.txt
-  mapfile -t measured_files < <(awk '{print $2}' sha256sum.txt)
-  for file in "${measured_files[@]}"; do
-    [[ "$file" != */* && -f "$file" ]] || {
-      echo "ERROR: unsafe or missing measured image file: $file" >&2
-      exit 1
-    }
-  done
-  tar -czf "$ARTIFACT_DIR/os/mr_${OS_IMAGE_HASH}.tar.gz.tmp" \
-    sha256sum.txt "${measured_files[@]}"
-)
-mv "$ARTIFACT_DIR/os/mr_${OS_IMAGE_HASH}.tar.gz.tmp" \
-  "$ARTIFACT_DIR/os/mr_${OS_IMAGE_HASH}.tar.gz"
+  # Build the exact flat archive consumed by the KMS verifier. Verify the
+  # source first and include only files named by sha256sum.txt.
+  (
+    cd "$image_dir"
+    sha256sum -c sha256sum.txt >&2
+    mapfile -t measured_files < <(awk '{print $2}' sha256sum.txt)
+    for file in "${measured_files[@]}"; do
+      [[ "$file" != */* && -f "$file" ]] || {
+        echo "ERROR: unsafe or missing measured image file: $file" >&2
+        exit 1
+      }
+    done
+    tar -czf "$ARTIFACT_DIR/os/mr_${image_hash}.tar.gz.tmp" \
+      sha256sum.txt "${measured_files[@]}"
+  )
+  mv "$ARTIFACT_DIR/os/mr_${image_hash}.tar.gz.tmp" \
+    "$ARTIFACT_DIR/os/mr_${image_hash}.tar.gz"
+  printf '%s' "$image_hash"
+}
+
+OS_IMAGE_HASH=$(package_os_image "$IMAGE_NAME")
+if [[ "$OLD_IMAGE_NAME" == "$IMAGE_NAME" ]]; then
+  OLD_OS_IMAGE_HASH=$OS_IMAGE_HASH
+else
+  OLD_OS_IMAGE_HASH=$(package_os_image "$OLD_IMAGE_NAME")
+fi
 
 token_file="$STATE_DIR/gateway-admin-token"
 if [[ ! -s "$token_file" ]]; then
@@ -237,8 +247,10 @@ VM_DIR=$VM_DIR
 ARTIFACT_DIR=$ARTIFACT_DIR
 IMAGE_ROOT=$IMAGE_ROOT
 IMAGE_NAME=$IMAGE_NAME
+OLD_IMAGE_NAME=$OLD_IMAGE_NAME
 PLATFORM=$PLATFORM
 OS_IMAGE_HASH=$OS_IMAGE_HASH
+OLD_OS_IMAGE_HASH=$OLD_OS_IMAGE_HASH
 VMM_PORT=$VMM_PORT
 AUTH_PORT=$AUTH_PORT
 ARTIFACT_PORT=$ARTIFACT_PORT
@@ -271,5 +283,6 @@ echo "  auth:         http://10.0.2.2:${AUTH_PORT}"
 echo "  artifacts:    http://10.0.2.2:${ARTIFACT_PORT}"
 echo "  old KMS:      https://${KMS_RPC_DOMAIN}:${KMS_OLD_HOST_PORT}"
 echo "  latest KMS:   https://${KMS_RPC_DOMAIN}:${KMS_LATEST_HOST_PORT}"
-echo "  image:        ${IMAGE_NAME} (${OS_IMAGE_HASH})"
+echo "  current image: ${IMAGE_NAME} (${OS_IMAGE_HASH})"
+echo "  old image:     ${OLD_IMAGE_NAME} (${OLD_OS_IMAGE_HASH})"
 echo "  gateway app:  ${GATEWAY_APP_ID}"

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -568,12 +568,12 @@ render_app() {
 }
 
 deploy_app() {
-  local label=$1 mode=$2 kms_url=$3 out vm_id
+  local label=$1 mode=$2 kms_url=$3 guest_image=${4:-$IMAGE_NAME} out vm_id
   render_app "$label" "$mode"
   log "deploying $label app CVM (forced TDX $mode)"
   if ! out=$("${VMM_CLI[@]}" deploy \
     --name "${SUITE_PREFIX}-${label}" \
-    --image "$IMAGE_NAME" \
+    --image "$guest_image" \
     --compose "$WORK_DIR/${label}.app-compose.json" \
     --kms-url "$kms_url" \
     --gateway-url "$GATEWAY1_URL" \
@@ -806,7 +806,7 @@ phase_upgrade() {
   gateway_version 2 old
   bootstrap_gateway
 
-  deploy_app legacy legacy "$KMS_OLD_URL"
+  deploy_app legacy legacy "$KMS_OLD_URL" "$OLD_IMAGE_NAME"
   verify_app_via_gateway legacy 1
   verify_app_via_gateway legacy 2
   capture_kms_identity old "$KMS_OLD_HOST_PORT" "$(cat "$WORK_DIR/legacy.app_id")"

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -863,6 +863,11 @@ phase_upgrade() {
     "$WORK_DIR/artifacts-access.log" || true)
   (( os_archive_gets >= 2 )) \
     || die "expected verified OS image downloads by both KMS versions, saw ${os_archive_gets}"
+  os_archive_gets=$(grep -Fc \
+    "GET /os/mr_${OLD_OS_IMAGE_HASH}.tar.gz HTTP/1.1\" 200" \
+    "$WORK_DIR/artifacts-access.log" || true)
+  (( os_archive_gets >= 2 )) \
+    || die "expected v0.5.11 OS verification by both KMS versions, saw ${os_archive_gets}"
   if grep -E 'Image verification is disabled|self-authorization is disabled' \
     "$WORK_DIR/kms-"*.vm.log; then
     die "KMS logs contain a forbidden disabled verification path"

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -115,7 +115,7 @@ wait_vm_stopped() {
   local id=$1 deadline=$((SECONDS + 180)) status
   while (( SECONDS < deadline )); do
     status=$("${VMM_CLI[@]}" info "$id" --json 2>/dev/null | jq -r '.status // ""' || true)
-    [[ "$status" != running && "$status" != starting ]] && return
+    [[ "$status" == stopped || "$status" == exited ]] && return
     sleep 2
   done
   die "VM $id did not stop"

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -861,19 +861,23 @@ phase_upgrade() {
   assert_no_insecure_shortcuts
   save_vm_logs
   # dstack-kms runs in an inner container, whose stdout is not part of the CVM
-  # serial log returned by VMM.  Each KMS has a fresh data disk, so two 200 GETs
-  # for the exact measured archive prove that both verifiers downloaded it.
+  # serial log returned by VMM.  Require an observed successful fetch of each
+  # exact measured archive, but do not require one fetch per KMS: onboarding
+  # deliberately copies durable KMS state and its verified-image cache.  The
+  # exact two-image allowlist asserted above, absence of disabled-verification
+  # paths below, and successful key delivery to old/current-image guests prove
+  # that the serving KMS accepted both images without assuming cache misses.
   local os_archive_gets
   os_archive_gets=$(grep -Fc \
     "GET /os/mr_${OS_IMAGE_HASH}.tar.gz HTTP/1.1\" 200" \
     "$WORK_DIR/artifacts-access.log" || true)
-  (( os_archive_gets >= 2 )) \
-    || die "expected verified OS image downloads by both KMS versions, saw ${os_archive_gets}"
+  (( os_archive_gets >= 1 )) \
+    || die "expected a verified current OS image archive download, saw ${os_archive_gets}"
   os_archive_gets=$(grep -Fc \
     "GET /os/mr_${OLD_OS_IMAGE_HASH}.tar.gz HTTP/1.1\" 200" \
     "$WORK_DIR/artifacts-access.log" || true)
-  (( os_archive_gets >= 2 )) \
-    || die "expected v0.5.11 OS verification by both KMS versions, saw ${os_archive_gets}"
+  (( os_archive_gets >= 1 )) \
+    || die "expected a verified v0.5.11 OS image archive download, saw ${os_archive_gets}"
   if grep -E 'Image verification is disabled|self-authorization is disabled' \
     "$WORK_DIR/kms-"*.vm.log; then
     die "KMS logs contain a forbidden disabled verification path"

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -571,8 +571,12 @@ render_app() {
 }
 
 deploy_app() {
-  local label=$1 mode=$2 kms_url=$3 guest_image=${4:-$IMAGE_NAME} out vm_id
-  render_app "$label" "$mode"
+  local label=$1 mode=$2 kms_url=$3 guest_image=${4:-$IMAGE_NAME} manifest_mode out vm_id
+  manifest_mode=$mode
+  # v0.5.11 only accepts numeric manifest versions. Omitting v3 requirements
+  # lets that released guest select its native legacy TDX attestation path.
+  [[ "$guest_image" == "$OLD_IMAGE_NAME" ]] && manifest_mode=auto
+  render_app "$label" "$manifest_mode"
   log "deploying $label app CVM (forced TDX $mode)"
   if ! out=$("${VMM_CLI[@]}" deploy \
     --name "${SUITE_PREFIX}-${label}" \

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -501,7 +501,10 @@ capture_gateway_state() {
     | jq -S '. as $status | {
         id: $status.id,
         uuid: ([$status.nodes[] | select(.id == $status.id)][0].uuid),
-        hosts: ([$status.hosts[] | {instance_id,ip,app_id,base_domain}] | sort_by(.instance_id))
+        # The active WireGuard address can move to the surviving Gateway
+        # subnet during a rolling restart. It is runtime routing state, not a
+        # durable identity invariant.
+        hosts: ([$status.hosts[] | {instance_id,app_id,base_domain}] | sort_by(.instance_id))
       }' \
     > "$WORK_DIR/gateway${node}-${stage}.status.json"
   admin_curl "$node" GetCertbotConfig | jq -S \

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -748,10 +748,10 @@ PY
 
   jq -e '
     .kms_enabled == true and .gateway_enabled == true
-    and .manifest_version == "3"
-    and .requirements.tdx_measure_acpi_tables == true
+    and .manifest_version == 2
+    and (has("requirements") | not)
   ' "$WORK_DIR/legacy.app-compose.json" >/dev/null \
-    || die "legacy app manifest did not force the legacy TDX verifier"
+    || die "v0.5.11 app manifest is not legacy-compatible"
   jq -e '
     .kms_enabled == true and .gateway_enabled == true
     and .manifest_version == "3"
@@ -761,8 +761,10 @@ PY
 
   jq -e --arg id "$GATEWAY_APP_ID" \
     --arg device "$ATTESTED_DEVICE_ID" \
+    --arg current_image "$OS_IMAGE_HASH" \
+    --arg old_image "$OLD_OS_IMAGE_HASH" \
     '.gatewayAppId == $id and .gatewayAppId != "any"
-      and (.osImages | length) == 1
+      and (.osImages | sort == ([$current_image, $old_image] | sort))
       and (.kms.mrAggregated | length) == 2
       and (.kms.allowAnyDevice == false)
       and (.kms.devices == [$device])

--- a/test-suites/full-stack-compose/scripts/runner.sh
+++ b/test-suites/full-stack-compose/scripts/runner.sh
@@ -555,10 +555,14 @@ assert_gateway_dns_credential_usable() {
 }
 
 render_app() {
-  local label=$1 mode=$2 meta app_id hash
+  local label=$1 mode=$2 meta app_id hash image_ref=$APP_IMAGE_ID
+  # The v0.5.11 Docker Compose treats a local image ID (`sha256:...`) as a
+  # repository name and tries to pull it. The pre-launch script has already
+  # loaded the digest-recorded archive under its original tag.
+  [[ "$mode" == auto ]] && image_ref=$APP_IMAGE
   meta=$(/suite/scripts/app_compose.py nginx \
     --name "${APP_NAME}-${label}" \
-    --image-ref "$APP_IMAGE_ID" \
+    --image-ref "$image_ref" \
     --image-archive app.tar \
     --artifact-port "$ARTIFACT_PORT" \
     --attestation-mode "$mode" \


### PR DESCRIPTION
## Summary

Follow-up to #819. The production TDX run exposed additional harness gaps after Local-Key-Provider became healthy. This PR:

- waits for a VM to be conclusively stopped before restarting it;
- provisions traceable v0.5.11/current guest images and measurement archives;
- uses a legacy-compatible manifest for the v0.5.11 guest;
- authorizes both exact OS image hashes;
- preserves durable Gateway state while ignoring transient WireGuard addresses;
- audits the mixed-image policy and verified artifact paths without assuming an onboarding cache miss.

## Verification

- `prek run --all-files`
- saved-state audit from the real TDX/SGX run: current archive GET=1, v0.5.11 archive GET=2, exact two-image allowlist, no disabled verification path, both KMS app keys present
- a clean full real-hardware rerun is in progress

Artifacts used:

- meta-dstack v0.5.11 archive SHA-256: `6f95a2a0b59975780e6f5d8bfbf016d50148092889554e4f8272c401ee549e42`
- v0.5.11 image digest: `c2aa0186182fe8a404f16d5f3facb334d89be32703b3571c401b114a8b6e700d`
- current image digest: `91bc72e3ca6f283cc0549d761ee436d381d1e8c4ddc4c23354e05c9bbccfdec1`
