### PR TITLE
fix(simulator): support current FUSE soname

### DIFF
--- a/dstack/tee-simulator/src/nsm.rs
+++ b/dstack/tee-simulator/src/nsm.rs
@@ -86,7 +86,12 @@ fn cuse() -> &'static CuseApi {
 }
 
 unsafe fn load_cuse() -> Result<CuseApi> {
-    let library = Box::leak(Box::new(libloading::Library::new("libfuse3.so.3")?));
+    // FUSE 3.18 bumped the shared-library SONAME to 4. Keep the older SONAME
+    // fallback so development binaries also run on distributions that still
+    // ship the previous ABI.
+    let library = libloading::Library::new("libfuse3.so.4")
+        .or_else(|_| libloading::Library::new("libfuse3.so.3"))?;
+    let library = Box::leak(Box::new(library));
     Ok(CuseApi {
         main: *library.get(b"cuse_lowlevel_main\0")?,
         reply_open: *library.get(b"fuse_reply_open\0")?,


### PR DESCRIPTION
## Problem

The Nitro NSM simulator dynamically loaded only `libfuse3.so.3`. FUSE 3.18 changed the SONAME to `libfuse3.so.4`, so the simulator failed during startup on current distributions even though FUSE 3 was installed.

The failure occurs before CUSE registration when `libloading` cannot open `.so.3`.

## Fix

Try `libfuse3.so.4` first and fall back to `libfuse3.so.3` for older distributions.

No TDX configfs behavior, mount handling, dependency change, or unrelated safety refactor remains in this PR.

## Diff

- One file: `dstack/tee-simulator/src/nsm.rs`
- `+6 / -1`

## Dependency

Directly based on `master`; no stacked dependency.

## Verification

- `cargo check -p dstack-tee-simulator --all-targets`: passed.
- `git diff --check origin/master...HEAD`: passed.
