### PR TITLE
fix(os): omit built-in FUSE module package

### DIFF
--- a/os/yocto/layers/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/os/yocto/layers/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -26,7 +26,6 @@ IMAGE_INSTALL = "\
     dstack-zfs \
     dstack-sysbox \
     kernel-module-tun \
-    kernel-module-fuse \
     kernel-module-br-netfilter \
     kernel-module-xt-mark \
     kernel-module-xt-connmark \


### PR DESCRIPTION
## Problem

The dstack kernel config sets:

```text
CONFIG_FUSE_FS=y
```

That compiles FUSE **into the kernel image**. Yocto therefore does not produce a separate `kernel-module-fuse` package.

However, `dstack-rootfs-base.inc` still listed `kernel-module-fuse` in `IMAGE_INSTALL`. When BitBake resolved the root filesystem, it tried to install a package that cannot exist with this kernel configuration and failed with an error of this form:

```text
Nothing RPROVIDES kernel-module-fuse
Required build target has no buildable providers
```

In other words, the image recipe expected FUSE to be a loadable module while the kernel deliberately builds it in.

## Fix

Remove `kernel-module-fuse` from `IMAGE_INSTALL`.

This does **not** remove FUSE support from the guest. FUSE remains available through the built-in kernel implementation selected by `CONFIG_FUSE_FS=y`; only the invalid request for a separate module package is removed.

## Changed file

- `os/yocto/layers/meta-dstack/recipes-core/images/dstack-rootfs-base.inc`

## Scope

This PR only fixes the Yocto package/configuration mismatch. It contains no test-infrastructure changes and no unrelated product fixes from #840.

## Dependency

This PR is based directly on `master` and has no dependency on another split PR.

## Verification

- Confirmed both OS kernel configurations select `CONFIG_FUSE_FS=y`.
- Confirmed the branch removes the sole `kernel-module-fuse` entry from the rootfs package list.
- `git diff --check origin/master..origin/codex/fix-os-fuse-package`: passed.
