### PR TITLE
fix(os): install TPM device TCTI for simulator

### DIFF
--- a/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/dstack-tee-simulator.bb
+++ b/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/dstack-tee-simulator.bb
@@ -13,7 +13,7 @@ DSTACK_CORE_SRC ?= "${DSTACK_MONOREPO_ROOT}/dstack"
 S = "${UNPACKDIR}/repo/dstack"
 
 DEPENDS += "rsync-native cmake-native"
-RDEPENDS:${PN} += "dstack-guest fuse3-utils swtpm tpm2-tools openssl"
+RDEPENDS:${PN} += "dstack-guest fuse3-utils swtpm tpm2-tools libtss2-tcti-device openssl"
 do_unpack[depends] += "rsync-native:do_populate_sysroot"
 
 # aws-lc-sys cannot detect this Yocto cross build reliably with its default


### PR DESCRIPTION
## Problem

The simulator talks to the TPM through the device TCTI, but its Yocto package installed the wrong TCTI runtime dependency. The binary could be present while TPM initialization failed because the device transport library was absent.

## Root cause and fix

Install the TPM2 device TCTI package in the simulator image so the configured `/dev/tpm*` transport can actually be opened.

## Implementation

The branch records the following focused implementation work:

- `fix(os): install TPM device TCTI for simulator`

Changed paths:

- `os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/dstack-tee-simulator.bb`

## Scope

This PR addresses one logical `os` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-os-simulator-tpm-tcti`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
