### PR TITLE
feat(vmm): add optional libvirt network filtering

### DIFF
--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -67,8 +67,38 @@ validated by libvirt.
 
 ## Deployment modes
 
-Production packages may socket-activate one shared `netd`, but that is only a
-deployment convenience. Development mode is two ordinary commands:
+Production should run one shared service. `netd` reads only the `[netd]`
+section, so its root-owned configuration can be small and independent of every
+VMM instance:
+
+```toml
+# /etc/dstack/netd.toml
+[netd]
+socket = "/run/dstack/netd.sock"
+allowed_uids = [991, 992]
+libvirt_uri = "qemu:///system"
+```
+
+```ini
+# /etc/systemd/system/dstack-netd.service
+[Unit]
+Description=dstack host networking service
+After=libvirtd.service
+
+[Service]
+ExecStart=/usr/bin/dstack-vmm --config /etc/dstack/netd.toml netd
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+All VMM instance configurations point to the same socket and use distinct
+`cvm.instance_id` values. A dedicated netd uses a different socket. A
+host-wide lock serializes mutations made by shared and dedicated netd
+processes.
+
+Development mode is two ordinary commands:
 
 ```bash
 sudo dstack-vmm --config ./vmm.toml netd \

--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -60,6 +60,12 @@ Teardown stops QEMU first, removes the binding, and deletes the TAP. Operations
 are serialized by `netd`. The design intentionally does not add ownership
 aliases; deployments must use unique instance IDs.
 
+Every UID listed in `allowed_uids` is mutually trusted for network operations:
+the protocol does not pin an UID to an instance namespace, so any allowed UID
+can prepare, check, or remove any deterministic identity. Deploy VMM instances
+that do not share this trust boundary with dedicated netd sockets and distinct
+allowlists.
+
 `netd` invokes fixed absolute `ip` and `virsh` executables with separate
 arguments. It never accepts a command, executable path, TAP name, or raw XML
 from a client. Filter XML is generated internally with XML escaping and is
@@ -109,3 +115,8 @@ dstack-vmm --config ./vmm.toml \
 
 User networking and bridge networking with `mode = "none"` never connect to
 `netd`. Libvirt mode fails closed if `netd` is unavailable.
+
+Filtered TAP netdevs currently set `vhost=off`. This keeps the initial backend
+on the directly bound TAP path and avoids adding `/dev/vhost-net` permissions
+to the QEMU user. It is a deliberate security-first throughput tradeoff; a
+future configurable vhost mode requires equivalent filter integration tests.

--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -1,0 +1,81 @@
+# Optional libvirt network filtering
+
+## Goal
+
+Allow bridge-backed VMs to opt into an existing libvirt `nwfilter` without
+allowing libvirt to create or launch the QEMU domain. QEMU remains entirely
+owned by `dstack-vmm`, so its command line and attestation inputs do not change
+outside the explicitly selected network backend.
+
+The measurable acceptance criteria are:
+
+- `network_filter = "none"` preserves the existing QEMU `-netdev bridge`
+  behavior and does not require `netd` or libvirt.
+- `network_filter = "libvirt"` creates the TAP and filter binding before QEMU
+  is submitted to Supervisor, and uses QEMU `-netdev tap`.
+- A failed TAP or filter setup prevents QEMU from starting and rolls back all
+  interfaces prepared for that VM.
+- Normal stop and removal delete the filter binding and TAP.
+- One host `netd` can serve multiple VMM instances. Resource names include a
+  stable VMM instance namespace, VM ID, and NIC index.
+- Development builds can run the VMM and `netd` directly, with explicit socket
+  and allowed-UID command-line options; systemd is not required.
+
+## Configuration
+
+Filtering is a VMM host policy, not a field accepted from a VM manifest:
+
+```toml
+[cvm.network_filter]
+mode = "none" # or "libvirt"
+filter = "clean-traffic"
+parameters = {}
+
+[netd]
+socket = "/run/dstack/netd.sock"
+allowed_uids = [] # empty means root only
+libvirt_uri = "qemu:///system"
+```
+
+Each VMM instance also has an `instance_id`. It must be unique among VMMs that
+share a host. If omitted, the VMM derives a stable namespace from its absolute
+run directory.
+
+## Architecture
+
+`netd` is a host-level privilege broker. It accepts a small, bounded JSON
+protocol over a Unix stream socket and authorizes clients with `SO_PEERCRED`.
+A single process can serve multiple VMMs; a dedicated process can use another
+socket for development or isolation.
+
+For libvirt mode, startup is:
+
+1. Derive the TAP name from instance namespace, VM ID, and NIC index.
+2. Create the TAP for the configured QEMU UID and attach it to the bridge.
+3. Create a libvirt nwfilter binding for the TAP.
+4. Bring the TAP up and return success.
+5. Start QEMU directly with `-netdev tap,script=no,downscript=no`.
+
+Teardown stops QEMU first, removes the binding, and deletes the TAP. Operations
+are serialized by `netd`. The design intentionally does not add ownership
+aliases; deployments must use unique instance IDs.
+
+`netd` invokes fixed absolute `ip` and `virsh` executables with separate
+arguments. It never accepts a command, executable path, TAP name, or raw XML
+from a client. Filter XML is generated internally with XML escaping and is
+validated by libvirt.
+
+## Deployment modes
+
+Production packages may socket-activate one shared `netd`, but that is only a
+deployment convenience. Development mode is two ordinary commands:
+
+```bash
+sudo dstack-vmm --config ./vmm.toml netd \
+  --socket /run/dstack-dev/netd.sock --allow-uid "$(id -u)"
+dstack-vmm --config ./vmm.toml \
+  --netd-socket /run/dstack-dev/netd.sock
+```
+
+User networking and bridge networking with `mode = "none"` never connect to
+`netd`. Libvirt mode fails closed if `netd` is unavailable.

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wait-timeout",
  "which 7.0.3",
 ]
 
@@ -8268,6 +8269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -287,6 +287,7 @@ strip-ansi-escapes = "0.2.1"
 tailf = "0.1.2"
 time = "0.3.47"
 uuid = { version = "1.15.1", features = ["v4"] }
+wait-timeout = "0.2"
 which = "7.0.2"
 smallvec = "1.14.0"
 cmd_lib = "1.9.5"

--- a/dstack/vmm/Cargo.toml
+++ b/dstack/vmm/Cargo.toml
@@ -63,7 +63,7 @@ reqwest.workspace = true
 flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
-wait-timeout = "0.2"
+wait-timeout.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/dstack/vmm/Cargo.toml
+++ b/dstack/vmm/Cargo.toml
@@ -63,6 +63,7 @@ reqwest.workspace = true
 flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+wait-timeout = "0.2"
 
 [dev-dependencies]
 insta.workspace = true

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -517,9 +517,6 @@ impl App {
         if let Err(error) = self.set_started(id, false) {
             warn!(id, %error, "failed to disable restart after start failure");
         }
-        if let Err(error) = self.supervisor.stop(id).await {
-            warn!(id, %error, "failed to stop process after start failure");
-        }
         if let Err(error) = self.supervisor.remove(id).await {
             warn!(id, %error, "failed to remove process after start failure");
         }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -464,15 +464,23 @@ impl App {
                 vm_state.state.runtime_networks = runtime_networks.clone();
             }
             for process in processes {
-                let result = self.supervisor.deploy(&process).await;
-                let result = match result {
-                    Ok(()) => self.confirm_process_started(&process.id).await,
-                    Err(error) => Err(error),
-                };
-                if let Err(error) = result {
-                    self.rollback_start_failure(id, &runtime_networks, &work_dir)
-                        .await;
-                    return Err(error)
+                if let Err(err) = self.supervisor.deploy(&process).await {
+                    if let Err(cleanup_error) = self
+                        .remove_filtered_networks(&vm_config.manifest.id, &runtime_networks)
+                        .await
+                    {
+                        warn!(id, %cleanup_error, "failed to roll back filtered networking");
+                    }
+                    if let Err(clear_err) = work_dir.clear_runtime_networks() {
+                        warn!(
+                            id,
+                            "failed to clear runtime networks after start failure: {clear_err}"
+                        );
+                    }
+                    if let Some(vm_state) = self.lock().get_mut(id) {
+                        vm_state.state.runtime_networks.clear();
+                    }
+                    return Err(err)
                         .with_context(|| format!("failed to start process {}", process.id));
                 }
             }
@@ -482,53 +490,6 @@ impl App {
             vm_state.state.devices = devices;
         }
         Ok(())
-    }
-
-    /// Supervisor deploy is asynchronous with respect to the launched command.
-    /// Keep the API call open briefly so an immediately failing QEMU launcher is
-    /// reported as a start failure instead of entering the auto-restart loop
-    /// with prepared host networking still attached.
-    async fn confirm_process_started(&self, id: &str) -> Result<()> {
-        for _ in 0..10 {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            let info = self
-                .supervisor
-                .info(id)
-                .await?
-                .with_context(|| format!("process {id} disappeared after deploy"))?;
-            if !info.state.status.is_running() {
-                bail!(
-                    "process {id} exited during startup: {:?}",
-                    info.state.status
-                );
-            }
-        }
-        Ok(())
-    }
-
-    async fn rollback_start_failure(
-        &self,
-        id: &str,
-        runtime_networks: &[Networking],
-        work_dir: &VmWorkDir,
-    ) {
-        // Prevent the periodic monitor from racing the rollback and preparing
-        // the same deterministic TAPs again.
-        if let Err(error) = self.set_started(id, false) {
-            warn!(id, %error, "failed to disable restart after start failure");
-        }
-        if let Err(error) = self.supervisor.remove(id).await {
-            warn!(id, %error, "failed to remove process after start failure");
-        }
-        if let Err(error) = self.remove_filtered_networks(id, runtime_networks).await {
-            warn!(id, %error, "failed to roll back filtered networking");
-        }
-        if let Err(error) = work_dir.clear_runtime_networks() {
-            warn!(id, %error, "failed to clear runtime networks after start failure");
-        }
-        if let Some(vm_state) = self.lock().get_mut(id) {
-            vm_state.state.runtime_networks.clear();
-        }
     }
 
     fn set_started(&self, id: &str, started: bool) -> Result<()> {

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -564,7 +564,11 @@ impl App {
         Ok(())
     }
 
-    async fn remove_filtered_networks(&self, vm_id: &str, networks: &[Networking]) -> Result<()> {
+    pub(crate) async fn remove_filtered_networks(
+        &self,
+        vm_id: &str,
+        networks: &[Networking],
+    ) -> Result<()> {
         if self.config.cvm.network_filter.mode == NetworkFilterMode::None {
             return Ok(());
         }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -464,23 +464,15 @@ impl App {
                 vm_state.state.runtime_networks = runtime_networks.clone();
             }
             for process in processes {
-                if let Err(err) = self.supervisor.deploy(&process).await {
-                    if let Err(cleanup_error) = self
-                        .remove_filtered_networks(&vm_config.manifest.id, &runtime_networks)
-                        .await
-                    {
-                        warn!(id, %cleanup_error, "failed to roll back filtered networking");
-                    }
-                    if let Err(clear_err) = work_dir.clear_runtime_networks() {
-                        warn!(
-                            id,
-                            "failed to clear runtime networks after start failure: {clear_err}"
-                        );
-                    }
-                    if let Some(vm_state) = self.lock().get_mut(id) {
-                        vm_state.state.runtime_networks.clear();
-                    }
-                    return Err(err)
+                let result = self.supervisor.deploy(&process).await;
+                let result = match result {
+                    Ok(()) => self.confirm_process_started(&process.id).await,
+                    Err(error) => Err(error),
+                };
+                if let Err(error) = result {
+                    self.rollback_start_failure(id, &runtime_networks, &work_dir)
+                        .await;
+                    return Err(error)
                         .with_context(|| format!("failed to start process {}", process.id));
                 }
             }
@@ -490,6 +482,53 @@ impl App {
             vm_state.state.devices = devices;
         }
         Ok(())
+    }
+
+    /// Supervisor deploy is asynchronous with respect to the launched command.
+    /// Keep the API call open briefly so an immediately failing QEMU launcher is
+    /// reported as a start failure instead of entering the auto-restart loop
+    /// with prepared host networking still attached.
+    async fn confirm_process_started(&self, id: &str) -> Result<()> {
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let info = self
+                .supervisor
+                .info(id)
+                .await?
+                .with_context(|| format!("process {id} disappeared after deploy"))?;
+            if !info.state.status.is_running() {
+                bail!(
+                    "process {id} exited during startup: {:?}",
+                    info.state.status
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn rollback_start_failure(
+        &self,
+        id: &str,
+        runtime_networks: &[Networking],
+        work_dir: &VmWorkDir,
+    ) {
+        // Prevent the periodic monitor from racing the rollback and preparing
+        // the same deterministic TAPs again.
+        if let Err(error) = self.set_started(id, false) {
+            warn!(id, %error, "failed to disable restart after start failure");
+        }
+        if let Err(error) = self.supervisor.remove(id).await {
+            warn!(id, %error, "failed to remove process after start failure");
+        }
+        if let Err(error) = self.remove_filtered_networks(id, runtime_networks).await {
+            warn!(id, %error, "failed to roll back filtered networking");
+        }
+        if let Err(error) = work_dir.clear_runtime_networks() {
+            warn!(id, %error, "failed to clear runtime networks after start failure");
+        }
+        if let Some(vm_state) = self.lock().get_mut(id) {
+            vm_state.state.runtime_networks.clear();
+        }
     }
 
     fn set_started(&self, id: &str, started: bool) -> Result<()> {

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -517,6 +517,9 @@ impl App {
         if let Err(error) = self.set_started(id, false) {
             warn!(id, %error, "failed to disable restart after start failure");
         }
+        if let Err(error) = self.supervisor.stop(id).await {
+            warn!(id, %error, "failed to stop process after start failure");
+        }
         if let Err(error) = self.supervisor.remove(id).await {
             warn!(id, %error, "failed to remove process after start failure");
         }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -505,7 +505,7 @@ impl App {
         }
         self.set_started(id, false)?;
         self.stop_vm_process(id).await?;
-        let networks = self.work_dir(id).runtime_networks();
+        let networks = self.work_dir(id)?.runtime_networks();
         self.remove_filtered_networks(id, &networks).await?;
         Ok(())
     }
@@ -696,7 +696,7 @@ impl App {
             }
         }
 
-        let runtime_networks = self.work_dir(id).runtime_networks();
+        let runtime_networks = self.work_dir(id)?.runtime_networks();
         if let Err(error) = self.remove_filtered_networks(id, &runtime_networks).await {
             warn!(id, %error, "failed to remove filtered networking during VM removal");
         }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -553,9 +553,12 @@ impl App {
                 netd::request(&self.config.netd.socket, &NetdRequest::Prepare(request)).await
             {
                 for identity in prepared.into_iter().rev() {
-                    let _ =
+                    if let Err(cleanup_error) =
                         netd::request(&self.config.netd.socket, &NetdRequest::Remove { identity })
-                            .await;
+                            .await
+                    {
+                        warn!(%cleanup_error, "failed to roll back prepared filtered network");
+                    }
                 }
                 return Err(error).context("failed to prepare libvirt-filtered networking");
             }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -21,7 +21,7 @@ use dstack_vmm_rpc::{
 use fs_err as fs;
 use guest_api::client::DefaultClient as GuestClient;
 use id_pool::IdPool;
-use nix::unistd::User;
+use nix::unistd::{Uid, User};
 use or_panic::ResultOrPanic;
 use ra_rpc::client::RaClient;
 use serde::{Deserialize, Serialize};
@@ -519,7 +519,7 @@ impl App {
             return Ok(());
         }
         let qemu_uid = if self.config.cvm.user.is_empty() {
-            unsafe { libc::geteuid() }
+            Uid::effective().as_raw()
         } else {
             User::from_name(&self.config.cvm.user)
                 .context("failed to resolve QEMU user")?
@@ -552,6 +552,19 @@ impl App {
             if let Err(error) =
                 netd::request(&self.config.netd.socket, &NetdRequest::Prepare(request)).await
             {
+                // The client may have timed out while netd was still finishing
+                // this Prepare. Remove the in-flight identity first; netd's
+                // serialized accept loop processes it after Prepare completes.
+                if let Err(cleanup_error) = netd::request(
+                    &self.config.netd.socket,
+                    &NetdRequest::Remove {
+                        identity: identity.clone(),
+                    },
+                )
+                .await
+                {
+                    warn!(%cleanup_error, "failed to roll back in-flight filtered network");
+                }
                 for identity in prepared.into_iter().rev() {
                     if let Err(cleanup_error) =
                         netd::request(&self.config.netd.socket, &NetdRequest::Remove { identity })

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::{Config, Networking, ProcessAnnotation, Protocol};
-use crate::logrotate;
+use crate::{
+    config::{Config, NetworkFilterMode, Networking, NetworkingMode, ProcessAnnotation, Protocol},
+    logrotate,
+    netd::{self, InterfaceIdentity, PrepareRequest, Request as NetdRequest},
+};
 
 use anyhow::{bail, Context, Result};
 use bon::Builder;
@@ -18,6 +21,7 @@ use dstack_vmm_rpc::{
 use fs_err as fs;
 use guest_api::client::DefaultClient as GuestClient;
 use id_pool::IdPool;
+use nix::unistd::User;
 use or_panic::ResultOrPanic;
 use ra_rpc::client::RaClient;
 use serde::{Deserialize, Serialize};
@@ -443,17 +447,30 @@ impl App {
                 append_boot_separator(&path);
             }
 
+            let runtime_networks = resolved_networks(&vm_config.manifest, &self.config.cvm);
             let devices = self.try_allocate_gpus(&vm_config.manifest)?;
             let processes = vm_config.config_qemu(&work_dir, &self.config.cvm, &devices)?;
-            let runtime_networks = resolved_networks(&vm_config.manifest, &self.config.cvm);
             work_dir.set_runtime_networks(&runtime_networks)?;
+            if let Err(error) = self
+                .prepare_filtered_networks(&vm_config, &runtime_networks)
+                .await
+            {
+                let _ = work_dir.clear_runtime_networks();
+                return Err(error);
+            }
             {
                 let mut state = self.lock();
                 let vm_state = state.get_mut(id).context("VM not found")?;
-                vm_state.state.runtime_networks = runtime_networks;
+                vm_state.state.runtime_networks = runtime_networks.clone();
             }
             for process in processes {
                 if let Err(err) = self.supervisor.deploy(&process).await {
+                    if let Err(cleanup_error) = self
+                        .remove_filtered_networks(&vm_config.manifest.id, &runtime_networks)
+                        .await
+                    {
+                        warn!(id, %cleanup_error, "failed to roll back filtered networking");
+                    }
                     if let Err(clear_err) = work_dir.clear_runtime_networks() {
                         warn!(
                             id,
@@ -488,6 +505,88 @@ impl App {
         }
         self.set_started(id, false)?;
         self.stop_vm_process(id).await?;
+        let networks = self.work_dir(id).runtime_networks();
+        self.remove_filtered_networks(id, &networks).await?;
+        Ok(())
+    }
+
+    async fn prepare_filtered_networks(
+        &self,
+        vm: &VmConfig,
+        networks: &[Networking],
+    ) -> Result<()> {
+        if self.config.cvm.network_filter.mode == NetworkFilterMode::None {
+            return Ok(());
+        }
+        let qemu_uid = if self.config.cvm.user.is_empty() {
+            unsafe { libc::geteuid() }
+        } else {
+            User::from_name(&self.config.cvm.user)
+                .context("failed to resolve QEMU user")?
+                .with_context(|| format!("QEMU user {} does not exist", self.config.cvm.user))?
+                .uid
+                .as_raw()
+        };
+        let mut prepared = Vec::new();
+        for (nic_index, network) in networks.iter().enumerate() {
+            if network.mode != NetworkingMode::Bridge {
+                continue;
+            }
+            let identity = InterfaceIdentity {
+                instance_id: self.config.cvm.instance_id.clone(),
+                vm_id: vm.manifest.id.clone(),
+                nic_index,
+            };
+            let request = PrepareRequest {
+                identity: identity.clone(),
+                bridge: network.bridge.clone(),
+                mac: network::mac_address_for_vm_index(
+                    &vm.manifest.id,
+                    &network.mac_prefix_bytes(),
+                    nic_index,
+                ),
+                qemu_uid,
+                filter: self.config.cvm.network_filter.filter.clone(),
+                parameters: self.config.cvm.network_filter.parameters.clone(),
+            };
+            if let Err(error) =
+                netd::request(&self.config.netd.socket, &NetdRequest::Prepare(request)).await
+            {
+                for identity in prepared.into_iter().rev() {
+                    let _ =
+                        netd::request(&self.config.netd.socket, &NetdRequest::Remove { identity })
+                            .await;
+                }
+                return Err(error).context("failed to prepare libvirt-filtered networking");
+            }
+            prepared.push(identity);
+        }
+        Ok(())
+    }
+
+    async fn remove_filtered_networks(&self, vm_id: &str, networks: &[Networking]) -> Result<()> {
+        if self.config.cvm.network_filter.mode == NetworkFilterMode::None {
+            return Ok(());
+        }
+        let mut first_error = None;
+        for (nic_index, network) in networks.iter().enumerate().rev() {
+            if network.mode != NetworkingMode::Bridge {
+                continue;
+            }
+            let identity = InterfaceIdentity {
+                instance_id: self.config.cvm.instance_id.clone(),
+                vm_id: vm_id.to_string(),
+                nic_index,
+            };
+            if let Err(error) =
+                netd::request(&self.config.netd.socket, &NetdRequest::Remove { identity }).await
+            {
+                first_error.get_or_insert(error);
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error).context("failed to remove libvirt-filtered networking");
+        }
         Ok(())
     }
 
@@ -595,6 +694,11 @@ impl App {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
             }
+        }
+
+        let runtime_networks = self.work_dir(id).runtime_networks();
+        if let Err(error) = self.remove_filtered_networks(id, &runtime_networks).await {
+            warn!(id, %error, "failed to remove filtered networking during VM removal");
         }
 
         // Only delete the workdir for user-initiated removal or if .removing marker exists.

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -618,6 +618,9 @@ impl QemuCommandBuilder<'_> {
                                 vm_id: self.vm.manifest.id.clone(),
                                 nic_index: index,
                             });
+                            // Keep the filtered backend conservative: QEMU
+                            // uses the TAP path on which libvirt installed the
+                            // nwfilter binding instead of opening vhost-net.
                             format!(
                                 "tap,id={net_id},ifname={tap},script=no,downscript=no,vhost=off"
                             )

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -14,7 +14,10 @@ use super::{
 };
 use crate::{
     app::Manifest,
-    config::{CvmConfig, CvmPlatform, Networking, NetworkingMode, ProcessAnnotation},
+    config::{
+        CvmConfig, CvmPlatform, NetworkFilterMode, Networking, NetworkingMode, ProcessAnnotation,
+    },
+    netd::{tap_name, InterfaceIdentity},
     vm_launcher::{ChildCommand, LaunchSpec},
 };
 use anyhow::{bail, Context, Result};
@@ -605,7 +608,21 @@ impl QemuCommandBuilder<'_> {
                 }
                 NetworkingMode::Bridge => {
                     tracing::info!("bridge networking: mac={mac} bridge={}", networking.bridge);
-                    format!("bridge,id={net_id},br={}", networking.bridge)
+                    match self.cfg.network_filter.mode {
+                        NetworkFilterMode::None => {
+                            format!("bridge,id={net_id},br={}", networking.bridge)
+                        }
+                        NetworkFilterMode::Libvirt => {
+                            let tap = tap_name(&InterfaceIdentity {
+                                instance_id: self.cfg.instance_id.clone(),
+                                vm_id: self.vm.manifest.id.clone(),
+                                nic_index: index,
+                            });
+                            format!(
+                                "tap,id={net_id},ifname={tap},script=no,downscript=no,vhost=off"
+                            )
+                        }
+                    }
                 }
                 NetworkingMode::Custom => {
                     if !networking.netdev.contains(&format!("id={net_id}")) {

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -1003,7 +1003,10 @@ mod tests {
     };
     use crate::app::image::{Image, ImageInfo};
     use crate::app::{needs_swtpm, GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir};
-    use crate::config::{Config, CvmPlatform, Protocol, DEFAULT_CONFIG};
+    use crate::config::{
+        Config, CvmPlatform, NetworkFilterMode, NetworkingMode, Protocol, DEFAULT_CONFIG,
+    };
+    use crate::netd::{tap_name, InterfaceIdentity};
     use dstack_types::{KeyProviderKind, TeeVariant};
 
     #[test]

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -1204,6 +1204,42 @@ mod tests {
             .iter()
             .any(|arg| arg.contains("virtio-net-pci,netdev=net1")));
 
+        for network in &mut prepared.networks {
+            network.mode = NetworkingMode::Bridge;
+            network.bridge = "br0".into();
+        }
+        let process = QemuCommandBuilder {
+            vm: &vm,
+            cfg: &config.cvm,
+            gpus: &GpuConfig::default(),
+            prepared: &prepared,
+        }
+        .build()
+        .unwrap();
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| arg == "bridge,id=net0,br=br0"));
+
+        config.cvm.instance_id = "vmm-a".into();
+        config.cvm.network_filter.mode = NetworkFilterMode::Libvirt;
+        let process = QemuCommandBuilder {
+            vm: &vm,
+            cfg: &config.cvm,
+            gpus: &GpuConfig::default(),
+            prepared: &prepared,
+        }
+        .build()
+        .unwrap();
+        let expected_tap = tap_name(&InterfaceIdentity {
+            instance_id: "vmm-a".into(),
+            vm_id: "vm-1".into(),
+            nic_index: 0,
+        });
+        assert!(process.args.iter().any(|arg| {
+            arg == &format!("tap,id=net0,ifname={expected_tap},script=no,downscript=no,vhost=off")
+        }));
+
         prepared.swtpm_socket = Some(PathBuf::from("/does-not-exist/vm-1/swtpm/swtpm.sock"));
         let process = QemuCommandBuilder {
             vm: &vm,

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::IpAddr, path::PathBuf, process::Command, str::FromStr};
+use std::{collections::BTreeMap, net::IpAddr, path::PathBuf, process::Command, str::FromStr};
 
 use anyhow::{bail, Context, Result};
 use load_config::load_config;
@@ -362,6 +362,15 @@ pub struct CvmConfig {
     /// Networking configuration
     pub networking: Networking,
 
+    /// Optional host-side filtering for bridge interfaces.
+    #[serde(default)]
+    pub network_filter: NetworkFilterConfig,
+
+    /// Stable namespace for TAP names when several VMMs share one host.
+    /// An empty value is derived from the absolute run directory.
+    #[serde(default)]
+    pub instance_id: String,
+
     /// Host sharing mode. (9p, vhd, vvfat)
     pub host_share_mode: String,
 
@@ -518,6 +527,10 @@ pub struct Config {
 
     /// CVM configuration
     pub cvm: CvmConfig,
+
+    /// Privileged host networking service configuration.
+    #[serde(default)]
+    pub netd: NetdConfig,
     /// Gateway configuration
     pub gateway: GatewayConfig,
 
@@ -532,6 +545,66 @@ pub struct Config {
 
     /// Key provider configuration
     pub key_provider: KeyProviderConfig,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkFilterMode {
+    #[default]
+    None,
+    Libvirt,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NetworkFilterConfig {
+    #[serde(default)]
+    pub mode: NetworkFilterMode,
+    #[serde(default = "default_libvirt_filter")]
+    pub filter: String,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, String>,
+}
+
+impl Default for NetworkFilterConfig {
+    fn default() -> Self {
+        Self {
+            mode: NetworkFilterMode::None,
+            filter: default_libvirt_filter(),
+            parameters: BTreeMap::new(),
+        }
+    }
+}
+
+fn default_libvirt_filter() -> String {
+    "clean-traffic".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NetdConfig {
+    #[serde(default = "default_netd_socket")]
+    pub socket: PathBuf,
+    #[serde(default)]
+    pub allowed_uids: Vec<u32>,
+    #[serde(default = "default_libvirt_uri")]
+    pub libvirt_uri: String,
+}
+
+impl Default for NetdConfig {
+    fn default() -> Self {
+        Self {
+            socket: default_netd_socket(),
+            allowed_uids: Vec::new(),
+            libvirt_uri: default_libvirt_uri(),
+        }
+    }
+}
+
+fn default_netd_socket() -> PathBuf {
+    PathBuf::from("/run/dstack/netd.sock")
+}
+
+fn default_libvirt_uri() -> String {
+    "qemu:///system".to_string()
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]

--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -7,7 +7,7 @@ use std::{path::Path, time::Duration};
 use anyhow::{anyhow, Context, Result};
 use app::App;
 use clap::{Args as ClapArgs, Parser, Subcommand};
-use config::Config;
+use config::{Config, NetdConfig};
 use dstack_api_auth::{Authenticator, HttpAuthConfig, HttpAuthFairing};
 use guest_api_service::GuestApiHandler;
 use host_api_service::HostApiHandler;
@@ -211,23 +211,28 @@ async fn main() -> Result<()> {
     }
 
     let figment = config::load_config_figment(args.config.as_deref());
+    if let Some(Command::Netd(netd_args)) = &args.command {
+        let mut netd_config: NetdConfig = figment
+            .extract_inner("netd")
+            .context("failed to load [netd] configuration")?;
+        if let Some(socket) = args.netd_socket.as_deref() {
+            netd_config.socket = socket.into();
+        }
+        if let Some(socket) = netd_args.socket.as_deref() {
+            netd_config.socket = socket.into();
+        }
+        netd_config
+            .allowed_uids
+            .extend(netd_args.allow_uids.iter().copied());
+        netd_config.allowed_uids.sort_unstable();
+        netd_config.allowed_uids.dedup();
+        return netd::serve(netd_config).await;
+    }
+
     let mut config = Config::extract_or_default(&figment)?.abs_path()?;
     config.cvm.instance_id = netd::instance_id(&config.cvm.instance_id, config.run_path.as_path());
     if let Some(socket) = args.netd_socket.as_deref() {
         config.netd.socket = socket.into();
-    }
-
-    if let Some(Command::Netd(netd_args)) = &args.command {
-        if let Some(socket) = netd_args.socket.as_deref() {
-            config.netd.socket = socket.into();
-        }
-        config
-            .netd
-            .allowed_uids
-            .extend(netd_args.allow_uids.iter().copied());
-        config.netd.allowed_uids.sort_unstable();
-        config.netd.allowed_uids.dedup();
-        return netd::serve(config.netd).await;
     }
 
     // Preserve the existing startup validation. The broader static checks are

--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -29,6 +29,7 @@ mod host_api_service;
 mod logrotate;
 mod main_routes;
 mod main_service;
+mod netd;
 mod one_shot;
 mod openapi;
 mod vm_launcher;
@@ -46,6 +47,9 @@ struct Args {
     /// Path to the configuration file
     #[arg(short, long)]
     config: Option<String>,
+    /// Override the netd socket used by the VMM (useful without systemd).
+    #[arg(long, global = true)]
+    netd_socket: Option<String>,
     /// Subcommand to run
     #[command(subcommand)]
     command: Option<Command>,
@@ -60,9 +64,21 @@ enum Command {
     CheckConfig,
     /// One-shot VM execution mode for debugging
     Run(RunArgs),
+    /// Run the privileged TAP and libvirt nwfilter broker.
+    Netd(NetdArgs),
     /// Internal per-VM QEMU/swtpm launcher.
     #[command(hide = true)]
     VmLauncher(VmLauncherArgs),
+}
+
+#[derive(ClapArgs)]
+struct NetdArgs {
+    /// Override the Unix socket configured in [netd].
+    #[arg(long)]
+    socket: Option<String>,
+    /// Authorize an additional client UID. May be repeated.
+    #[arg(long = "allow-uid")]
+    allow_uids: Vec<u32>,
 }
 
 #[derive(ClapArgs)]
@@ -195,7 +211,24 @@ async fn main() -> Result<()> {
     }
 
     let figment = config::load_config_figment(args.config.as_deref());
-    let config = Config::extract_or_default(&figment)?.abs_path()?;
+    let mut config = Config::extract_or_default(&figment)?.abs_path()?;
+    if let Some(socket) = args.netd_socket.as_deref() {
+        config.netd.socket = socket.into();
+    }
+
+    if let Some(Command::Netd(netd_args)) = &args.command {
+        if let Some(socket) = netd_args.socket.as_deref() {
+            config.netd.socket = socket.into();
+        }
+        config
+            .netd
+            .allowed_uids
+            .extend(netd_args.allow_uids.iter().copied());
+        config.netd.allowed_uids.sort_unstable();
+        config.netd.allowed_uids.dedup();
+        return netd::serve(config.netd).await;
+    }
+
     // Preserve the existing startup validation. The broader static checks are
     // opt-in through `check-config` until they have seen wider deployment use.
     config
@@ -222,6 +255,7 @@ async fn main() -> Result<()> {
             println!("configuration is valid");
             return Ok(());
         }
+        Command::Netd(_) => unreachable!("netd mode handled before server startup"),
         Command::Run(run_args) => {
             // One-shot VM execution mode
             return one_shot::run_one_shot(

--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -212,6 +212,7 @@ async fn main() -> Result<()> {
 
     let figment = config::load_config_figment(args.config.as_deref());
     let mut config = Config::extract_or_default(&figment)?.abs_path()?;
+    config.cvm.instance_id = netd::instance_id(&config.cvm.instance_id, config.run_path.as_path());
     if let Some(socket) = args.netd_socket.as_deref() {
         config.netd.socket = socket.into();
     }

--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -701,7 +701,7 @@ impl VmmRpc for RpcHandler {
             manifest.gateway_urls = request.gateway_urls.clone();
         }
         if request.update_networking {
-            manifest.networks = if request.networks.is_empty() {
+            let networks = if request.networks.is_empty() {
                 validate_default_network(&self.app.config.cvm)?;
                 vec![]
             } else {
@@ -715,8 +715,14 @@ impl VmmRpc for RpcHandler {
                 .await?
                 .is_some_and(|info| info.state.status.is_running());
             if !is_running {
+                let runtime_networks = vm_work_dir.runtime_networks();
+                self.app
+                    .remove_filtered_networks(&request.id, &runtime_networks)
+                    .await
+                    .context("failed to remove previous filtered networking")?;
                 vm_work_dir.clear_runtime_networks()?;
             }
+            manifest.networks = networks;
         }
         let compose_file = fs::read_to_string(vm_work_dir.app_compose_path())
             .context("failed to read app compose for swtpm decision")?;

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -157,6 +157,9 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
     info!(socket = %config.socket.display(), "netd listening");
     loop {
         let (mut stream, _) = listener.accept().await?;
+        // This timeout bounds async socket reads and writes. handle_request is
+        // synchronous, so helper execution is bounded separately by
+        // COMMAND_TIMEOUT rather than preempted by this future timeout.
         match timeout(CONNECTION_TIMEOUT, serve_connection(&config, &mut stream)).await {
             Ok(Ok(())) => {}
             Ok(Err(error)) => warn!(%error, "netd connection failed"),

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::BTreeMap,
-    fs::Permissions,
+    fs::{File, OpenOptions, Permissions},
     io::Write as _,
     os::{
         fd::AsRawFd,
@@ -33,6 +33,7 @@ use crate::config::NetdConfig;
 const MAX_MESSAGE_SIZE: u64 = 64 * 1024;
 const IP_PATH: &str = "/usr/sbin/ip";
 const VIRSH_PATH: &str = "/usr/bin/virsh";
+const LOCK_PATH: &str = "/run/lock/dstack-netd.lock";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceIdentity {
@@ -138,9 +139,12 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
     }
     require_executable(IP_PATH)?;
     require_executable(VIRSH_PATH)?;
-    prepare_socket_path(&config.socket)?;
-    let listener = UnixListener::bind(&config.socket)
-        .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?;
+    let listener = {
+        let _lock = OperationLock::acquire()?;
+        prepare_socket_path(&config.socket)?;
+        UnixListener::bind(&config.socket)
+            .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?
+    };
     // Access control is based on SO_PEERCRED rather than filesystem groups so
     // one shared service can authorize VMM instances running under different
     // UIDs and development mode needs no system group setup.
@@ -196,6 +200,7 @@ async fn read_request(stream: &mut UnixStream) -> Result<Request> {
 }
 
 fn handle_request(libvirt_uri: &str, request: Request) -> Result<String> {
+    let _lock = OperationLock::acquire()?;
     match request {
         Request::Prepare(request) => prepare_interface(libvirt_uri, &request),
         Request::Remove { identity } => {
@@ -212,6 +217,34 @@ fn handle_request(libvirt_uri: &str, request: Request) -> Result<String> {
             }
             virsh(libvirt_uri, &["nwfilter-binding-dumpxml", &tap], None)?;
             Ok(tap)
+        }
+    }
+}
+
+struct OperationLock(File);
+
+impl OperationLock {
+    fn acquire() -> Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(LOCK_PATH)
+            .with_context(|| format!("failed to open {LOCK_PATH}"))?;
+        // SAFETY: flock only acts on the valid file descriptor owned by file.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(std::io::Error::last_os_error()).context("failed to lock netd operations");
+        }
+        Ok(Self(file))
+    }
+}
+
+impl Drop for OperationLock {
+    fn drop(&mut self) {
+        // SAFETY: the file remains alive until after Drop returns.
+        unsafe {
+            libc::flock(self.0.as_raw_fd(), libc::LOCK_UN);
         }
     }
 }
@@ -248,12 +281,30 @@ fn remove_interface(libvirt_uri: &str, tap: &str) -> Result<()> {
     if Path::new("/sys/class/net").join(tap).exists() {
         let _ = ip(&["link", "set", "dev", tap, "down"]);
     }
-    let _ = virsh(libvirt_uri, &["nwfilter-binding-delete", tap], None);
+    delete_binding(libvirt_uri, tap)?;
     if Path::new("/sys/class/net").join(tap).exists() {
         ip(&["link", "delete", "dev", tap])?;
         info!(%tap, "removed filtered TAP");
     }
     Ok(())
+}
+
+fn delete_binding(uri: &str, tap: &str) -> Result<()> {
+    let output = Command::new(VIRSH_PATH)
+        .args(["--connect", uri, "nwfilter-binding-delete", tap])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to execute virsh")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let error = String::from_utf8_lossy(&output.stderr);
+    if error.contains("Network filter binding not found") {
+        return Ok(());
+    }
+    bail!("virsh failed to delete binding {tap}: {}", error.trim())
 }
 
 fn binding_xml(request: &PrepareRequest, tap: &str) -> String {

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -27,11 +27,13 @@ use tokio::{
 };
 use tracing::{info, warn};
 use uuid::Uuid;
+use wait_timeout::ChildExt;
 
 use crate::config::NetdConfig;
 
 const MAX_MESSAGE_SIZE: u64 = 64 * 1024;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(35);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const IP_PATH: &str = "/usr/sbin/ip";
 const VIRSH_PATH: &str = "/usr/bin/virsh";
 const LOCK_PATH: &str = "/run/lock/dstack-netd.lock";
@@ -446,6 +448,15 @@ fn virsh(uri: &str, args: &[&str], stdin: Option<&[u8]>) -> Result<()> {
 }
 
 fn run_command(program: &str, args: &[&str], stdin: Option<&[u8]>) -> Result<()> {
+    run_command_with_timeout(program, args, stdin, COMMAND_TIMEOUT)
+}
+
+fn run_command_with_timeout(
+    program: &str,
+    args: &[&str],
+    stdin: Option<&[u8]>,
+    command_timeout: Duration,
+) -> Result<()> {
     let mut child = Command::new(program)
         .args(args)
         .stdin(if stdin.is_some() {
@@ -463,6 +474,14 @@ fn run_command(program: &str, args: &[&str], stdin: Option<&[u8]>) -> Result<()>
             .take()
             .context("missing command stdin")?
             .write_all(input)?;
+    }
+    if child.wait_timeout(command_timeout)?.is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+        bail!(
+            "{} timed out after {command_timeout:?}",
+            Path::new(program).display()
+        );
     }
     let output = child.wait_with_output()?;
     if !output.status.success() {
@@ -588,5 +607,19 @@ mod tests {
         // EPIPE. In both cases serve() logs this per-connection error and keeps
         // accepting clients.
         assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn command_timeout_kills_stalled_tool() {
+        let started = std::time::Instant::now();
+        let error = run_command_with_timeout(
+            "/bin/sh",
+            &["-c", "sleep 10"],
+            None,
+            Duration::from_millis(50),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(2));
     }
 }

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 use crate::config::NetdConfig;
 
 const MAX_MESSAGE_SIZE: u64 = 64 * 1024;
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(35);
 const IP_PATH: &str = "/usr/sbin/ip";
 const VIRSH_PATH: &str = "/usr/bin/virsh";
 const LOCK_PATH: &str = "/run/lock/dstack-netd.lock";
@@ -152,39 +153,48 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
     info!(socket = %config.socket.display(), "netd listening");
     loop {
         let (mut stream, _) = listener.accept().await?;
-        let uid = peer_uid(&stream)?;
-        let allowed = uid == 0 || config.allowed_uids.contains(&uid);
-        let response = if allowed {
-            match read_request(&mut stream)
-                .await
-                .and_then(|request| handle_request(&config.libvirt_uri, request))
-            {
-                Ok(tap) => Response {
-                    ok: true,
-                    tap: Some(tap),
-                    error: None,
-                },
-                Err(error) => {
-                    warn!(%uid, %error, "netd request failed");
-                    Response {
-                        ok: false,
-                        tap: None,
-                        error: Some(format!("{error:#}")),
-                    }
+        match timeout(CONNECTION_TIMEOUT, serve_connection(&config, &mut stream)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => warn!(%error, "netd connection failed"),
+            Err(_) => warn!("netd connection timed out"),
+        }
+    }
+}
+
+async fn serve_connection(config: &NetdConfig, stream: &mut UnixStream) -> Result<()> {
+    let uid = peer_uid(stream)?;
+    let allowed = uid == 0 || config.allowed_uids.contains(&uid);
+    let response = if allowed {
+        match read_request(stream)
+            .await
+            .and_then(|request| handle_request(&config.libvirt_uri, request))
+        {
+            Ok(tap) => Response {
+                ok: true,
+                tap: Some(tap),
+                error: None,
+            },
+            Err(error) => {
+                warn!(%uid, %error, "netd request failed");
+                Response {
+                    ok: false,
+                    tap: None,
+                    error: Some(format!("{error:#}")),
                 }
             }
-        } else {
-            warn!(%uid, "rejected unauthorized netd client");
-            Response {
-                ok: false,
-                tap: None,
-                error: Some("caller UID is not authorized".into()),
-            }
-        };
-        let encoded = serde_json::to_vec(&response)?;
-        stream.write_all(&encoded).await?;
-        stream.shutdown().await?;
-    }
+        }
+    } else {
+        warn!(%uid, "rejected unauthorized netd client");
+        Response {
+            ok: false,
+            tap: None,
+            error: Some("caller UID is not authorized".into()),
+        }
+    };
+    let encoded = serde_json::to_vec(&response)?;
+    stream.write_all(&encoded).await?;
+    stream.shutdown().await?;
+    Ok(())
 }
 
 async fn read_request(stream: &mut UnixStream) -> Result<Request> {
@@ -562,5 +572,21 @@ mod tests {
         assert_eq!(value["vm_id"], "vm");
         assert_eq!(value["nic_index"], 2);
         assert!(value.get("identity").is_none());
+    }
+
+    #[tokio::test]
+    async fn disconnected_client_is_confined_to_one_connection() {
+        let (mut server, client) = UnixStream::pair().unwrap();
+        drop(client);
+        let result = timeout(
+            Duration::from_secs(1),
+            serve_connection(&NetdConfig::default(), &mut server),
+        )
+        .await;
+        assert!(result.is_ok(), "disconnected peer blocked the handler");
+        // Either the EOF is reported while reading or the response write sees
+        // EPIPE. In both cases serve() logs this per-connection error and keeps
+        // accepting clients.
+        assert!(result.unwrap().is_err());
     }
 }

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -65,6 +65,8 @@ pub enum Request {
         #[serde(flatten)]
         identity: InterfaceIdentity,
     },
+    /// Verify a deterministic TAP and binding for operations and integration
+    /// diagnostics. The VMM startup path uses Prepare rather than Check.
     Check {
         #[serde(flatten)]
         identity: InterfaceIdentity,
@@ -137,7 +139,7 @@ pub async fn request(socket: &Path, request: &Request) -> Result<String> {
 }
 
 pub async fn serve(config: NetdConfig) -> Result<()> {
-    if unsafe { libc::geteuid() } != 0 {
+    if !nix::unistd::Uid::effective().is_root() {
         bail!("netd must run as root");
     }
     require_executable(IP_PATH)?;

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -57,8 +57,14 @@ pub struct PrepareRequest {
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum Request {
     Prepare(PrepareRequest),
-    Remove { identity: InterfaceIdentity },
-    Check { identity: InterfaceIdentity },
+    Remove {
+        #[serde(flatten)]
+        identity: InterfaceIdentity,
+    },
+    Check {
+        #[serde(flatten)]
+        identity: InterfaceIdentity,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -492,5 +498,18 @@ mod tests {
         assert!(validate_name("bridge", "br0;id", 15, "_.-").is_err());
         assert!(validate_name("filter", "../../filter", 128, "_.:-").is_err());
         assert!(validate_mac("ff:ff:ff:ff:ff:ff").is_err());
+    }
+
+    #[test]
+    fn remove_protocol_keeps_identity_fields_flat() {
+        let request = Request::Remove {
+            identity: identity("instance", "vm", 2),
+        };
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["operation"], "remove");
+        assert_eq!(value["instance_id"], "instance");
+        assert_eq!(value["vm_id"], "vm");
+        assert_eq!(value["nic_index"], 2);
+        assert!(value.get("identity").is_none());
     }
 }

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -135,7 +135,10 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
     prepare_socket_path(&config.socket)?;
     let listener = UnixListener::bind(&config.socket)
         .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?;
-    std::fs::set_permissions(&config.socket, Permissions::from_mode(0o660))?;
+    // Access control is based on SO_PEERCRED rather than filesystem groups so
+    // one shared service can authorize VMM instances running under different
+    // UIDs and development mode needs no system group setup.
+    std::fs::set_permissions(&config.socket, Permissions::from_mode(0o666))?;
     info!(socket = %config.socket.display(), "netd listening");
     loop {
         let (mut stream, _) = listener.accept().await?;
@@ -263,12 +266,11 @@ fn binding_xml(request: &PrepareRequest, tap: &str) -> String {
     }
     format!(
         "<filterbinding><owner><name>{}</name><uuid>{}</uuid></owner>\
-         <portdev name='{}'/><linkdev name='{}'/><mac address='{}'/>\
+         <portdev name='{}'/><mac address='{}'/>\
          <filterref filter='{}'>{}</filterref></filterbinding>",
         xml_escape(&owner_name),
         owner_uuid,
         xml_escape(tap),
-        xml_escape(&request.bridge),
         xml_escape(&request.mac),
         xml_escape(&request.filter),
         parameters

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -12,7 +12,7 @@ use std::{
         fd::AsRawFd,
         unix::{fs::PermissionsExt, net::UnixStream as StdUnixStream},
     },
-    path::{Path, PathBuf},
+    path::Path,
     process::{Command, Stdio},
     time::Duration,
 };

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -1,0 +1,494 @@
+// SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Small privileged broker for TAP creation and libvirt nwfilter bindings.
+
+use std::{
+    collections::BTreeMap,
+    fs::Permissions,
+    io::Write as _,
+    os::{
+        fd::AsRawFd,
+        unix::{fs::PermissionsExt, net::UnixStream as StdUnixStream},
+    },
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{UnixListener, UnixStream},
+    time::timeout,
+};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::config::NetdConfig;
+
+const MAX_MESSAGE_SIZE: u64 = 64 * 1024;
+const IP_PATH: &str = "/usr/sbin/ip";
+const VIRSH_PATH: &str = "/usr/bin/virsh";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterfaceIdentity {
+    pub instance_id: String,
+    pub vm_id: String,
+    pub nic_index: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrepareRequest {
+    #[serde(flatten)]
+    pub identity: InterfaceIdentity,
+    pub bridge: String,
+    pub mac: String,
+    pub qemu_uid: u32,
+    pub filter: String,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum Request {
+    Prepare(PrepareRequest),
+    Remove { identity: InterfaceIdentity },
+    Check { identity: InterfaceIdentity },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Response {
+    ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+pub fn tap_name(identity: &InterfaceIdentity) -> String {
+    let input = format!(
+        "{}\0{}\0{}",
+        identity.instance_id, identity.vm_id, identity.nic_index
+    );
+    let digest = Sha256::digest(input.as_bytes());
+    format!("dt{}", hex::encode(&digest[..6]))
+}
+
+pub fn instance_id(configured: &str, run_path: &Path) -> String {
+    if !configured.trim().is_empty() {
+        return configured.trim().to_string();
+    }
+    let digest = Sha256::digest(run_path.as_os_str().as_encoded_bytes());
+    format!("path-{}", hex::encode(&digest[..8]))
+}
+
+pub async fn request(socket: &Path, request: &Request) -> Result<String> {
+    let operation = match request {
+        Request::Prepare(_) => "prepare",
+        Request::Remove { .. } => "remove",
+        Request::Check { .. } => "check",
+    };
+    let exchange = async {
+        let mut stream = UnixStream::connect(socket)
+            .await
+            .with_context(|| format!("failed to connect to netd at {}", socket.display()))?;
+        let message = serde_json::to_vec(request)?;
+        if message.len() as u64 > MAX_MESSAGE_SIZE {
+            bail!("netd request is too large");
+        }
+        stream.write_all(&message).await?;
+        stream.shutdown().await?;
+        let mut response = Vec::new();
+        stream
+            .take(MAX_MESSAGE_SIZE + 1)
+            .read_to_end(&mut response)
+            .await?;
+        if response.len() as u64 > MAX_MESSAGE_SIZE {
+            bail!("netd response is too large");
+        }
+        let response: Response =
+            serde_json::from_slice(&response).context("failed to decode netd response")?;
+        if !response.ok {
+            bail!(
+                "netd {operation} failed: {}",
+                response.error.as_deref().unwrap_or("unknown error")
+            );
+        }
+        response.tap.context("netd response omitted TAP name")
+    };
+    timeout(Duration::from_secs(30), exchange)
+        .await
+        .context("timed out waiting for netd")?
+}
+
+pub async fn serve(config: NetdConfig) -> Result<()> {
+    if unsafe { libc::geteuid() } != 0 {
+        bail!("netd must run as root");
+    }
+    require_executable(IP_PATH)?;
+    require_executable(VIRSH_PATH)?;
+    prepare_socket_path(&config.socket)?;
+    let listener = UnixListener::bind(&config.socket)
+        .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?;
+    std::fs::set_permissions(&config.socket, Permissions::from_mode(0o660))?;
+    info!(socket = %config.socket.display(), "netd listening");
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+        let uid = peer_uid(&stream)?;
+        let allowed = uid == 0 || config.allowed_uids.contains(&uid);
+        let response = if allowed {
+            match read_request(&mut stream)
+                .await
+                .and_then(|request| handle_request(&config.libvirt_uri, request))
+            {
+                Ok(tap) => Response {
+                    ok: true,
+                    tap: Some(tap),
+                    error: None,
+                },
+                Err(error) => {
+                    warn!(%uid, %error, "netd request failed");
+                    Response {
+                        ok: false,
+                        tap: None,
+                        error: Some(format!("{error:#}")),
+                    }
+                }
+            }
+        } else {
+            warn!(%uid, "rejected unauthorized netd client");
+            Response {
+                ok: false,
+                tap: None,
+                error: Some("caller UID is not authorized".into()),
+            }
+        };
+        let encoded = serde_json::to_vec(&response)?;
+        stream.write_all(&encoded).await?;
+        stream.shutdown().await?;
+    }
+}
+
+async fn read_request(stream: &mut UnixStream) -> Result<Request> {
+    let mut message = Vec::new();
+    stream
+        .take(MAX_MESSAGE_SIZE + 1)
+        .read_to_end(&mut message)
+        .await?;
+    if message.len() as u64 > MAX_MESSAGE_SIZE {
+        bail!("request exceeds {MAX_MESSAGE_SIZE} bytes");
+    }
+    serde_json::from_slice(&message).context("invalid netd request")
+}
+
+fn handle_request(libvirt_uri: &str, request: Request) -> Result<String> {
+    match request {
+        Request::Prepare(request) => prepare_interface(libvirt_uri, &request),
+        Request::Remove { identity } => {
+            validate_identity(&identity)?;
+            let tap = tap_name(&identity);
+            remove_interface(libvirt_uri, &tap)?;
+            Ok(tap)
+        }
+        Request::Check { identity } => {
+            validate_identity(&identity)?;
+            let tap = tap_name(&identity);
+            if !Path::new("/sys/class/net").join(&tap).exists() {
+                bail!("TAP {tap} does not exist");
+            }
+            virsh(libvirt_uri, &["nwfilter-binding-dumpxml", &tap], None)?;
+            Ok(tap)
+        }
+    }
+}
+
+fn prepare_interface(libvirt_uri: &str, request: &PrepareRequest) -> Result<String> {
+    validate_prepare(request)?;
+    let tap = tap_name(&request.identity);
+    // A failed VMM start may leave a deterministic resource behind. Replacing
+    // it makes prepare idempotent without accepting a caller-selected TAP.
+    remove_interface(libvirt_uri, &tap)?;
+
+    let uid = request.qemu_uid.to_string();
+    ip(&["tuntap", "add", "dev", &tap, "mode", "tap", "user", &uid])?;
+    let result = (|| {
+        ip(&["link", "set", "dev", &tap, "master", &request.bridge])?;
+        let xml = binding_xml(request, &tap);
+        virsh(
+            libvirt_uri,
+            &["nwfilter-binding-create", "--validate", "/dev/stdin"],
+            Some(xml.as_bytes()),
+        )?;
+        ip(&["link", "set", "dev", &tap, "up"])?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = remove_interface(libvirt_uri, &tap);
+        return Err(error);
+    }
+    info!(%tap, bridge = %request.bridge, filter = %request.filter, "prepared filtered TAP");
+    Ok(tap)
+}
+
+fn remove_interface(libvirt_uri: &str, tap: &str) -> Result<()> {
+    if Path::new("/sys/class/net").join(tap).exists() {
+        let _ = ip(&["link", "set", "dev", tap, "down"]);
+    }
+    let _ = virsh(libvirt_uri, &["nwfilter-binding-delete", tap], None);
+    if Path::new("/sys/class/net").join(tap).exists() {
+        ip(&["link", "delete", "dev", tap])?;
+        info!(%tap, "removed filtered TAP");
+    }
+    Ok(())
+}
+
+fn binding_xml(request: &PrepareRequest, tap: &str) -> String {
+    let owner_uuid = stable_uuid(&request.identity);
+    let owner_name = format!(
+        "dstack:{}:{}:{}",
+        request.identity.instance_id, request.identity.vm_id, request.identity.nic_index
+    );
+    let mut parameters = String::new();
+    for (name, value) in &request.parameters {
+        parameters.push_str(&format!(
+            "<parameter name='{}' value='{}'/>",
+            xml_escape(name),
+            xml_escape(value)
+        ));
+    }
+    format!(
+        "<filterbinding><owner><name>{}</name><uuid>{}</uuid></owner>\
+         <portdev name='{}'/><linkdev name='{}'/><mac address='{}'/>\
+         <filterref filter='{}'>{}</filterref></filterbinding>",
+        xml_escape(&owner_name),
+        owner_uuid,
+        xml_escape(tap),
+        xml_escape(&request.bridge),
+        xml_escape(&request.mac),
+        xml_escape(&request.filter),
+        parameters
+    )
+}
+
+fn stable_uuid(identity: &InterfaceIdentity) -> Uuid {
+    let digest = Sha256::digest(
+        format!(
+            "{}\0{}\0{}",
+            identity.instance_id, identity.vm_id, identity.nic_index
+        )
+        .as_bytes(),
+    );
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x50;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+fn validate_prepare(request: &PrepareRequest) -> Result<()> {
+    validate_identity(&request.identity)?;
+    validate_name("bridge", &request.bridge, 15, "_.-")?;
+    if !Path::new("/sys/class/net")
+        .join(&request.bridge)
+        .join("bridge")
+        .exists()
+    {
+        bail!("{} is not a host bridge", request.bridge);
+    }
+    validate_mac(&request.mac)?;
+    validate_name("filter", &request.filter, 128, "_.:-")?;
+    if request.parameters.len() > 64 {
+        bail!("too many nwfilter parameters");
+    }
+    for (name, value) in &request.parameters {
+        validate_name("parameter name", name, 64, "_")?;
+        if value.len() > 512 || value.contains('\0') {
+            bail!("invalid nwfilter parameter value");
+        }
+    }
+    Ok(())
+}
+
+fn validate_identity(identity: &InterfaceIdentity) -> Result<()> {
+    for (label, value) in [
+        ("instance ID", identity.instance_id.as_str()),
+        ("VM ID", identity.vm_id.as_str()),
+    ] {
+        if value.is_empty() || value.len() > 128 || value.contains('\0') {
+            bail!("invalid {label}");
+        }
+    }
+    if identity.nic_index > 255 {
+        bail!("NIC index is out of range");
+    }
+    Ok(())
+}
+
+fn validate_name(label: &str, value: &str, max: usize, punctuation: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > max
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || punctuation.contains(ch))
+    {
+        bail!("invalid {label}");
+    }
+    Ok(())
+}
+
+fn validate_mac(mac: &str) -> Result<()> {
+    let bytes = mac
+        .split(':')
+        .map(|part| {
+            if part.len() != 2 {
+                bail!("invalid MAC address");
+            }
+            u8::from_str_radix(part, 16).context("invalid MAC address")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if bytes.len() != 6 || bytes[0] & 1 != 0 {
+        bail!("invalid unicast MAC address");
+    }
+    Ok(())
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('\'', "&apos;")
+        .replace('"', "&quot;")
+}
+
+fn ip(args: &[&str]) -> Result<()> {
+    run_command(IP_PATH, args, None)
+}
+
+fn virsh(uri: &str, args: &[&str], stdin: Option<&[u8]>) -> Result<()> {
+    let mut full_args = vec!["--connect", uri];
+    full_args.extend_from_slice(args);
+    run_command(VIRSH_PATH, &full_args, stdin)
+}
+
+fn run_command(program: &str, args: &[&str], stdin: Option<&[u8]>) -> Result<()> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to execute {program}"))?;
+    if let Some(input) = stdin {
+        child
+            .stdin
+            .take()
+            .context("missing command stdin")?
+            .write_all(input)?;
+    }
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        bail!("{} failed: {}", Path::new(program).display(), error.trim());
+    }
+    Ok(())
+}
+
+fn require_executable(path: &str) -> Result<()> {
+    if !Path::new(path).is_file() {
+        bail!("required executable {path} does not exist");
+    }
+    Ok(())
+}
+
+fn prepare_socket_path(socket: &Path) -> Result<()> {
+    let parent = socket.parent().context("netd socket has no parent")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {}", parent.display()))?;
+    if socket.exists() {
+        if StdUnixStream::connect(socket).is_ok() {
+            bail!("another netd is listening at {}", socket.display());
+        }
+        std::fs::remove_file(socket)
+            .with_context(|| format!("failed to remove stale socket {}", socket.display()))?;
+    }
+    Ok(())
+}
+
+fn peer_uid(stream: &UnixStream) -> Result<u32> {
+    let mut credentials = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: credentials and length point to valid writable storage of the
+    // exact size passed to getsockopt, and the stream owns a valid socket FD.
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut credentials as *mut libc::ucred).cast(),
+            &mut length,
+        )
+    };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error()).context("failed to read peer credentials");
+    }
+    Ok(credentials.uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(instance: &str, vm: &str, nic_index: usize) -> InterfaceIdentity {
+        InterfaceIdentity {
+            instance_id: instance.into(),
+            vm_id: vm.into(),
+            nic_index,
+        }
+    }
+
+    #[test]
+    fn tap_names_are_stable_bounded_and_namespaced() {
+        let first = tap_name(&identity("one", "vm", 0));
+        assert_eq!(first, tap_name(&identity("one", "vm", 0)));
+        assert_ne!(first, tap_name(&identity("two", "vm", 0)));
+        assert_ne!(first, tap_name(&identity("one", "vm", 1)));
+        assert!(first.len() <= 15);
+    }
+
+    #[test]
+    fn binding_xml_escapes_values() {
+        let request = PrepareRequest {
+            identity: identity("instance<&", "vm", 0),
+            bridge: "br0".into(),
+            mac: "02:00:00:00:00:01".into(),
+            qemu_uid: 1000,
+            filter: "clean-traffic".into(),
+            parameters: BTreeMap::from([("IP".into(), "10.0.0.2<&".into())]),
+        };
+        let xml = binding_xml(&request, "dt123");
+        assert!(xml.contains("instance&lt;&amp;"));
+        assert!(xml.contains("10.0.0.2&lt;&amp;"));
+        assert!(!xml.contains("instance<&"));
+    }
+
+    #[test]
+    fn validation_rejects_injected_host_names() {
+        assert!(validate_name("bridge", "br0;id", 15, "_.-").is_err());
+        assert!(validate_name("filter", "../../filter", 128, "_.:-").is_err());
+        assert!(validate_mac("ff:ff:ff:ff:ff:ff").is_err());
+    }
+}

--- a/dstack/vmm/src/one_shot.rs
+++ b/dstack/vmm/src/one_shot.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::app::{
-    make_sys_config, simulator_config_for_manifest, sync_tee_simulator_config, Image, VmConfig,
-    VmWorkDir,
+    make_sys_config, resolved_networks, simulator_config_for_manifest, sync_tee_simulator_config,
+    Image, VmConfig, VmWorkDir,
 };
-use crate::config::Config;
+use crate::config::{Config, NetworkFilterMode, NetworkingMode};
 use crate::main_service;
 use anyhow::{Context, Result};
 use fs_err as fs;
@@ -278,6 +278,17 @@ Compose file content (first 200 chars):
         workdir: workdir_path.clone(),
         gateway_enabled: app_compose.gateway_enabled(),
     };
+
+    if !dry_run
+        && config.cvm.network_filter.mode == NetworkFilterMode::Libvirt
+        && resolved_networks(&manifest, &config.cvm)
+            .iter()
+            .any(|network| network.mode == NetworkingMode::Bridge)
+    {
+        anyhow::bail!(
+            "one-shot execution does not manage libvirt-filtered TAP lifecycle; run the VMM server directly or use --dry-run"
+        );
+    }
 
     let process_configs = vm_builder_config
         .config_qemu(&workdir_path, &config.cvm, &gpus)

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -44,6 +44,9 @@ max_allocable_memory_in_mb = 100_000 # MB
 qmp_socket = false
 # The user to run the VM as. If empty, the VM will be run as the current user.
 user = ""
+# Unique namespace when multiple dstack-vmm instances share one host. When
+# empty, a stable value is derived from run_path.
+instance_id = ""
 use_mrconfigid = true
 
 # QEMU flags
@@ -108,6 +111,20 @@ restrict = false
 
 # for mode = "bridge"
 # bridge = "virbr0"
+
+# Optional filtering for bridge interfaces. "none" preserves the existing
+# QEMU bridge-helper behavior and has no netd/libvirt dependency.
+[cvm.network_filter]
+mode = "none"
+filter = "clean-traffic"
+parameters = {}
+
+# Shared privileged networking service. Only used when network_filter.mode is
+# "libvirt". An empty allowed_uids list permits root only.
+[netd]
+socket = "/run/dstack/netd.sock"
+allowed_uids = []
+libvirt_uri = "qemu:///system"
 
 [cvm.port_mapping]
 enabled = false


### PR DESCRIPTION
## Summary

- add an optional `cvm.network_filter.mode = "libvirt"` backend for bridge NICs; the default `none` mode preserves the existing unfiltered QEMU bridge-helper path
- keep QEMU launch and every attestation-sensitive QEMU argument under `dstack-vmm`; libvirt is used only for standalone nwfilter bindings
- add a small privileged `dstack-vmm netd` broker that creates deterministic TAPs, attaches them to the requested bridge, and creates/removes libvirt nwfilter bindings before/after QEMU
- support one shared host netd across multiple VMM instances through a stable instance namespace, while allowing dedicated sockets for development
- authenticate Unix-socket clients with `SO_PEERCRED`, bound protocol messages and fields, derive TAP names server-side, generate/escape binding XML internally, use fixed absolute host tools, and serialize operations across netd processes
- roll back all prepared NICs if setup or Supervisor deployment fails; remove bindings and TAPs after VM stop/removal
- let netd load only `[netd]`, so it can use a small standalone root-owned configuration and does not initialize QEMU/VMM services
- support running both VMM and netd directly without systemd through `--socket`, `--allow-uid`, and `--netd-socket`

This implementation starts from `master` and does not depend on or reuse the implementation in #835/#836. Those PRs remain available only as historical reference.

## Configuration

```toml
[cvm]
instance_id = "worker-a" # optional; derived from run_path when empty

[cvm.network_filter]
mode = "libvirt" # or "none" (default)
filter = "clean-traffic"
parameters = { IP = "192.0.2.10" }

[netd]
socket = "/run/dstack/netd.sock"
allowed_uids = [991, 992]
libvirt_uri = "qemu:///system"
```

When mode is `none`, dstack does not connect to netd and continues to emit:

```text
-netdev bridge,id=netN,br=<bridge>
```

When mode is `libvirt`, netd finishes the binding before dstack submits QEMU, which receives:

```text
-netdev tap,id=netN,ifname=<derived>,script=no,downscript=no,vhost=off
```

## Verification

- `cargo test -p dstack-vmm` — 60 passed
- `cargo clippy -p dstack-vmm --all-targets -- -D warnings`
- `cargo fmt --manifest-path vmm/Cargo.toml -- --check`
- `git diff --check origin/master...HEAD`
- root integration test against the installed `qemu:///system` libvirt:
  - create temporary bridge
  - start the built `dstack-vmm netd`
  - prepare TAP with `clean-traffic` and static `IP` parameter
  - verify `virsh nwfilter-binding-dumpxml`
  - remove binding/TAP and verify both disappeared
- direct development-mode test with a minimal `[netd]` config and a non-root client authorized by UID
