### PR TITLE
build(os/mkosi): fold dev-image into image with --no-cache

### DIFF
--- a/.github/workflows/mkosi-build.yml
+++ b/.github/workflows/mkosi-build.yml
@@ -138,10 +138,13 @@ jobs:
             action=image
             dist_dir="$build_dir/out/prod"
           fi
+          # A release build never reuses the component cache. The runner is
+          # fresh, so this costs nothing here, but it keeps the published
+          # artifacts a product of the cold path the repro check verifies.
           sudo --set-home env \
             "PATH=$ci_bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             "JOBS=$JOBS" \
-            ./os/mkosi/build.sh "$action" "$build_dir"
+            ./os/mkosi/build.sh --no-cache "$action" "$build_dir"
           sudo chown -R "$USER:$USER" "$build_dir"
           echo "dist_dir=$dist_dir" >> "$GITHUB_OUTPUT"
           df -h /

--- a/os/mkosi/README.md
+++ b/os/mkosi/README.md
@@ -67,6 +67,7 @@ The native interface remains available when those host tools are present:
 
 ```sh
 ./os/mkosi/build.sh lint
+./os/mkosi/build.sh image "$PWD/os/mkosi/build"
 ./os/build.sh --backend mkosi --build-dir "$PWD/os/mkosi/build"
 ./os/mkosi/build.sh repro-check "$PWD/os/mkosi/repro"
 # QEMU smoke-test the assembled UKI disk (host OVMF path is distro-specific)
@@ -75,11 +76,16 @@ qemu-system-x86_64 -machine q35 -m 2G -nographic \
   -drive if=virtio,format=raw,file=os/mkosi/build/out/prod/dstack-0.6.0/disk.raw
 ```
 
-For local iteration only, `dev-image` enables a component-output cache:
+`image` reuses a component-output cache, which is what makes local iteration
+affordable. `--no-cache` forces the cold path; the release workflow and the
+container path above both pass it, and `repro-check` never consults the cache at
+all. `DSTACK_COMPONENT_CACHE=0` in the environment changes the default for
+callers that cannot pass a flag, such as `os/build.sh`.
 
 ```sh
 DSTACK_DEV_CACHE_DIR="$HOME/.cache/dstack/mkosi-dev" \
-  ./os/mkosi/build.sh dev-image "$PWD/os/mkosi/build-dev"
+  ./os/mkosi/build.sh image "$PWD/os/mkosi/build-dev"
+./os/mkosi/build.sh --no-cache image "$PWD/os/mkosi/build"
 ```
 
 The cache covers dstack Rust, image tools, the container stack, Sysbox, nvattest, the
@@ -91,9 +97,9 @@ untracked source path inventory on the host, while file contents are hashed in
 the mkosi build root; Git metadata is never mounted into the sandbox.
 `build-components.sh` is intentionally only the ordered component list.
 Component install trees are merged with strict non-directory conflict
-detection. `image` and `repro-check` never calculate, read or write component
-cache keys. Release artifacts, Debian rootfs, dm-verity data and measurements
-are never cached.
+detection. A cold build never calculates, reads or writes component cache keys.
+Release artifacts, Debian rootfs, dm-verity data and measurements are never
+cached.
 
 The cache is stored in mkosi's `BuildDirectory=`, which is the only mount a
 build script gets that is both writable and preserved between runs. It must not

--- a/os/mkosi/build.sh
+++ b/os/mkosi/build.sh
@@ -7,13 +7,39 @@ ROOT=$(cd "$SELF/../.." && pwd)
 # shellcheck source=/dev/null
 source "$SELF/versions.env"
 FLAVORS=${FLAVORS:-prod}
-action=${1:-image}
-BUILD_DIR=${2:-$SELF/build}
-BUILD_DIR=$(realpath -m "$BUILD_DIR")
+usage="Usage: $0 [--no-cache] {image|repro-check|lint} [build-dir]"
+# The component cache is keyed on every declared input of each component, so a
+# hit reproduces the same output a cold build would have produced. Reusing it is
+# therefore the sensible default; --no-cache forces the cold path for a release
+# build or when the key itself is what needs auditing. repro-check ignores both
+# and always builds cold, because a cache hit would answer the wrong question.
+cache=${DSTACK_COMPONENT_CACHE:-1}
+action=
+BUILD_DIR=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-cache) cache=0 ;;
+    -h|--help) echo "$usage"; exit 0 ;;
+    -*) echo "Unknown option: $1" >&2; echo "$usage" >&2; exit 2 ;;
+    *)
+      if [[ -z $action ]]; then action=$1
+      elif [[ -z $BUILD_DIR ]]; then BUILD_DIR=$1
+      else echo "Unexpected argument: $1" >&2; echo "$usage" >&2; exit 2
+      fi
+      ;;
+  esac
+  shift
+done
+action=${action:-image}
+BUILD_DIR=$(realpath -m "${BUILD_DIR:-$SELF/build}")
 case "$action" in
-  image|dev-image|repro-check|lint) ;;
-  *) echo "Usage: $0 {image|dev-image|repro-check|lint} [build-dir]" >&2; exit 2 ;;
+  image|repro-check|lint) ;;
+  *) echo "$usage" >&2; exit 2 ;;
 esac
+if [[ $action == repro-check ]]; then cache=0; fi
+[[ $cache == 1 || $cache == 0 ]] || {
+  echo "DSTACK_COMPONENT_CACHE must be 0 or 1, got: $cache" >&2; exit 2;
+}
 if [[ $action == lint ]]; then exec "$SELF/tests/acceptance.sh"; fi
 command -v mkosi >/dev/null || { echo "mkosi $MKOSI_VERSION is required" >&2; exit 1; }
 actual=$(mkosi --version | awk '{print $2}' | cut -d. -f1)
@@ -43,10 +69,11 @@ fi
 export DSTACK_BUILD_GIT_REVISION=${DSTACK_BUILD_GIT_REVISION:-git:${revision:0:20}$dirty}
 revision="$revision$dirty"
 export TZ=UTC LC_ALL=C
-# A production invocation reconstructs the tools tree once from the immutable
+# A cold invocation reconstructs the tools tree once from the immutable
 # snapshot, then shares that read-only environment across all requested flavors
-# or both legs of repro-check.
-if [[ $action != dev-image ]]; then
+# or both legs of repro-check. A cached invocation keeps it, because rebuilding
+# the tools overlay every run is exactly the cost the cache exists to avoid.
+if [[ $cache == 0 ]]; then
   # --directory only chdirs, and no OutputDirectory= is configured, so without
   # the same --output-directory the build uses, mkosi.clean would run its
   # removal against os/mkosi/ instead of the build tree.
@@ -63,12 +90,12 @@ build_one() {
     --output-directory="$out"
     --profile="$flavor"
     --source-date-epoch="$SOURCE_DATE_EPOCH"
-    --environment="DSTACK_COMPONENT_CACHE=$([[ $action == dev-image ]] && echo 1 || echo 0)"
+    --environment="DSTACK_COMPONENT_CACHE=$cache"
     --environment="DSTACK_BUILD_GIT_REVISION=$DSTACK_BUILD_GIT_REVISION"
     --environment="DSTACK_SOURCE_REVISION=$revision"
     --environment="JOBS=$jobs"
   )
-  if [[ $action == dev-image ]]; then
+  if [[ $cache == 1 ]]; then
     cache_root=${DSTACK_DEV_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/dstack/mkosi-dev}
     # The component cache must go through BuildDirectory, which mkosi
     # bind-mounts read-write and preserves between runs. A BuildSources mount
@@ -92,7 +119,7 @@ build_one() {
         "$out/dstack-$DSTACK_VERSION-rootfs"
 }
 
-if [[ $action == image || $action == dev-image ]]; then
+if [[ $action == image ]]; then
   for flavor in $FLAVORS; do build_one "$BUILD_DIR/out/$flavor" "$flavor"; done
   exit
 fi

--- a/os/mkosi/components/sysbox/sysbox-build.sh
+++ b/os/mkosi/components/sysbox/sysbox-build.sh
@@ -46,7 +46,7 @@ done
 install -Dm0644 "$ROOT/os/yocto/layers/meta-dstack/recipes-core/dstack-sysbox/files/99-sysbox-sysctl.conf" "$STAGE/etc/sysctl.d/99-sysbox-sysctl.conf"
 install -Dm0644 "$ROOT/os/yocto/layers/meta-dstack/recipes-core/dstack-sysbox/files/50-sysbox-mod.conf" "$STAGE/etc/modules-load.d/50-sysbox-mod.conf"
 mkdir -p "$STAGE/var/lib/sysbox" "$STAGE/etc"
-# Truncating, not appending: the staging tree is reused across dev-image runs,
+# Truncating, not appending: the staging tree is reused across cached runs,
 # and duplicate entries here are a fatal parse error for some userns tooling.
 printf 'sysbox:100000:65536\n' > "$STAGE/etc/subuid"
 printf 'sysbox:100000:65536\n' > "$STAGE/etc/subgid"

--- a/os/mkosi/repro-build/entrypoint.sh
+++ b/os/mkosi/repro-build/entrypoint.sh
@@ -47,5 +47,8 @@ cd "$SRC"
 # Deliberately not exec: exec replaces this shell and the EXIT trap above would
 # never run, leaving a root-owned build directory the caller cannot even delete.
 status=0
-./os/mkosi/build.sh "$ACTION" "$OUT" || status=$?
+# The container path exists to produce reproducible artifacts, and its cache
+# directory would be discarded with the container anyway, so it always takes
+# the cold path rather than the cached default of a local `build.sh image`.
+./os/mkosi/build.sh --no-cache "$ACTION" "$OUT" || status=$?
 exit "$status"

--- a/os/mkosi/scripts/dev-cache.sh
+++ b/os/mkosi/scripts/dev-cache.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Local archive mechanics for dev-image. Component definitions own their keys
-# and output boundaries; this file only validates, restores and stores them.
+# Local archive mechanics for a cached build. Component definitions own their
+# keys and output boundaries; this file only validates, restores and stores them.
 
 DEV_CACHE_ENABLED=0
 

--- a/os/mkosi/tests/acceptance.sh
+++ b/os/mkosi/tests/acceptance.sh
@@ -181,7 +181,9 @@ if grep -q 'random.trust_bootloader' "$D/scripts/make-release-artifacts.sh"; the
 fi
 grep -q 'Archiving UKI image' "$D/../image/assemble.sh"
 grep -Fq "FLAVORS=\${FLAVORS:-prod}" "$D/build.sh"
-grep -q 'DSTACK_COMPONENT_CACHE.*dev-image' "$D/build.sh"
+# A cache hit must never be able to answer the question repro-check asks.
+grep -Fq 'if [[ $action == repro-check ]]; then cache=0; fi' "$D/build.sh"
+grep -Fq -e '--environment="DSTACK_COMPONENT_CACHE=$cache"' "$D/build.sh"
 grep -q 'write-source-manifest.py' "$D/build.sh"
 grep -q 'DSTACK_SOURCE_REVISION.*revision' "$D/build.sh"
 grep -q 'DSTACK_SOURCE_REVISION:?' "$D/scripts/make-release-artifacts.sh"

--- a/os/mkosi/tests/acceptance.sh
+++ b/os/mkosi/tests/acceptance.sh
@@ -182,8 +182,8 @@ fi
 grep -q 'Archiving UKI image' "$D/../image/assemble.sh"
 grep -Fq "FLAVORS=\${FLAVORS:-prod}" "$D/build.sh"
 # A cache hit must never be able to answer the question repro-check asks.
-grep -Fq 'if [[ $action == repro-check ]]; then cache=0; fi' "$D/build.sh"
-grep -Fq -e '--environment="DSTACK_COMPONENT_CACHE=$cache"' "$D/build.sh"
+grep -Fq "if [[ \$action == repro-check ]]; then cache=0; fi" "$D/build.sh"
+grep -Fq -e "--environment=\"DSTACK_COMPONENT_CACHE=\$cache\"" "$D/build.sh"
 grep -q 'write-source-manifest.py' "$D/build.sh"
 grep -q 'DSTACK_SOURCE_REVISION.*revision' "$D/build.sh"
 grep -q 'DSTACK_SOURCE_REVISION:?' "$D/scripts/make-release-artifacts.sh"


### PR DESCRIPTION
## Problem

The mkosi backend exposed two build actions that differ in exactly one bit:

```
./os/mkosi/build.sh image      "$dir"   # cold: no component cache
./os/mkosi/build.sh dev-image  "$dir"   # cached
```

Nothing else distinguishes them. Both build the same flavors, produce the same
release artifacts, and run the same assembler. The split forced every caller —
and every developer — to remember which action name meant "fast" and which meant
"clean", and it put the slow path on the name people type most.

The root cause is that the cache decision was encoded in the action name rather
than as a property of the build. That shows up directly in the code: three
separate `$action == dev-image` tests scattered through `build.sh`, including
one that computes an environment value with a nested `$([[ ... ]] && echo 1 ||
echo 0)`, plus a fourth site listing both action names to mean "build an image".
Adding any future action would have to re-answer the cache question in all four.

It also made the default wrong. The cache key already covers every declared
input of a component — inputs, tools, packages, declared dependencies,
architecture, flavor and `SOURCE_DATE_EPOCH` — so a hit reproduces what a cold
build would have produced. Defaulting the common invocation to *discard* that
and rebuild the whole tools overlay is a cost with nothing bought for it.

## Fix

One action, with the cache as a flag:

| Before | After |
|---|---|
| `build.sh dev-image [dir]` | `build.sh image [dir]` |
| `build.sh image [dir]` | `build.sh --no-cache image [dir]` |
| `build.sh repro-check [dir]` | unchanged |

`repro-check` ignores the flag and always builds cold. A cache hit there would
answer the wrong question — the whole point of the check is that the cold path
reproduces byte for byte — so it forces `cache=0` regardless of what the caller
asked for, and an acceptance assertion pins that.

Callers that produce release artifacts pass `--no-cache` explicitly:

- `.github/workflows/mkosi-build.yml` — the runner is fresh so the cache would
  be empty anyway, but the published artifacts should be a product of the cold
  path the repro check actually verifies, not an implicit default.
- `os/mkosi/repro-build/entrypoint.sh` — the container path exists to produce
  reproducible artifacts, and its cache directory dies with the container.

`os/build.sh` is backend-agnostic and cannot carry a mkosi-specific flag, so the
opt-out is also readable from `DSTACK_COMPONENT_CACHE=0` in the environment.

The four `$action == dev-image` tests collapse to `$cache`, and the environment
line loses its nested conditional:

```diff
-    --environment="DSTACK_COMPONENT_CACHE=$([[ $action == dev-image ]] && echo 1 || echo 0)"
+    --environment="DSTACK_COMPONENT_CACHE=$cache"
```

### Behavioral change worth review

The `mkosi clean -f` that `build.sh` runs up front now follows the cache rather
than the action name, so a plain `build.sh image` no longer wipes the build tree
first. That is deliberate: rebuilding the tools overlay every run is precisely
the cost the cache exists to avoid, and `mkosi build` already runs with
`--force`. It is not a new code path — it is exactly what `dev-image` has been
doing. `--no-cache` restores the old `image` behavior exactly.

Measured below: the cold leg invokes the clean script twice (the explicit one
plus mkosi's own in-build call), the cached legs once. The cache removes the
up-front wipe only, not mkosi's internal clean.

## Verification

Three real builds off this branch's commit (`f520858c3`), on a 64-core / 125 GiB
host, `JOBS=32`, run as root (unprivileged userns is unavailable there, same as
CI). Cold ran first so a cache bug could not contaminate the reference.

| leg | invocation | elapsed | cache | clean calls | exit |
|---|---|---|---|---|---|
| cold | `build.sh --no-cache image` | **1576 s** | 0 hit / 0 miss | 2 | 0 |
| warm1 | `build.sh image`, cache wiped first | 1558 s | 0 hit / **9 miss** | 1 | 0 |
| warm2 | `build.sh image`, cache primed | **485 s** | **9 hit** / 0 miss | 1 | 0 |

**The cached path reproduces the cold path byte for byte.** All six release
artifacts across the three legs collapse to exactly two distinct hashes:

```
f2553dee0ffe34e72f70ba22cf064c20edcc0aba99009aabb48611e649669e96  cold/dstack-0.6.0.tar.gz
f2553dee0ffe34e72f70ba22cf064c20edcc0aba99009aabb48611e649669e96  warm1/dstack-0.6.0.tar.gz
f2553dee0ffe34e72f70ba22cf064c20edcc0aba99009aabb48611e649669e96  warm2/dstack-0.6.0.tar.gz
2d0351f7737155f790d3c0696d8a851a8bb813ba6042bb3c8441d753ce4a7471  cold/dstack-0.6.0-uki.tar.gz
2d0351f7737155f790d3c0696d8a851a8bb813ba6042bb3c8441d753ce4a7471  warm1/dstack-0.6.0-uki.tar.gz
2d0351f7737155f790d3c0696d8a851a8bb813ba6042bb3c8441d753ce4a7471  warm2/dstack-0.6.0-uki.tar.gz
```

That is the claim the whole change rests on, so it is the one that had to be
measured rather than argued from the cache-key implementation.

Secondary results:

- `--no-cache` touches the cache logic not at all (0 hit / 0 miss) and keeps the
  up-front clean, so it is a faithful replacement for the old `image`.
- The cache is actually exercised, not merely written: warm2 hits all 9
  components and finishes in **3.3× less wall clock** (485 s vs 1576 s). Without
  a warm leg the run would have proven only the write side.
- warm1 populated a 2.2 GiB cache directory under `DSTACK_DEV_CACHE_DIR`.

Static checks:

- `bash -n` and `shellcheck` clean on `build.sh`, `entrypoint.sh`, `dev-cache.sh`.
- Argument parsing probed on every path — flag before or after the action, bad
  option, extra positional, env override, invalid env value:

  | invocation | result |
  |---|---|
  | *(no args)* | `image`, cache=1, default dir |
  | `--no-cache image` | `image`, cache=0 |
  | `image --no-cache /tmp/bd` | `image`, cache=0, `/tmp/bd` |
  | `repro-check` / `--no-cache repro-check` | `repro-check`, cache=0 |
  | `image /tmp/bd extra` | exit 2, `Unexpected argument: extra` |
  | `--bogus image` | exit 2, `Unknown option: --bogus` |
  | `DSTACK_COMPONENT_CACHE=0 image` | `image`, cache=0 |
  | `DSTACK_COMPONENT_CACHE=x image` | exit 2, must be 0 or 1 |

- Full `./os/mkosi/build.sh lint` acceptance suite passes. The assertion that
  pinned the old wiring (`DSTACK_COMPONENT_CACHE.*dev-image`) is replaced by two
  pinning the invariant that matters: `repro-check` forces `cache=0`, and
  `$cache` is what reaches mkosi's environment.

**Limitation.** These builds used the host's installed mkosi 26 rather than the
revision-pinned venv `versions.env` builds in CI. All three legs shared one
mkosi, so the cached-vs-cold equivalence above holds; this is not an independent
check of pinned-revision reproducibility. `repro-check` was not run end to end —
it is unchanged by this PR and always builds cold.