### PR TITLE
fix(os): fail multi-flavor builds on first error

### DIFF
--- a/os/yocto/Makefile
+++ b/os/yocto/Makefile
@@ -20,7 +20,7 @@ all: dist
 -include $(wildcard mk.d/*.mk)
 
 dist: images
-	$(foreach flavor,$(FLAVORS),./mkimage.sh --dist-name $(call flavor_to_dist,$(flavor)) --flavor $(flavor);)
+	set -e; $(foreach flavor,$(FLAVORS),./mkimage.sh --dist-name $(call flavor_to_dist,$(flavor)) --flavor $(flavor);)
 
 # Build common artifacts (shared across all flavors)
 # dstack-guest is built here first to warm sstate/downloads and avoid concurrent
@@ -30,17 +30,17 @@ images-common:
 
 # Build flavor-specific artifacts using multiconfig (serial to avoid deadlock warnings)
 images-flavors:
-	$(foreach flavor,$(FLAVORS),bitbake mc:$(flavor):dstack-rootfs mc:$(flavor):dstack-uki;)
+	set -e; $(foreach flavor,$(FLAVORS),bitbake mc:$(flavor):dstack-rootfs mc:$(flavor):dstack-uki;)
 
 images: images-common images-flavors
 
 clean:
 	bitbake -c cleansstate virtual/kernel dstack-initramfs dstack-ovmf
-	$(foreach flavor,$(FLAVORS),bitbake -c cleansstate mc:$(flavor):dstack-rootfs mc:$(flavor):dstack-uki;)
+	set -e; $(foreach flavor,$(FLAVORS),bitbake -c cleansstate mc:$(flavor):dstack-rootfs mc:$(flavor):dstack-uki;)
 
 clean-dstack:
 	bitbake -c cleansstate dstack-guest
-	$(foreach flavor,$(FLAVORS),bitbake -c cleansstate mc:$(flavor):dstack-rootfs;)
+	set -e; $(foreach flavor,$(FLAVORS),bitbake -c cleansstate mc:$(flavor):dstack-rootfs;)
 
 clean-initrd:
 	bitbake -c cleansstate dstack-initramfs


### PR DESCRIPTION
## Problem

The multi-flavor Yocto target launched each flavor through a shell pipeline whose final status did not reliably propagate an earlier failed build. A failure in one flavor could therefore be followed by later work and leave the wrapper reporting success, hiding the first broken image.

## Root cause and fix

Run the flavor loop with immediate error propagation so the first non-zero BitBake/build result terminates the aggregate target and is returned to the caller.

## Implementation

The branch records the following focused implementation work:

- `fix(os): fail multi-flavor builds on first error`

Changed paths:

- `os/yocto/Makefile`

## Scope

This PR addresses one logical `os` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-os-multiflavor-failure`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
