### PR TITLE
fix(gateway): validate WireGuard peer public keys

### DIFF
--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -12,6 +12,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use auth_client::AuthClient;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 use crate::distributed_certbot::DistributedCertBot;
 use cmd_lib::run_cmd as cmd;
@@ -50,6 +51,16 @@ mod auth_client;
 mod handshakes;
 
 use handshakes::LatestHandshakesCache;
+
+fn validate_wireguard_public_key(public_key: &str) -> Result<()> {
+    let decoded = STANDARD
+        .decode(public_key)
+        .context("invalid WireGuard public key encoding")?;
+    if decoded.len() != 32 {
+        bail!("WireGuard public key must decode to 32 bytes");
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct Proxy {
@@ -488,9 +499,8 @@ impl Proxy {
         if instance_id.is_empty() {
             bail!("[{instance_id}] instance id is empty");
         }
-        if client_public_key.is_empty() {
-            bail!("[{instance_id}] client public key is empty");
-        }
+        validate_wireguard_public_key(client_public_key)
+            .with_context(|| format!("[{instance_id}] invalid client public key"))?;
         let client_info = state
             .new_client_by_id(
                 instance_id,

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -115,6 +115,21 @@ async fn test_invalid_wireguard_public_key_does_not_register() {
 }
 
 #[tokio::test]
+async fn test_wireguard_public_key_cannot_be_reused_by_another_instance() {
+    const PUBLIC_KEY: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    let state = create_test_state().await;
+    state
+        .lock()
+        .new_client_by_id("instance-1", "app", PUBLIC_KEY, "compose", None)
+        .unwrap();
+
+    let result = state.do_register_cvm("app", "instance-2", PUBLIC_KEY, "compose", None);
+
+    assert!(result.is_err());
+    assert!(!state.lock().state.instances.contains_key("instance-2"));
+}
+
+#[tokio::test]
 async fn test_port_policy_restrict_mode_allows_listed_only() {
     let state = create_test_state().await;
     state

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -98,6 +98,22 @@ fn policy(restrict: bool, ports: &[u16]) -> PortPolicy {
     }
 }
 
+#[test]
+fn test_validate_wireguard_public_key() {
+    assert!(validate_wireguard_public_key("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=").is_ok());
+    assert!(validate_wireguard_public_key("not-a-wireguard-key").is_err());
+    assert!(validate_wireguard_public_key("AQID").is_err());
+}
+
+#[tokio::test]
+async fn test_invalid_wireguard_public_key_does_not_register() {
+    let state = create_test_state().await;
+    let result = state.do_register_cvm("app", "instance", "invalid", "compose", None);
+
+    assert!(result.is_err());
+    assert!(!state.lock().state.instances.contains_key("instance"));
+}
+
 #[tokio::test]
 async fn test_port_policy_restrict_mode_allows_listed_only() {
     let state = create_test_state().await;


### PR DESCRIPTION
## Summary

- validate CVM WireGuard public keys before updating gateway state
- require standard Base64 encoding that decodes to exactly 32 bytes
- reject a public key already assigned to another instance
- add regression coverage for malformed and duplicate keys

This prevents malformed registration input from poisoning generated WireGuard configurations and prevents duplicate peer identities from silently replacing an existing peer's `AllowedIPs`.

## Testing

- `cargo test -p dstack-gateway` (54 passed)