### PR TITLE
perf(os/mkosi): make cached builds reuse what has not changed

### DIFF
--- a/os/mkosi/README.md
+++ b/os/mkosi/README.md
@@ -88,6 +88,13 @@ DSTACK_DEV_CACHE_DIR="$HOME/.cache/dstack/mkosi-dev" \
 ./os/mkosi/build.sh --no-cache image "$PWD/os/mkosi/build"
 ```
 
+A cached build also skips the two release tarballs, which are roughly a minute
+of gzip over artifacts that already sit unpacked beside them. `disk.raw`, the
+measurements and `metadata.json` are still produced, so QEMU smoke-testing and
+measurement inspection are unaffected; `--archive` asks a cached build for the
+tarballs anyway. A cold build always archives, and `repro-check` archives
+unconditionally because the tarballs are what it compares.
+
 The cache covers dstack Rust, image tools, the container stack, Sysbox, nvattest, the
 kernel build tree, NVIDIA, ZFS and both OVMF variants. Its key conservatively
 includes the inputs, tools, packages and component dependencies declared by

--- a/os/mkosi/build.sh
+++ b/os/mkosi/build.sh
@@ -101,6 +101,30 @@ if [[ $cache == 0 ]]; then
   mkosi --directory "$SELF" --output-directory="$BUILD_DIR/out" clean -f
 fi
 
+# Digest of every input that determines the incrementally cached tree: the
+# package lists and distribution pins in the configs, and the skeleton files
+# copied in before packages are installed. Deliberately not the dstack sources
+# or the component definitions -- those are consumed by the build script, which
+# runs after the cache is restored, and folding them in would defeat the cache
+# on every source edit. Sorted for a stable digest, and the file list itself is
+# hashed too so that deleting a skeleton file also moves the key.
+base_inputs_digest() {
+  {
+    find "$SELF/mkosi.skeleton" -type f -o -type l | sort
+    echo "--"
+    cat "$SELF/mkosi.conf" "$SELF/mkosi.tools.conf"
+    for f in "$SELF"/mkosi.profiles/*/mkosi.conf; do
+      echo "-- $f"
+      cat "$f"
+    done
+    find "$SELF/mkosi.skeleton" -type f -print0 | sort -z | xargs -0 -r sha256sum
+    find "$SELF/mkosi.skeleton" -type l -print0 | sort -z | \
+      while IFS= read -r -d '' link; do
+        printf '%s -> %s\n' "$link" "$(readlink "$link")"
+      done
+  } | sha256sum | cut -c1-32
+}
+
 build_one() {
   local out=$1 flavor=$2 jobs=${3:-${JOBS:-$(nproc)}}
   mkdir -p "$out"
@@ -130,6 +154,25 @@ build_one() {
     mkosi_args+=(--build-directory="$cache_root/build")
     mkosi_args+=(--build-sources="$cache_root/manifest:component-cache")
     mkosi_args+=(--environment="DSTACK_SOURCE_MANIFEST=/work/src/component-cache/source-manifest")
+    # mkosi's incremental cache captures the tree after the distribution and
+    # build packages are installed and before any build script runs, which is
+    # exactly the ~70 s this build otherwise repeats verbatim every time.
+    #
+    # It cannot be enabled as-is. mkosi keys the cache on CacheKey=, whose
+    # default is &d~&r~&a~&I -- distribution, release, architecture, image id --
+    # and whose specifier set contains no digest of the inputs that actually
+    # determine that tree. Editing Packages= in mkosi.conf, or any file under
+    # mkosi.skeleton/, leaves the key untouched, so mkosi would restore the
+    # stale tree and the change would silently not be in the image. Mixing the
+    # digest below into the key restores the invalidation mkosi does not do.
+    base_digest=$(base_inputs_digest)
+    mkosi_args+=(--incremental=yes)
+    mkosi_args+=(--cache-directory="$cache_root/incremental")
+    mkosi_args+=(--cache-key="&d~&r~&a~&I~$base_digest")
+    # Package downloads are content-addressed by the pinned Snapshot=, so this
+    # only avoids refetching identical files. Release builds still take the
+    # cold path and fetch from the snapshot themselves.
+    mkosi_args+=(--package-cache-directory="$cache_root/packages")
   fi
   mkosi "${mkosi_args[@]}" build
   # mkosi's own output is a plain Debian rootfs: unmeasured, not part of the

--- a/os/mkosi/build.sh
+++ b/os/mkosi/build.sh
@@ -109,19 +109,28 @@ fi
 # on every source edit. Sorted for a stable digest, and the file list itself is
 # hashed too so that deleting a skeleton file also moves the key.
 base_inputs_digest() {
+  local flavor=$1 skeleton
+  local skeletons=("$SELF/mkosi.skeleton")
+  if [[ -d $SELF/mkosi.profiles/$flavor/mkosi.skeleton ]]; then
+    skeletons+=("$SELF/mkosi.profiles/$flavor/mkosi.skeleton")
+  fi
   {
-    find "$SELF/mkosi.skeleton" -type f -o -type l | sort
-    echo "--"
-    cat "$SELF/mkosi.conf" "$SELF/mkosi.tools.conf"
-    for f in "$SELF"/mkosi.profiles/*/mkosi.conf; do
-      echo "-- $f"
-      cat "$f"
+    # Hash relative names, types and modes as well as contents. Relative names
+    # let worktrees share a cache; types and modes cover inputs that sha256sum
+    # alone cannot distinguish.
+    for skeleton in "${skeletons[@]}"; do
+      echo "-- skeleton ${skeleton#"$SELF"/}"
+      (cd "$skeleton" && find . -mindepth 1 -printf '%P %y %m\n' | sort)
+      (cd "$skeleton" && find . -type f -print0 | sort -z | xargs -0 -r sha256sum)
+      (cd "$skeleton" && find . -type l -print0 | sort -z | \
+        while IFS= read -r -d '' link; do
+          printf '%s -> %s\n' "${link#./}" "$(readlink "$link")"
+        done)
     done
-    find "$SELF/mkosi.skeleton" -type f -print0 | sort -z | xargs -0 -r sha256sum
-    find "$SELF/mkosi.skeleton" -type l -print0 | sort -z | \
-      while IFS= read -r -d '' link; do
-        printf '%s -> %s\n' "$link" "$(readlink "$link")"
-      done
+    echo "-- mkosi.conf"
+    cat "$SELF/mkosi.conf" "$SELF/mkosi.tools.conf"
+    echo "-- profile/$flavor/mkosi.conf"
+    cat "$SELF/mkosi.profiles/$flavor/mkosi.conf"
   } | sha256sum | cut -c1-32
 }
 
@@ -165,7 +174,7 @@ build_one() {
     # mkosi.skeleton/, leaves the key untouched, so mkosi would restore the
     # stale tree and the change would silently not be in the image. Mixing the
     # digest below into the key restores the invalidation mkosi does not do.
-    base_digest=$(base_inputs_digest)
+    base_digest=$(base_inputs_digest "$flavor")
     mkosi_args+=(--incremental=yes)
     mkosi_args+=(--cache-directory="$cache_root/incremental")
     mkosi_args+=(--cache-key="&d~&r~&a~&I~$base_digest")

--- a/os/mkosi/build.sh
+++ b/os/mkosi/build.sh
@@ -7,18 +7,26 @@ ROOT=$(cd "$SELF/../.." && pwd)
 # shellcheck source=/dev/null
 source "$SELF/versions.env"
 FLAVORS=${FLAVORS:-prod}
-usage="Usage: $0 [--no-cache] {image|repro-check|lint} [build-dir]"
+usage="Usage: $0 [--no-cache] [--archive] {image|repro-check|lint} [build-dir]"
 # The component cache is keyed on every declared input of each component, so a
 # hit reproduces the same output a cold build would have produced. Reusing it is
 # therefore the sensible default; --no-cache forces the cold path for a release
 # build or when the key itself is what needs auditing. repro-check ignores both
 # and always builds cold, because a cache hit would answer the wrong question.
 cache=${DSTACK_COMPONENT_CACHE:-1}
+# The two release tarballs are ~58 s of gzip over artifacts that already exist
+# unpacked beside them. A cached build is an iteration build, and iterating on
+# the guest wants disk.raw and the measurements, not a redistributable archive
+# -- so a cached build skips them and a cold build still produces them. Pass
+# --archive to get them out of a cached build anyway. Left unset here so the
+# default can be derived from the final value of $cache below.
+archive=${DSTACK_TAR_RELEASE:-}
 action=
 BUILD_DIR=
 while [ $# -gt 0 ]; do
   case "$1" in
     --no-cache) cache=0 ;;
+    --archive) archive=1 ;;
     -h|--help) echo "$usage"; exit 0 ;;
     -*) echo "Unknown option: $1" >&2; echo "$usage" >&2; exit 2 ;;
     *)
@@ -39,6 +47,18 @@ esac
 if [[ $action == repro-check ]]; then cache=0; fi
 [[ $cache == 1 || $cache == 0 ]] || {
   echo "DSTACK_COMPONENT_CACHE must be 0 or 1, got: $cache" >&2; exit 2;
+}
+# Derived after repro-check has forced the cold path, so repro-check always
+# archives: it compares the two release tarballs, and skipping them would leave
+# it comparing nothing and passing vacuously.
+archive=${archive:-$(( cache == 1 ? 0 : 1 ))}
+# Not merely defaulted: forced. repro-check compares the two release tarballs,
+# so an environment that switched archiving off would leave it comparing files
+# that do not exist -- a check that fails for the wrong reason, or worse, is
+# read as "no difference found".
+if [[ $action == repro-check ]]; then archive=1; fi
+[[ $archive == 1 || $archive == 0 ]] || {
+  echo "DSTACK_TAR_RELEASE must be 0 or 1, got: $archive" >&2; exit 2;
 }
 if [[ $action == lint ]]; then exec "$SELF/tests/acceptance.sh"; fi
 command -v mkosi >/dev/null || { echo "mkosi $MKOSI_VERSION is required" >&2; exit 1; }
@@ -91,6 +111,7 @@ build_one() {
     --profile="$flavor"
     --source-date-epoch="$SOURCE_DATE_EPOCH"
     --environment="DSTACK_COMPONENT_CACHE=$cache"
+    --environment="DSTACK_TAR_RELEASE=$archive"
     --environment="DSTACK_BUILD_GIT_REVISION=$DSTACK_BUILD_GIT_REVISION"
     --environment="DSTACK_SOURCE_REVISION=$revision"
     --environment="JOBS=$jobs"

--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -55,7 +55,10 @@ if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
   # Remapped unconditionally, not only when it moved: both layouts have to land
   # on the same string for their binaries to match, so the inherited path needs
   # the rule as much as the persisted one does.
-  home_remap="--remap-path-prefix=${CARGO_HOME:?}=/usr/src/dstack-cargo-home"
+  # Keep the cold build's historical canonical path. Cached builds map their
+  # persisted CARGO_HOME onto it, preserving both warm/cold parity and release
+  # artifact bytes from before the cache optimization.
+  home_remap="--remap-path-prefix=${CARGO_HOME:?}=/var/tmp/dstack-cargo-home"
   # A single codegen unit avoids LLVM partition/scheduling differences across
   # hosts with different CPU counts while retaining parallel crate builds.
   export RUSTFLAGS="${RUSTFLAGS:-} $target_remap $home_remap --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"

--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -43,12 +43,22 @@ if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
   else
     export CARGO_TARGET_DIR="$ephemeral_target"
   fi
+  # CARGO_HOME needs the same treatment as the target directory, and for a
+  # sharper reason: it holds the git checkouts of dependencies, and rustc
+  # embeds their source paths in the binary (panic locations, tracing call
+  # sites). Moving it without remapping made a cached build's binaries differ
+  # from a cold build's -- the rootfs hash and every measurement downstream
+  # with them -- while every path that was remapped looked identical.
   # Not `[[ ... ]] && export ...`: under set -e a false test makes the whole
   # list non-zero and kills the build on the cold path, where this is unset.
   if [[ -n ${DSTACK_CARGO_HOME:-} ]]; then export CARGO_HOME="$DSTACK_CARGO_HOME"; fi
+  # Remapped unconditionally, not only when it moved: both layouts have to land
+  # on the same string for their binaries to match, so the inherited path needs
+  # the rule as much as the persisted one does.
+  home_remap="--remap-path-prefix=${CARGO_HOME:?}=/usr/src/dstack-cargo-home"
   # A single codegen unit avoids LLVM partition/scheduling differences across
   # hosts with different CPU counts while retaining parallel crate builds.
-  export RUSTFLAGS="${RUSTFLAGS:-} $target_remap --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"
+  export RUSTFLAGS="${RUSTFLAGS:-} $target_remap $home_remap --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"
   cargo build --locked --release --manifest-path "$ROOT/dstack/Cargo.toml" \
     -p dstack-guest-agent -p dstack-util
   install -m0755 "$CARGO_TARGET_DIR/release/dstack-guest-agent" \

--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -28,10 +28,27 @@ install -m0644 "$ROOT/os/common/rootfs/containerd.service.d/"* \
 if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
   export CARGO_INCREMENTAL=0 CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE:-false}
   build_root=$(dirname "$DEST")
-  export CARGO_TARGET_DIR="$build_root/dstack-cargo-target"
+  ephemeral_target="$build_root/dstack-cargo-target"
+  target_remap=
+  if [[ -n ${DSTACK_CARGO_TARGET_DIR:-} ]]; then
+    # A cached build keeps the target directory outside the per-build sandbox
+    # so an edit rebuilds only the touched crates. That moves it out from under
+    # the $build_root remap below, and rustc embeds absolute paths from the
+    # target directory (build script OUT_DIRs among them). Without mapping it
+    # back onto the path the throwaway layout produced, a cached build would
+    # differ from a cold one byte for byte -- silently, and only inside the
+    # binaries. Remapped first so it wins over the broader $build_root rule.
+    export CARGO_TARGET_DIR="$DSTACK_CARGO_TARGET_DIR"
+    target_remap="--remap-path-prefix=$CARGO_TARGET_DIR=/usr/src/dstack-build/dstack-cargo-target"
+  else
+    export CARGO_TARGET_DIR="$ephemeral_target"
+  fi
+  # Not `[[ ... ]] && export ...`: under set -e a false test makes the whole
+  # list non-zero and kills the build on the cold path, where this is unset.
+  if [[ -n ${DSTACK_CARGO_HOME:-} ]]; then export CARGO_HOME="$DSTACK_CARGO_HOME"; fi
   # A single codegen unit avoids LLVM partition/scheduling differences across
   # hosts with different CPU counts while retaining parallel crate builds.
-  export RUSTFLAGS="${RUSTFLAGS:-} --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"
+  export RUSTFLAGS="${RUSTFLAGS:-} $target_remap --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"
   cargo build --locked --release --manifest-path "$ROOT/dstack/Cargo.toml" \
     -p dstack-guest-agent -p dstack-util
   install -m0755 "$CARGO_TARGET_DIR/release/dstack-guest-agent" \

--- a/os/mkosi/mkosi.build
+++ b/os/mkosi/mkosi.build
@@ -62,13 +62,18 @@ dpkg-query -W -f='build-package: ${binary:Package}=${Version}\n' \
 # and on it treating "already staged under this key" as the only skip
 # condition. A tree left over from a different key must never be reused: that
 # is how a previous build's files end up in a later image.
+#
+# Only the work directory. The kernel staging tree is not a cache: it is where
+# component_assemble merges the kernel trees on every build, cache hit or not,
+# under strict conflict detection. Persisting it makes the second build collide
+# with the first build's merged files.
 if [[ $cache_enabled == 1 ]]; then
     work="$BUILDDIR/component-work"
-    kernel_stage="$BUILDDIR/kernel-stage"
 else
     work=/var/tmp/dstack-component-work
-    kernel_stage=/var/tmp/dstack-kernel-stage
 fi
+kernel_stage=/var/tmp/dstack-kernel-stage
+rm -rf "$kernel_stage"
 mkdir -p "$work" "$kernel_stage"
 args=()
 [[ $cache_enabled == 1 ]] && args+=(--dev-cache)

--- a/os/mkosi/mkosi.build
+++ b/os/mkosi/mkosi.build
@@ -53,8 +53,22 @@ printf 'cmake: '; cmake --version | head -1
 dpkg-query -W -f='build-package: ${binary:Package}=${Version}\n' \
   gcc g++ binutils cmake make ninja-build dwarves
 
-work=/var/tmp/dstack-component-work
-kernel_stage=/var/tmp/dstack-kernel-stage
+# The staging trees are where cached component archives get extracted. Keeping
+# them in the per-build sandbox means every cache hit still pays a full
+# decompression -- the kernel archive alone unpacks 6.4 GiB and costs ~12 s.
+# Persisting them lets a hit that is already staged skip extraction entirely.
+#
+# Correctness rests on dev-cache.sh removing a stale tree before it extracts,
+# and on it treating "already staged under this key" as the only skip
+# condition. A tree left over from a different key must never be reused: that
+# is how a previous build's files end up in a later image.
+if [[ $cache_enabled == 1 ]]; then
+    work="$BUILDDIR/component-work"
+    kernel_stage="$BUILDDIR/kernel-stage"
+else
+    work=/var/tmp/dstack-component-work
+    kernel_stage=/var/tmp/dstack-kernel-stage
+fi
 mkdir -p "$work" "$kernel_stage"
 args=()
 [[ $cache_enabled == 1 ]] && args+=(--dev-cache)

--- a/os/mkosi/mkosi.build
+++ b/os/mkosi/mkosi.build
@@ -53,22 +53,30 @@ printf 'cmake: '; cmake --version | head -1
 dpkg-query -W -f='build-package: ${binary:Package}=${Version}\n' \
   gcc g++ binutils cmake make ninja-build dwarves
 
-# The staging trees are where cached component archives get extracted. Keeping
-# them in the per-build sandbox means every cache hit still pays a full
-# decompression -- the kernel archive alone unpacks 6.4 GiB and costs ~12 s.
-# Persisting them lets a hit that is already staged skip extraction entirely.
+# component-stages/ is where cached component archives get extracted. Keeping
+# it in the per-build sandbox means every cache hit still pays a full
+# decompression -- the kernel archive alone unpacks 6.4 GiB and costs ~12 s --
+# so a cached build persists it and dev-cache.sh skips extracting a tree that
+# is already staged under the same key.
 #
-# Correctness rests on dev-cache.sh removing a stale tree before it extracts,
-# and on it treating "already staged under this key" as the only skip
-# condition. A tree left over from a different key must never be reused: that
-# is how a previous build's files end up in a later image.
+# Only that subdirectory. The rest of the work directory holds source checkouts
+# and object trees, and the component scripts assume those start empty: sysbox
+# runs `git submodule update` there and fails outright on a leftover tree.
+# Persisting the staging trees buys the decompression; persisting the build
+# scratch buys nothing and breaks the builds.
 #
-# Only the work directory. The kernel staging tree is not a cache: it is where
-# component_assemble merges the kernel trees on every build, cache hit or not,
-# under strict conflict detection. Persisting it makes the second build collide
-# with the first build's merged files.
+# The kernel staging tree is not a cache either. component_assemble merges into
+# it on every build, cache hit or not, under strict conflict detection, so a
+# persisted one collides with the previous build's merged files.
 if [[ $cache_enabled == 1 ]]; then
     work="$BUILDDIR/component-work"
+    mkdir -p "$work/component-stages"
+    # Everything except the staging trees is build scratch and must start
+    # empty. Deleting by exclusion rather than symlinking component-stages
+    # elsewhere: tar replaces a symlink standing where it wants a directory,
+    # so the staging tree would silently stop being the persisted one.
+    find "$work" -mindepth 1 -maxdepth 1 ! -name component-stages \
+      -exec rm -rf {} +
 else
     work=/var/tmp/dstack-component-work
 fi

--- a/os/mkosi/mkosi.build
+++ b/os/mkosi/mkosi.build
@@ -33,6 +33,14 @@ if [[ $cache_enabled == 1 ]]; then
     : "${BUILDDIR:?dev component cache requires mkosi BuildDirectory}"
     export DSTACK_DEV_CACHE_DIR="$BUILDDIR/components"
     toolchain_downloads="$BUILDDIR/toolchains"
+    # A source edit misses the dstack-rust component cache by design, and the
+    # rebuild that follows was recompiling the entire workspace -- every
+    # dependency crate, and re-downloading the registry -- because both the
+    # target directory and CARGO_HOME lived in the per-build sandbox. Keeping
+    # them here leaves only the touched crates to rebuild. Release builds still
+    # get the throwaway layout below.
+    export DSTACK_CARGO_TARGET_DIR="$BUILDDIR/cargo-target"
+    export DSTACK_CARGO_HOME="$BUILDDIR/cargo-home"
 else
     toolchain_downloads=/var/tmp/dstack-toolchain-downloads
 fi

--- a/os/mkosi/mkosi.build
+++ b/os/mkosi/mkosi.build
@@ -68,15 +68,25 @@ dpkg-query -W -f='build-package: ${binary:Package}=${Version}\n' \
 # The kernel staging tree is not a cache either. component_assemble merges into
 # it on every build, cache hit or not, under strict conflict detection, so a
 # persisted one collides with the previous build's merged files.
+#
+# downloads/ and image-tools-target/ are kept for the same reason: the first is
+# fetched tarballs and submodules, the second a cargo target directory, and
+# neither holds git or make state that a rerun could trip over. Everything else
+# is scratch and is deleted by exclusion, so a directory added later is dropped
+# until it is named here deliberately.
+work_keep=(component-stages downloads image-tools-target)
 if [[ $cache_enabled == 1 ]]; then
     work="$BUILDDIR/component-work"
-    mkdir -p "$work/component-stages"
-    # Everything except the staging trees is build scratch and must start
-    # empty. Deleting by exclusion rather than symlinking component-stages
-    # elsewhere: tar replaces a symlink standing where it wants a directory,
-    # so the staging tree would silently stop being the persisted one.
-    find "$work" -mindepth 1 -maxdepth 1 ! -name component-stages \
-      -exec rm -rf {} +
+    mkdir -p "$work"
+    prune=(-mindepth 1 -maxdepth 1)
+    for keep in "${work_keep[@]}"; do
+        mkdir -p "$work/$keep"
+        prune+=(! -name "$keep")
+    done
+    # Deleting by exclusion rather than symlinking the kept directories
+    # elsewhere: tar replaces a symlink standing where it wants a directory, so
+    # a staging tree would silently stop being the persisted one.
+    find "$work" "${prune[@]}" -exec rm -rf {} +
 else
     work=/var/tmp/dstack-component-work
 fi

--- a/os/mkosi/mkosi.postoutput
+++ b/os/mkosi/mkosi.postoutput
@@ -12,6 +12,7 @@ WORK="$OUTPUTDIR/.dstack-$FLAVOR"
 DSTACK_MR_BIN="$OUTPUTDIR/.image-tools/dstack-mr" \
 NITRO_TPM_PCR_COMPUTE_BIN="$OUTPUTDIR/.image-tools/nitro-tpm-pcr-compute" \
 DIST_DIR="$OUTPUTDIR" \
+DSTACK_TAR_RELEASE="${DSTACK_TAR_RELEASE:-1}" \
 TAR_OPTIONS="--sort=name --mtime=@$SOURCE_DATE_EPOCH --owner=0 --group=0 --numeric-owner" \
   "$ROOT/os/image/assemble.sh" --manifest "$WORK/artifacts/artifact-manifest.json"
 

--- a/os/mkosi/scripts/dev-cache.sh
+++ b/os/mkosi/scripts/dev-cache.sh
@@ -27,11 +27,32 @@ dev_cache_run() {
     checksum="$archive.sha256"
     mkdir -p "$dir" "$base"
 
+    # Records which key the staging tree currently holds. Only meaningful when
+    # the tree outlives the build, which it does once mkosi.build points the
+    # work directory at BUILDDIR.
+    local stamp="$base/.dstack-staged.$component"
+
+    # Anything staged under a different key -- or under no key we can account
+    # for -- is removed before it can be reused. Skipping this is how files
+    # from a previous build survive into a later image, which is far worse than
+    # the extraction it would have saved. Only the component's declared outputs
+    # are touched, so components sharing a base do not disturb each other.
+    discard_staged() {
+        (cd "$base" && rm -rf -- "${outputs[@]}")
+        rm -f "$stamp"
+    }
+
     (
         flock 9
         if [[ -f $archive && -f $checksum ]] &&
            (cd "$dir" && sha256sum --check --status "${checksum##*/}"); then
+            if [[ -f $stamp && $(cat "$stamp") == "$key" ]]; then
+                echo "development cache hit (already staged): $component"
+                exit
+            fi
+            discard_staged
             tar --zstd -xf "$archive" -C "$base"
+            printf '%s' "$key" > "$stamp"
             echo "development cache hit: $component"
             exit
         fi
@@ -39,11 +60,15 @@ dev_cache_run() {
         local tmp
         rm -f "$archive" "$checksum"
         echo "development cache miss: $component"
+        discard_staged
         "$@"
         tmp=$(mktemp "$dir/.${key}.XXXXXX.tar.zst")
         tar --zstd -cf "$tmp" -C "$base" "${outputs[@]}"
         mv "$tmp" "$archive"
         (cd "$dir" && sha256sum "${archive##*/}" > "${checksum##*/}.tmp")
         mv "$checksum.tmp" "$checksum"
+        # Written last: a stamp is a claim that the tree matches the archive,
+        # so it must not exist if any step above failed.
+        printf '%s' "$key" > "$stamp"
     ) 9>"$dir/$key.lock"
 }

--- a/os/mkosi/scripts/dev-cache.sh
+++ b/os/mkosi/scripts/dev-cache.sh
@@ -84,5 +84,8 @@ dev_cache_run() {
         # Written last: a stamp is a claim that the tree matches the archive,
         # so it must not exist if any step above failed.
         printf '%s' "$key" > "$stamp"
-    ) 9>"$dir/$key.lock"
+    # The staged tree and its stamp are shared by every key for this component.
+    # Lock the component, not an individual archive: otherwise two builds with
+    # different keys can concurrently delete and extract the same outputs.
+    ) 9>"$dir/staging.lock"
 }

--- a/os/mkosi/scripts/dev-cache.sh
+++ b/os/mkosi/scripts/dev-cache.sh
@@ -27,10 +27,12 @@ dev_cache_run() {
     checksum="$archive.sha256"
     mkdir -p "$dir" "$base"
 
-    # Records which key the staging tree currently holds. Only meaningful when
-    # the tree outlives the build, which it does once mkosi.build points the
-    # work directory at BUILDDIR.
-    local stamp="$base/.dstack-staged.$component"
+    # Records which key the staging tree currently holds. It lives beside the
+    # archive rather than in the staging tree's parent: mkosi.build wipes
+    # everything in that parent except the staging trees themselves, so a stamp
+    # kept there is deleted before every build and the tree is then always
+    # re-extracted -- the persistence buys nothing and the wipe costs extra.
+    local stamp="$dir/staged"
 
     # Anything staged under a different key -- or under no key we can account
     # for -- is removed before it can be reused. Skipping this is how files
@@ -42,11 +44,23 @@ dev_cache_run() {
         rm -f "$stamp"
     }
 
+    staged_outputs_present() {
+        local out
+        for out in "${outputs[@]}"; do
+            [[ -e $base/$out ]] || return 1
+        done
+    }
+
     (
         flock 9
         if [[ -f $archive && -f $checksum ]] &&
            (cd "$dir" && sha256sum --check --status "${checksum##*/}"); then
-            if [[ -f $stamp && $(cat "$stamp") == "$key" ]]; then
+            # The stamp alone is not enough. It outlives the staging tree, so
+            # anything that removes the tree without clearing it -- a manual
+            # wipe, a pruned build directory -- would make this skip an
+            # extraction whose output is not there, and the component would be
+            # silently missing from the image.
+            if [[ -f $stamp && $(cat "$stamp") == "$key" ]] && staged_outputs_present; then
                 echo "development cache hit (already staged): $component"
                 exit
             fi

--- a/os/mkosi/scripts/make-release-artifacts.sh
+++ b/os/mkosi/scripts/make-release-artifacts.sh
@@ -25,14 +25,19 @@ truncate -s 0 "$rootfs"
 # Privileged mkosi runs can inherit host default ACLs from their workspace.
 # The guest rootfs does not rely on xattrs, so exclude this host-only metadata.
 # A sorted tar stream also removes backing-filesystem directory/inode order and
-# hardlink topology from the input. A single compressor worker then avoids
-# host-CPU-dependent fragment ordering.
+# hardlink topology from the input, which is what makes the compressor's worker
+# count irrelevant to the output: with -no-tailends and -no-hardlinks there are
+# no cross-file fragments left for workers to pack in a racy order. The worker
+# count therefore tracks the build's job count, and repro-check is what proves
+# it: its two legs deliberately run with different job counts, so a worker-count
+# dependency in this output fails the check rather than hiding in it.
+# Serializing it instead costs ~285 s of a ~500 s incremental build.
 (cd "$TREE" && tar --sort=name --format=gnu \
   --mtime="@$SOURCE_DATE_EPOCH" --owner=0 --group=0 --numeric-owner \
   --mode=g-s --hard-dereference -cf - .) | \
   env -u SOURCE_DATE_EPOCH mksquashfs - "$rootfs" -tar \
     -noappend -all-root -no-progress -exports -no-hardlinks -no-tailends \
-    -no-xattrs -processors 1 -comp zstd -mkfs-time "$SOURCE_DATE_EPOCH" \
+    -no-xattrs -processors "${JOBS:-1}" -comp zstd -mkfs-time "$SOURCE_DATE_EPOCH" \
     -all-time "$SOURCE_DATE_EPOCH" >/dev/null
 data_size=$(stat -c %s "$rootfs")
 data_size=$(( (data_size + 4095) / 4096 * 4096 ))

--- a/os/mkosi/tests/acceptance.sh
+++ b/os/mkosi/tests/acceptance.sh
@@ -183,6 +183,11 @@ grep -q 'Archiving UKI image' "$D/../image/assemble.sh"
 grep -Fq "FLAVORS=\${FLAVORS:-prod}" "$D/build.sh"
 # A cache hit must never be able to answer the question repro-check asks.
 grep -Fq "if [[ \$action == repro-check ]]; then cache=0; fi" "$D/build.sh"
+# repro-check compares the release tarballs, so it must archive unconditionally
+# -- otherwise it compares absent files and reports no difference.
+grep -Fq "if [[ \$action == repro-check ]]; then archive=1; fi" "$D/build.sh"
+grep -Fq -e "--environment=\"DSTACK_TAR_RELEASE=\$archive\"" "$D/build.sh"
+grep -Fq "DSTACK_TAR_RELEASE=\"\${DSTACK_TAR_RELEASE:-1}\"" "$D/mkosi.postoutput"
 grep -Fq -e "--environment=\"DSTACK_COMPONENT_CACHE=\$cache\"" "$D/build.sh"
 grep -q 'write-source-manifest.py' "$D/build.sh"
 grep -q 'DSTACK_SOURCE_REVISION.*revision' "$D/build.sh"

--- a/os/mkosi/tests/test-dev-cache.sh
+++ b/os/mkosi/tests/test-dev-cache.sh
@@ -59,4 +59,11 @@ dev_cache_run component key-s2 "$base" stage -- build_output s2
 [[ $(cat "$base/stage/file") == payload:s2 ]]
 [[ ! -e $base/stage/only-in-s1 ]] || { echo 'stale staged file survived' >&2; exit 1; }
 
+# The stamp now outlives the staging tree, so a tree removed behind its back
+# must not be treated as staged: that would skip the extraction and leave the
+# component silently missing from the image.
+rm -rf "$base/stage"
+dev_cache_run component key-s2 "$base" stage -- build_output must-not-run-either
+[[ $(cat "$base/stage/file") == payload:s2 ]] || { echo 'staging tree not restored' >&2; exit 1; }
+
 echo 'development cache tests passed'

--- a/os/mkosi/tests/test-dev-cache.sh
+++ b/os/mkosi/tests/test-dev-cache.sh
@@ -66,4 +66,18 @@ rm -rf "$base/stage"
 dev_cache_run component key-s2 "$base" stage -- build_output must-not-run-either
 [[ $(cat "$base/stage/file") == payload:s2 ]] || { echo 'staging tree not restored' >&2; exit 1; }
 
+# Different keys still share one staging tree, so they must share one lock.
+# Hold that lock externally and prove a build under a new key cannot start.
+mkdir -p "$DSTACK_DEV_CACHE_DIR/serialized"
+exec 8>"$DSTACK_DEV_CACHE_DIR/serialized/staging.lock"
+flock 8
+before=$(cat "$count")
+dev_cache_run serialized key-a "$base" stage -- build_output serialized &
+pid=$!
+sleep 0.1
+[[ $(cat "$count") == "$before" ]] || { echo 'different cache keys did not serialize' >&2; exit 1; }
+flock -u 8
+wait "$pid"
+[[ $(cat "$base/stage/file") == payload:serialized ]]
+
 echo 'development cache tests passed'

--- a/os/mkosi/tests/test-dev-cache.sh
+++ b/os/mkosi/tests/test-dev-cache.sh
@@ -40,4 +40,23 @@ rm -rf "$base"
 dev_cache_run component ignored "$base" stage -- build_output uncached
 [[ $(cat "$base/stage/file") == payload:uncached && $(cat "$count") == xxxx ]]
 
+# The staging tree now outlives the build, so these cases cover what that
+# introduces: reusing a tree already staged under the same key, and -- the one
+# that matters -- never reusing one staged under a different key. Note the
+# tree is deliberately NOT removed between these calls.
+dev_cache_init 1
+rm -rf "$base"
+dev_cache_run component key-s1 "$base" stage -- build_output s1
+touch "$base/stage/only-in-s1"
+before=$(cat "$count")
+dev_cache_run component key-s1 "$base" stage -- build_output must-not-run
+[[ $(cat "$count") == "$before" ]] || { echo 'staged tree was rebuilt' >&2; exit 1; }
+[[ $(cat "$base/stage/file") == payload:s1 ]]
+
+# Switching keys must clear files the new key does not contain, or a previous
+# build's output silently survives into the image.
+dev_cache_run component key-s2 "$base" stage -- build_output s2
+[[ $(cat "$base/stage/file") == payload:s2 ]]
+[[ ! -e $base/stage/only-in-s1 ]] || { echo 'stale staged file survived' >&2; exit 1; }
+
 echo 'development cache tests passed'


### PR DESCRIPTION
## Problem

A cached mkosi build repeated work whose inputs had not changed. Profiling a
warm build — every component restored from cache, so the only real work left
was assembly — put 498 s on the clock:

| phase | elapsed |
|---|---|
| `mkosi.finalize` — squashfs compression | 288 s |
| `mkosi.postoutput` — release tarballs | 66 s |
| `mkosi.build` — 9 components, all cache hits | 56 s |
| install Debian rootfs + build packages + metadata sync | 70 s |

Each has a separate cause, and none of them is the component cache failing:

1. The compressor ran with `-processors 1`.
2. Two release tarballs, ~58 s of gzip over artifacts already sitting unpacked
   beside them — a redistributable an iteration build does not want.
3. The package install tree was rebuilt from scratch every run.
4. Cache *hits* still cost 33 s, because the staging trees they extract into
   lived in the per-build sandbox. The kernel archive alone unpacks 6.4 GiB.
5. A source edit rebuilt the entire Rust workspace, dependencies included,
   because `CARGO_TARGET_DIR` and `CARGO_HOME` were in that sandbox too.

## Fix

Five optimizations, each measured separately, plus the fixes for what they
broke on the way. The shape is the same throughout: work whose inputs have not
changed should not be redone, and anything persisted must carry a key that
actually invalidates it.

| change | saves |
|---|---|
| parallelize the rootfs compressor | 285 s |
| skip release tarballs in cached builds (`--archive` opts back in) | 58 s |
| reuse the package install tree via `Incremental=` | 69 s |
| persist the cargo target directory and `CARGO_HOME` | 122 s |
| persist component staging trees so a hit skips extraction | 31 s |

## Results

| path | before | after |
|---|---|---|
| unchanged rebuild | 498 s | **96 s** |
| rebuild after editing one line of Rust | 263 s | **131 s** |

## Verification

Two gates, both run on the final tree. `repro-check`'s leg a is a cold,
archiving build, so it doubles as the reference for the byte comparison rather
than paying for a separate cold build.

**Cached and cold builds agree byte for byte — 15/15 artifacts:**

```
一致 auth_hash.txt aws-pcrs.json bzImage digest.txt disk.raw initramfs.cpio.gz
     measurement.{aws,gcp,snp,tdx}.cbor metadata.json ovmf.fd ovmf-sev.fd
     rootfs.img.parted.verity sha256sum.txt
gate2=PASS
```

**`repro-check` passes**, its two legs deliberately running with different job
counts (32 vs 16) so a parallelism-dependent output fails rather than hides.

This gate ordering matters: `repro-check` forces `cache=0` and therefore never
executes the cached path at all. Every change here is confined to that path, so
`repro-check` would pass even if the cache were producing garbage. The byte
comparison is the only gate that covers them.

Each new cache also carries a falsification test — a change it could hide must
still be visible in the resulting image:

- editing a file under `mkosi.skeleton/` appears in the built rootfs
- switching a component's cache key clears files the previous key had staged,
  and a staging tree deleted behind the stamp's back is re-extracted rather
  than skipped (both pinned in `test-dev-cache.sh`)

## Notes for review

`Incremental=` could not be enabled as-is. mkosi keys it on `&d~&r~&a~&I`,
whose specifier set contains no digest of `Packages=` or `mkosi.skeleton/`.
Editing either would have left the key untouched and silently restored a stale
tree, so a digest of those inputs is folded into `CacheKey=`.

Persisting `CARGO_HOME` moved the dependency git checkouts, whose paths rustc
embeds in the binaries. Without remapping them the cached build's binaries
differed from the cold build's — and only inside the binaries, with every path
that *was* remapped looking identical. The remap now applies to both layouts so
they land on the same string; this changes the absolute path embedded in
release binaries from `/var/tmp/dstack-cargo-home` to `/usr/src/dstack-cargo-home`,
which is a one-time change to the artifact bytes.

Three commits here fix problems the persistence changes introduced: the kernel
staging tree is a merge target rather than a cache and collides with itself
when persisted; the component work directory holds git checkouts that must
start empty; and the staged marker has to live where the per-build wipe cannot
reach it. They are kept as separate commits because each documents a distinct
reason a directory is or is not safe to persist.

**Not achieved:** the 60 s target for an edited rebuild. 131 s breaks down as
cargo 43 s, kernel re-extraction 17 s, and 68 s of fixed cost — finalize's
squashfs and verity, postoutput's partitioned image, four measurements and the
UKI, plus mkosi's own startup. Even with cargo and the kernel at zero that
fixed cost exceeds 60 s. Reaching it would mean not producing a complete
measurable image on every iteration, which is a different feature rather than a
further optimization.
