### PR TITLE
chore(key-provider): use host QCNL config

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -59,7 +59,6 @@ SPDX-License-Identifier = "Apache-2.0"
 path = [
     "dstack/gateway/templates/wg.conf",
     "dstack/guest-agent/templates/metrics.tpl",
-    "dstack/local-key-provider/build/sgx_default_qcnl.conf",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2024-2025 The Project Contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/docs/tutorials/gramine-key-provider.md
+++ b/docs/tutorials/gramine-key-provider.md
@@ -70,10 +70,10 @@ git clone https://github.com/Dstack-TEE/dstack.git
 cd dstack/dstack/local-key-provider/build
 ```
 
-The bundled `sgx_default_qcnl.conf` points AESM at the Phala PCCS. To use a
-different PCCS, edit its `pccs_url` while keeping certificate verification
-enabled, and export the provider's base URL as `PCCS_URL` before running
-Compose.
+Compose mounts the host's `/etc/sgx_default_qcnl.conf` into the AESM
+container. Make sure that file points at a working PCCS before starting the
+services. To use a different PCCS for the provider, export its base URL as
+`PCCS_URL` before running Compose.
 
 Build and start both AESM and the provider:
 

--- a/docs/tutorials/troubleshooting-prerequisites.md
+++ b/docs/tutorials/troubleshooting-prerequisites.md
@@ -289,7 +289,7 @@ docker logs aesmd 2>&1 | tail -30
 **Solution:**
 1. Verify QCNL configuration points to `https://pccs.phala.network/sgx/certification/v4/`
 2. Check network connectivity: `curl -sk https://pccs.phala.network/sgx/certification/v4/rootcacrl`
-3. Verify the QCNL config file exists at `~/dstack/dstack/local-key-provider/build/sgx_default_qcnl.conf`
+3. Verify the host QCNL config file exists at `/etc/sgx_default_qcnl.conf`
 
 ### HTTP health checks fail
 

--- a/dstack/local-key-provider/build/docker-compose.yaml
+++ b/dstack/local-key-provider/build/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - "/dev/sgx_enclave:/dev/sgx_enclave"
       - "/dev/sgx_provision:/dev/sgx_provision"
     volumes:
-      - "./sgx_default_qcnl.conf:/etc/sgx_default_qcnl.conf"
+      - "/etc/sgx_default_qcnl.conf:/etc/sgx_default_qcnl.conf:ro"
       - "aesmd:/var/run/aesmd/"
     network_mode: "host"
 

--- a/dstack/local-key-provider/build/sgx_default_qcnl.conf
+++ b/dstack/local-key-provider/build/sgx_default_qcnl.conf
@@ -1,9 +1,0 @@
-{
-  "pccs_url": "https://pccs.phala.network/sgx/certification/v4/",
-  "use_secure_cert": true,
-  "retry_times": 6,
-  "retry_delay": 10,
-  "pck_cache_expire_hours": 168,
-  "verify_collateral_cache_expire_hours": 168,
-  "local_cache_only": false
-}


### PR DESCRIPTION
## Summary

- mount the host `/etc/sgx_default_qcnl.conf` into the AESM container read-only
- remove the bundled QCNL configuration
- update deployment and troubleshooting documentation

## Validation

- `git diff --check`
- `docker compose -f dstack/local-key-provider/build/docker-compose.yaml config`
- `docker compose -f test-suites/full-stack-compose/compose.yml config`