### PR TITLE
fix(ra-rpc): say whose attestation failed in client-side errors

### DIFF
--- a/dstack/ra-rpc/src/client.rs
+++ b/dstack/ra-rpc/src/client.rs
@@ -156,7 +156,9 @@ impl RaClient {
                         .into_v1()
                         .verify_with_ra_pubkey(cert.public_key().raw, &self.attestation_verifier)
                         .await
-                        .context("Failed to verify the attestation report")?;
+                        .context(
+                            "failed to verify the attestation report presented by the server",
+                        )?;
                     Some(verified_attestation)
                 }
             }
@@ -187,9 +189,17 @@ impl RequestClient for RaClient {
             .await
             .context("Failed to send request")?;
 
+        // Name the direction explicitly: this validates the *server's* attestation,
+        // not the client's own quote. Without it the error chain reads as if the
+        // remote end rejected us.
         self.try_validate_attestation(&response)
             .await
-            .context("Failed to validate attestation")?;
+            .with_context(|| {
+                format!(
+                    "failed to validate the server attestation of {}",
+                    self.remote_uri
+                )
+            })?;
 
         let status = response.status();
         if !status.is_success() {


### PR DESCRIPTION
This pull request improves error messages related to remote attestation verification in the `RaClient` implementation. The main focus is to clarify the error context, making it easier to diagnose issues by specifying that errors are related to the server's attestation, not the client's.

**Error message improvements:**

* Updated the error context in `verify_with_ra_pubkey` to explicitly state it's about verifying the attestation report presented by the server (`dstack/ra-rpc/src/client.rs`).
* Enhanced the error message in `try_validate_attestation` to clarify that it is the server's attestation being validated, and included the `remote_uri` for better traceability (`dstack/ra-rpc/src/client.rs`).