### PR TITLE
fix(gateway): move localhost routing behind an insecure debug flag

### DIFF
--- a/dstack/gateway/dstack-app/builder/entrypoint.sh
+++ b/dstack/gateway/dstack-app/builder/entrypoint.sh
@@ -114,7 +114,6 @@ tls_versions = ["1.2"]
 listen_addr = "0.0.0.0"
 listen_port = "${PROXY_LISTEN_PORT:-443}"
 connect_top_n = 3
-localhost_enabled = false
 app_address_ns_compat = true
 workers = ${PROXY_WORKERS:-32}
 max_connections_per_app = ${MAX_CONNECTIONS_PER_APP:-0}

--- a/dstack/gateway/gateway.toml
+++ b/dstack/gateway/gateway.toml
@@ -56,6 +56,11 @@ insecure_no_auth = false
 
 [core.debug]
 insecure_enable_debug_rpc = false
+# Route the app address "localhost" to 127.0.0.1 on the gateway host. Off by
+# default: the app address also comes from the _dstack-app-address TXT record of
+# arbitrary custom domains, so enabling this lets any DNS zone owner reach the
+# gateway's own loopback on a port of their choosing, bypassing port_policy.
+insecure_localhost_backend = false
 insecure_skip_attestation = false
 key_file = "debug_key.json"
 address = "127.0.0.1:8012"
@@ -80,7 +85,6 @@ agent_port = 8090
 buffer_size = 65536
 # number of hosts to try to connect to
 connect_top_n = 3
-localhost_enabled = false
 app_address_ns_prefix = "_dstack-app-address"
 app_address_ns_compat = true
 workers = 32

--- a/dstack/gateway/src/config.rs
+++ b/dstack/gateway/src/config.rs
@@ -129,7 +129,6 @@ pub struct ProxyConfig {
     /// 1 MiB pipe fed without the syscall rate 8 KiB imposed.
     pub buffer_size: usize,
     pub connect_top_n: usize,
-    pub localhost_enabled: bool,
     pub workers: usize,
     /// Run one single-threaded runtime per worker, each with its own
     /// `SO_REUSEPORT` listener, instead of one accept thread feeding a shared
@@ -522,6 +521,19 @@ pub struct DebugConfig {
     pub insecure_enable_debug_rpc: bool,
     #[serde(default)]
     pub insecure_skip_attestation: bool,
+    /// Let the app-address `localhost` resolve to 127.0.0.1, so a hostname can
+    /// be routed to a service on the gateway host itself.
+    ///
+    /// This lives under `debug` and carries the `insecure_` prefix because the
+    /// app address is not only read from the platform's own `<id>.<base_domain>`
+    /// grammar: it also comes from the `_dstack-app-address` TXT record of an
+    /// arbitrary custom domain. With this on, anyone who controls any DNS zone
+    /// can point the gateway at its own loopback -- where the admin and debug
+    /// listeners bind precisely because being unreachable is their access
+    /// control -- and pick the port, since the `localhost` shortcut is not a
+    /// registered instance and so bypasses `port_policy` entirely.
+    #[serde(default)]
+    pub insecure_localhost_backend: bool,
     /// Path to pre-generated debug key data file (JSON format containing key, quote, event_log, and vm_config)
     #[serde(default)]
     pub key_file: String,

--- a/dstack/gateway/src/main.rs
+++ b/dstack/gateway/src/main.rs
@@ -21,7 +21,7 @@ use rocket::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 
 use admin_service::AdminRpcHandler;
 use main_service::{Proxy, ProxyOptions, RpcHandler};
@@ -244,6 +244,15 @@ async fn main() -> Result<()> {
     // Validate node_id
     if config.sync.enabled && config.sync.node_id == 0 {
         anyhow::bail!("node_id must be greater than 0");
+    }
+    if config.debug.insecure_localhost_backend {
+        warn!(
+            "core.debug.insecure_localhost_backend = true; the app address \"localhost\" now \
+             resolves to 127.0.0.1 on this host. App addresses also come from the \
+             _dstack-app-address TXT record of arbitrary custom domains, so any DNS zone owner \
+             can reach this host's loopback on a port of their choosing, bypassing port_policy. \
+             Never use this outside local development"
+        );
     }
     // Before anything reads `proxy.ktls`: the acceptor built later decides
     // whether to extract session secrets from it.

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1143,7 +1143,7 @@ impl ProxyState {
     }
 
     pub(crate) fn select_top_n_hosts(&mut self, id: &str) -> Result<AddressGroup> {
-        if self.config.proxy.localhost_enabled && id == "localhost" {
+        if self.config.debug.insecure_localhost_backend && id == "localhost" {
             return Ok(smallvec![AddressInfo {
                 ip: Ipv4Addr::new(127, 0, 0, 1),
                 counter: Default::default(),

--- a/dstack/gateway/test-run/proxy/gwconfig.py
+++ b/dstack/gateway/test-run/proxy/gwconfig.py
@@ -58,6 +58,7 @@ kms_url = ""
 rpc_domain = ""
 set_ulimit = false
 [core.debug]
+insecure_localhost_backend = true
 insecure_skip_attestation = true
 insecure_enable_debug_rpc = false
 [core.admin]
@@ -81,7 +82,6 @@ endpoint = "10.90.0.1:{o["wg_port"]}"
 [core.proxy]
 listen_addr = "127.0.0.1"
 listen_port = {o["proxy_port"]}
-localhost_enabled = true
 base_domain = "{o["base_domain"]}"
 cert_chain = "{cert}"
 cert_key = "{key}"

--- a/dstack/gateway/test-run/test_proxy.sh
+++ b/dstack/gateway/test-run/test_proxy.sh
@@ -35,8 +35,8 @@ ORIGIN_PLAIN=$((BASE_PORT + 4))
 ORIGIN_TLS=$((BASE_PORT + 5))
 
 BASE_DOMAIN="gwtest.local"
-# `localhost_enabled` routes `localhost-<port>[s]` to 127.0.0.1:<port>, which is
-# what lets these tests run without registering a CVM.
+# `insecure_localhost_backend` routes `localhost-<port>[s]` to 127.0.0.1:<port>,
+# which is what lets these tests run without registering a CVM.
 SNI_TERMINATE="localhost-$ORIGIN_PLAIN.$BASE_DOMAIN"
 SNI_PASSTHROUGH="localhost-${ORIGIN_TLS}s.$BASE_DOMAIN"
 ADMIN_TOKEN="proxy-integration-test"


### PR DESCRIPTION
## Problem

`core.proxy.localhost_enabled` reads like a proxy convenience — "let the app address `localhost` resolve to 127.0.0.1" — and it sits next to ordinary tuning like `listen_port` and `buffer_size`. Its blast radius is much wider than that placement suggests.

App addresses do not only come from the platform's own `<app_id>.<base_domain>` grammar. `select_top_n_hosts` is reached from both routing paths:

```
gateway/src/proxy/tls_terminate.rs:290   <- base domain
gateway/src/proxy/tls_passthough.rs:243  <- custom domain, resolved from an unauthenticated
                                            _dstack-app-address TXT record
```

So with the flag on, anyone who controls any DNS zone can publish

```
_dstack-app-address.evil.example  TXT  "localhost:8111"
```

and have the gateway open a connection to **127.0.0.1:8111 on the gateway host**, then pass their TLS through to it. Port 8111 is the default admin listener, which binds loopback precisely because unreachability is its access control; the debug RPC and the gateway's own RPC are next door.

`port_policy` does not constrain it either — the shortcut is not a registered instance, and the code says so:

```rust
/// Instances not present in state (e.g. the `localhost` shortcut) bypass the
/// check — the policy machinery only applies to registered CVMs.
```

so the caller picks the port.

The flag is off by default, which is the saving grace. But an operator turning it on for the base-domain case it advertises has no way to see that they are also opening the gateway's loopback to every domain owner on the internet.

## Fix

Move it to `[core.debug] insecure_localhost_backend`, next to `insecure_skip_attestation` and `insecure_enable_debug_rpc`, and warn at startup when it is set.

The `insecure_` prefix is earned here in a way it would not be for every switch: this one makes a relying party — the gateway — accept a routing target it would otherwise reject, and skips a policy check on the way. That is the same shape as `insecure_no_auth` and `insecure_allow_external_trust_anchors`, and unlike, say, a switch that only narrows what a component asserts about itself.

The doc comment and the `gateway.toml` comment both state the custom-domain coupling explicitly, since that is the part that is not obvious from the name alone.

No compatibility shim: an old config with `core.proxy.localhost_enabled` now leaves the feature off, which is the safe direction, and this is a development-only switch.

Not changed here, but worth a follow-up decision: the shortcut could be restricted to the base-domain path so the TXT path can never name it. That would keep the development use case while removing the exposure entirely, rather than relying on the operator reading a flag name.

## Verification

`test-run/test_proxy.sh` — the gateway's proxy data-path integration suite — runs entirely on this shortcut (`localhost-<port>[s].<base_domain>` is how it avoids registering a CVM), so it exercises the renamed flag end to end:

```
66 passed, 0 failed, 2 skipped
```

(the two skips are environmental: the TLS ULP is not removable on this host, and the Status RPC needs a real WireGuard device.)

`cargo build`, `cargo fmt` and `cargo clippy -p dstack-gateway` are clean.
