### PR TITLE
fix(simulator): wait for GCP vTPM readiness

### DIFF
--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -115,7 +115,22 @@ pub fn start_gcp_vtpm(runtime_dir: &Path, config: &TeeSimulatorConfig) -> Result
         }
         thread::sleep(Duration::from_millis(20));
     }
-    command("tpm2_startup", &["-c"])?;
+    let mut startup_error = None;
+    for _ in 0..100 {
+        match command("tpm2_startup", &["-c"]) {
+            Ok(()) => {
+                startup_error = None;
+                break;
+            }
+            Err(error) => {
+                startup_error = Some(error);
+                thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+    if let Some(error) = startup_error {
+        return Err(error).context("GCP vTPM did not become ready");
+    }
     replay_fixture_event_log()?;
 
     let template_with_size = state_dir.join("ak.tpm2b-public");


### PR DESCRIPTION
## Problem

On GCP the vTPM character device is not guaranteed to be usable at the instant the simulator service starts. Opening it once made boot timing decide whether the simulator came up or exited with a device-open failure.

## Root cause and fix

Probe the configured GCP vTPM until it becomes ready, with a bounded timeout, before exposing the simulator as available.

## Implementation

The branch records the following focused implementation work:

- `fix(simulator): wait for GCP vTPM readiness`

Changed paths:

- `dstack/tee-simulator/src/tpm.rs`

## Scope

This PR addresses one logical `simulator` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-simulator-gcp-vtpm-readiness`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
