### PR TITLE
fix(simulator): expose GCP TPM event log

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2161,6 +2161,7 @@ dependencies = [
  "libc",
  "libloading",
  "mock-attestation",
+ "nix 0.29.0",
  "nsm-qvl",
  "pem",
  "reqwest",

--- a/dstack/tee-simulator/Cargo.toml
+++ b/dstack/tee-simulator/Cargo.toml
@@ -21,7 +21,7 @@ dstack-types.workspace = true
 dstack-mr.workspace = true
 fuser.workspace = true
 libc.workspace = true
-nix = { workspace = true, features = ["mount"] }
+nix = { workspace = true, features = ["fs", "mount"] }
 sd-notify.workspace = true
 sha2.workspace = true
 tracing.workspace = true

--- a/dstack/tee-simulator/Cargo.toml
+++ b/dstack/tee-simulator/Cargo.toml
@@ -21,6 +21,7 @@ dstack-types.workspace = true
 dstack-mr.workspace = true
 fuser.workspace = true
 libc.workspace = true
+nix = { workspace = true, features = ["mount"] }
 sd-notify.workspace = true
 sha2.workspace = true
 tracing.workspace = true

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -6,6 +6,7 @@
 //! template and certificate NV indices consumed by `tpm-attest`.
 
 use std::{
+    ffi::CString,
     io::{Read, Write},
     os::{
         fd::{AsRawFd, FromRawFd},
@@ -117,6 +118,7 @@ pub fn start_gcp_vtpm(runtime_dir: &Path, config: &TeeSimulatorConfig) -> Result
     }
     command("tpm2_startup", &["-c"])?;
     replay_fixture_event_log()?;
+    install_fixture_event_log()?;
 
     let template_with_size = state_dir.join("ak.tpm2b-public");
     let generated_public = state_dir.join("ak.public");
@@ -210,6 +212,45 @@ fn replay_fixture_event_log() -> Result<()> {
         let extension = format!("{}:sha256={}", event.pcr_index, hex::encode(event.digest));
         command("tpm2_pcrextend", &[&extension])?;
     }
+    Ok(())
+}
+
+fn install_fixture_event_log() -> Result<()> {
+    let security_root = Path::new("/sys/kernel/security");
+    let event_log = security_root.join("tpm0/binary_bios_measurements");
+    if event_log.exists() {
+        return Ok(());
+    }
+    let tpm_dir = event_log.parent().context("TPM event log has no parent")?;
+    if let Err(error) = fs_err::create_dir_all(tpm_dir) {
+        if !matches!(error.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) {
+            return Err(error).context("failed to create simulated TPM event-log directory");
+        }
+        let source = CString::new("dstack-tee-simulator")?;
+        let target = CString::new("/sys/kernel/security")?;
+        let fstype = CString::new("tmpfs")?;
+        let data = CString::new("mode=0755")?;
+        let rc = unsafe {
+            libc::mount(
+                source.as_ptr(),
+                target.as_ptr(),
+                fstype.as_ptr(),
+                libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
+                data.as_ptr().cast(),
+            )
+        };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to mount simulated securityfs shadow");
+        }
+        fs_err::create_dir_all(tpm_dir)
+            .context("failed to create simulated TPM event-log directory")?;
+    }
+    fs_err::write(
+        event_log,
+        include_bytes!("../../cc-eventlog/samples/tpm_eventlog.bin"),
+    )
+    .context("failed to install simulated TPM event log")?;
     Ok(())
 }
 

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -6,7 +6,6 @@
 //! template and certificate NV indices consumed by `tpm-attest`.
 
 use std::{
-    ffi::CString,
     io::{Read, Write},
     os::{
         fd::{AsRawFd, FromRawFd},
@@ -225,23 +224,17 @@ fn install_fixture_event_log() -> Result<()> {
     // securityfs does not permit userspace to create a synthetic TPM event
     // log hierarchy. Shadow it in this development-only guest before
     // publishing the fixture that was replayed into the simulated PCRs.
-    let source = CString::new("dstack-tee-simulator")?;
-    let target = CString::new("/sys/kernel/security")?;
-    let fstype = CString::new("tmpfs")?;
-    let data = CString::new("mode=0755")?;
-    let rc = unsafe {
-        libc::mount(
-            source.as_ptr(),
-            target.as_ptr(),
-            fstype.as_ptr(),
-            libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
-            data.as_ptr().cast(),
-        )
-    };
-    if rc != 0 {
-        return Err(std::io::Error::last_os_error())
-            .context("failed to mount simulated securityfs shadow");
-    }
+    let flags = nix::mount::MsFlags::MS_NOSUID
+        | nix::mount::MsFlags::MS_NODEV
+        | nix::mount::MsFlags::MS_NOEXEC;
+    nix::mount::mount(
+        Some("dstack-tee-simulator"),
+        security_root,
+        Some("tmpfs"),
+        flags,
+        Some("mode=0755"),
+    )
+    .context("failed to mount simulated securityfs shadow")?;
     fs_err::create_dir_all(tpm_dir)
         .context("failed to create TPM event-log directory in securityfs shadow")?;
     fs_err::write(

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -293,12 +293,15 @@ pub fn run_nitro_vtpm(runtime_dir: &Path, config: &TeeSimulatorConfig) -> Result
     let generator = NsmGenerator::from_seed(parse_seed(seed)?)?;
     let (mut simulator, swtpm_stream) = UnixStream::pair()?;
     let swtpm_fd = swtpm_stream.as_raw_fd();
-    let flags = unsafe { libc::fcntl(swtpm_fd, libc::F_GETFD) };
-    anyhow::ensure!(flags >= 0, "failed to get swtpm socket flags");
-    anyhow::ensure!(
-        unsafe { libc::fcntl(swtpm_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } >= 0,
-        "failed to make swtpm socket inheritable"
+    let flags = nix::fcntl::FdFlag::from_bits_truncate(
+        nix::fcntl::fcntl(swtpm_fd, nix::fcntl::FcntlArg::F_GETFD)
+            .context("failed to get swtpm socket flags")?,
     );
+    nix::fcntl::fcntl(
+        swtpm_fd,
+        nix::fcntl::FcntlArg::F_SETFD(flags - nix::fcntl::FdFlag::FD_CLOEXEC),
+    )
+    .context("failed to make swtpm socket inheritable")?;
 
     let state_dir = std::env::temp_dir().join(format!("dstack-nitro-swtpm-{}", std::process::id()));
     fs_err::create_dir_all(&state_dir)?;

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -222,30 +222,28 @@ fn install_fixture_event_log() -> Result<()> {
         return Ok(());
     }
     let tpm_dir = event_log.parent().context("TPM event log has no parent")?;
-    if let Err(error) = fs_err::create_dir_all(tpm_dir) {
-        if !matches!(error.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) {
-            return Err(error).context("failed to create simulated TPM event-log directory");
-        }
-        let source = CString::new("dstack-tee-simulator")?;
-        let target = CString::new("/sys/kernel/security")?;
-        let fstype = CString::new("tmpfs")?;
-        let data = CString::new("mode=0755")?;
-        let rc = unsafe {
-            libc::mount(
-                source.as_ptr(),
-                target.as_ptr(),
-                fstype.as_ptr(),
-                libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
-                data.as_ptr().cast(),
-            )
-        };
-        if rc != 0 {
-            return Err(std::io::Error::last_os_error())
-                .context("failed to mount simulated securityfs shadow");
-        }
-        fs_err::create_dir_all(tpm_dir)
-            .context("failed to create simulated TPM event-log directory")?;
+    // securityfs does not permit userspace to create a synthetic TPM event
+    // log hierarchy. Shadow it in this development-only guest before
+    // publishing the fixture that was replayed into the simulated PCRs.
+    let source = CString::new("dstack-tee-simulator")?;
+    let target = CString::new("/sys/kernel/security")?;
+    let fstype = CString::new("tmpfs")?;
+    let data = CString::new("mode=0755")?;
+    let rc = unsafe {
+        libc::mount(
+            source.as_ptr(),
+            target.as_ptr(),
+            fstype.as_ptr(),
+            libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
+            data.as_ptr().cast(),
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to mount simulated securityfs shadow");
     }
+    fs_err::create_dir_all(tpm_dir)
+        .context("failed to create TPM event-log directory in securityfs shadow")?;
     fs_err::write(
         event_log,
         include_bytes!("../../cc-eventlog/samples/tpm_eventlog.bin"),


### PR DESCRIPTION
## Problem

The GCP vTPM simulator replays a measured-boot fixture into PCRs, but it did not expose the corresponding binary event log at the Linux securityfs path:

```text
/sys/kernel/security/tpm0/binary_bios_measurements
```

A verifier could read the simulated PCR values but could not replay the events that produced them.

In a no-hardware development guest, securityfs does not allow userspace to create the synthetic TPM hierarchy directly, so the simulator needs a development-only tmpfs shadow before publishing the fixture.

## Fix

After replaying the event fixture into the simulated PCRs:

1. Keep an existing event-log path unchanged when the platform already provides it.
2. Otherwise mount a `tmpfs` shadow at `/sys/kernel/security`.
3. Create `tpm0/binary_bios_measurements` in that shadow.
4. Write the exact fixture that was replayed into the PCRs.

## Unsafe removal

The raw mount block added by the original PR has been removed:

- `libc::mount` and `CString` arguments are replaced with safe `nix::mount::mount`.
- The existing raw `fcntl` calls in the same TPM module are also replaced with safe `nix::fcntl` wrappers.
- The PR adds no new `unsafe` block.

Two pre-existing unsafe boundaries remain outside the event-log change:

- `VTPM_PROXY_IOC_NEW_DEV`, which is a raw kernel ioctl;
- taking ownership of the file descriptor returned by that successful ioctl.

Those operations have no maintained high-level Rust vTPM-proxy API; moving them behind generated bindings would relocate rather than eliminate the ownership/FFI assertion.

## Changed files

- `dstack/tee-simulator/src/tpm.rs`
- `dstack/tee-simulator/Cargo.toml`
- `dstack/Cargo.lock`

## Dependency

Directly based on `master`; no stacked dependency.

## Verification

- `cargo check -p dstack-tee-simulator --all-targets`: passed.
- `git diff --check origin/master...HEAD`: passed.
- No added diff line contains `unsafe`.
- The only remaining `unsafe` lines in `tpm.rs` are the pre-existing vTPM ioctl and returned-FD ownership boundary.
