### PR TITLE
fix(simulator): report live NitroTPM PCR capabilities

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
  "tokio",
  "tpm-qvl",
  "tpm-types",
+ "tpm2",
  "tracing",
  "tracing-subscriber",
 ]

--- a/dstack/tee-simulator/Cargo.toml
+++ b/dstack/tee-simulator/Cargo.toml
@@ -23,6 +23,7 @@ fuser.workspace = true
 libc.workspace = true
 sd-notify.workspace = true
 sha2.workspace = true
+tpm2.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde_json.workspace = true

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -371,6 +371,9 @@ fn proxy_tpm_commands(
         command.truncate(size);
         anyhow::ensure!(command.len() >= 10, "truncated TPM command");
         let code = read_be_u32(&command[6..10], "TPM command code")?;
+        if code >= 0x2000_0000 {
+            eprintln!("NitroTPM proxy received vendor command 0x{code:08x}");
+        }
         let response = if code == TPM2_CC_AWS_NSM_REQUEST {
             let template = nv_write
                 .as_ref()

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -373,9 +373,6 @@ fn proxy_tpm_commands(
         command.truncate(size);
         anyhow::ensure!(command.len() >= 10, "truncated TPM command");
         let code = read_be_u32(&command[6..10], "TPM command code")?;
-        if code >= 0x2000_0000 {
-            eprintln!("NitroTPM proxy received vendor command 0x{code:08x}");
-        }
         let response = if code == TPM2_CC_AWS_NSM_REQUEST {
             let template = nv_write
                 .as_ref()

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use aws_nitro_enclaves_nsm_api::api::{Request as NsmRequest, Response as NsmResponse};
 use dstack_types::TeeSimulatorConfig;
 use mock_attestation::{nsm::NsmGenerator, parse_seed, server::MockCollateralState};
@@ -28,7 +28,9 @@ const TPM2_CC_NV_WRITE: u32 = 0x0000_0137;
 const TPM2_CC_NV_DEFINE_SPACE: u32 = 0x0000_012a;
 const TPM2_CC_NV_READ: u32 = 0x0000_014e;
 const TPM2_CC_NV_READ_PUBLIC: u32 = 0x0000_0169;
+const TPM2_CC_GET_CAPABILITY: u32 = 0x0000_017a;
 const TPM2_CC_AWS_NSM_REQUEST: u32 = 0x2000_0001;
+const TPM2_CAP_COMMANDS: u32 = 2;
 const VTPM_PROXY_IOC_NEW_DEV: libc::c_ulong = 0xc014_a100;
 const VTPM_PROXY_FLAG_TPM2: u32 = 1;
 
@@ -409,12 +411,51 @@ fn proxy_tpm_commands(
                     nv_write = Some(template);
                 }
             }
-            transact(backend, &command)?
+            let mut response = transact(backend, &command)?;
+            advertise_nsm_vendor_command(code, &mut response)?;
+            response
         };
         proxy
             .write_all(&response)
             .context("failed to write vTPM response")?;
     }
+}
+
+fn advertise_nsm_vendor_command(code: u32, response: &mut Vec<u8>) -> Result<()> {
+    if code != TPM2_CC_GET_CAPABILITY || response.len() < 19 {
+        return Ok(());
+    }
+    let response_code = read_be_u32(&response[6..10], "TPM response code")?;
+    let capability = read_be_u32(&response[11..15], "TPM capability")?;
+    if response_code != 0 || capability != TPM2_CAP_COMMANDS || response[10] != 0 {
+        return Ok(());
+    }
+    let count = read_be_u32(&response[15..19], "TPM command attribute count")? as usize;
+    let attributes_end = 19usize
+        .checked_add(count.checked_mul(4).context("TPM command count overflow")?)
+        .context("TPM command attributes overflow")?;
+    anyhow::ensure!(
+        response.len() >= attributes_end,
+        "truncated TPM command attributes"
+    );
+    if response[19..attributes_end].chunks_exact(4).any(|value| {
+        read_be_u32(value, "TPM command attributes")
+            .is_ok_and(|attributes| attributes == TPM2_CC_AWS_NSM_REQUEST)
+    }) {
+        return Ok(());
+    }
+    let insertion = response[19..attributes_end]
+        .chunks_exact(4)
+        .position(|value| {
+            read_be_u32(value, "TPM command attributes")
+                .is_ok_and(|attributes| attributes & 0x2000_ffff > TPM2_CC_AWS_NSM_REQUEST)
+        })
+        .map_or(attributes_end, |index| 19 + index * 4);
+    response.splice(insertion..insertion, TPM2_CC_AWS_NSM_REQUEST.to_be_bytes());
+    response[15..19].copy_from_slice(&((count + 1) as u32).to_be_bytes());
+    let response_size = response.len() as u32;
+    response[2..6].copy_from_slice(&response_size.to_be_bytes());
+    Ok(())
 }
 
 fn parse_nv_write(command: &[u8]) -> Result<Option<NvWriteTemplate>> {
@@ -518,4 +559,34 @@ fn transact(stream: &mut UnixStream, command: &[u8]) -> Result<Vec<u8>> {
 
 fn tpm_success_response() -> Vec<u8> {
     [0x80, 0x01, 0, 0, 0, 10, 0, 0, 0, 0].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_capability_advertises_nsm_vendor_command() {
+        let mut response = Vec::new();
+        response.extend_from_slice(&0x8001u16.to_be_bytes());
+        response.extend_from_slice(&23u32.to_be_bytes());
+        response.extend_from_slice(&0u32.to_be_bytes());
+        response.push(0);
+        response.extend_from_slice(&TPM2_CAP_COMMANDS.to_be_bytes());
+        response.extend_from_slice(&1u32.to_be_bytes());
+        response.extend_from_slice(&0x2000_1000u32.to_be_bytes());
+
+        advertise_nsm_vendor_command(TPM2_CC_GET_CAPABILITY, &mut response).unwrap();
+
+        assert_eq!(read_be_u32(&response[2..6], "size").unwrap(), 27);
+        assert_eq!(read_be_u32(&response[15..19], "count").unwrap(), 2);
+        assert_eq!(
+            read_be_u32(&response[19..23], "vendor command").unwrap(),
+            TPM2_CC_AWS_NSM_REQUEST
+        );
+        assert_eq!(
+            read_be_u32(&response[23..27], "existing command").unwrap(),
+            0x2000_1000
+        );
+    }
 }

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -380,7 +380,7 @@ fn proxy_tpm_commands(
             let template = nv_write
                 .as_ref()
                 .context("NitroTPM vendor command without an NV request")?;
-            nsm_response = Some(handle_nsm_vendor_command(generator, template)?);
+            nsm_response = Some(handle_nsm_vendor_command(generator, template, backend)?);
             tpm_success_response()
         } else if code == TPM2_CC_NV_READ && nsm_response.is_some() {
             nv_read_response(
@@ -486,14 +486,15 @@ fn parse_nv_write(command: &[u8]) -> Result<Option<NvWriteTemplate>> {
 fn handle_nsm_vendor_command(
     generator: &NsmGenerator,
     template: &NvWriteTemplate,
+    backend: &mut UnixStream,
 ) -> Result<Vec<u8>> {
     let request: NsmRequest = serde_cbor::from_slice(&template.request)?;
     let response = match request {
         NsmRequest::Attestation { user_data, .. } => {
             let pcrs = [4u16, 7, 8, 12, 14]
                 .into_iter()
-                .map(|i| (i, vec![0; 48]))
-                .collect();
+                .map(|index| Ok((index, read_sha384_pcr(backend, index)?)))
+                .collect::<Result<_>>()?;
             let document = generator.attest_with_pcrs(
                 user_data.as_ref().map(|v| v.as_slice()).unwrap_or_default(),
                 pcrs,
@@ -503,6 +504,35 @@ fn handle_nsm_vendor_command(
         _ => anyhow::bail!("unsupported NitroTPM NSM request"),
     };
     Ok(serde_cbor::to_vec(&response)?)
+}
+
+fn read_sha384_pcr(backend: &mut UnixStream, index: u16) -> Result<Vec<u8>> {
+    anyhow::ensure!(index < 24, "invalid PCR index {index}");
+    let mut command = Vec::with_capacity(20);
+    command.extend_from_slice(&0x8001u16.to_be_bytes());
+    command.extend_from_slice(&20u32.to_be_bytes());
+    command.extend_from_slice(&0x0000_017eu32.to_be_bytes());
+    command.extend_from_slice(&1u32.to_be_bytes());
+    command.extend_from_slice(&0x000cu16.to_be_bytes());
+    command.push(3);
+    let mut selection = [0u8; 3];
+    selection[index as usize / 8] = 1 << (index % 8);
+    command.extend_from_slice(&selection);
+
+    let response = transact(backend, &command)?;
+    anyhow::ensure!(response.len() >= 30, "truncated TPM PCR_Read response");
+    anyhow::ensure!(
+        read_be_u32(&response[6..10], "TPM PCR_Read response code")? == 0,
+        "TPM PCR_Read failed"
+    );
+    anyhow::ensure!(
+        read_be_u32(&response[24..28], "TPM PCR digest count")? == 1,
+        "unexpected TPM PCR digest count"
+    );
+    let size = read_be_u16(&response[28..30], "TPM PCR digest size")? as usize;
+    anyhow::ensure!(size == 48, "unexpected SHA-384 PCR size {size}");
+    anyhow::ensure!(response.len() >= 30 + size, "truncated TPM PCR digest");
+    Ok(response[30..30 + size].to_vec())
 }
 
 fn set_nv_public_size(response: &mut [u8], size: usize) -> Result<()> {

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -17,11 +17,11 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use aws_nitro_enclaves_nsm_api::api::{Request as NsmRequest, Response as NsmResponse};
 use dstack_types::TeeSimulatorConfig;
 use mock_attestation::{nsm::NsmGenerator, parse_seed, server::MockCollateralState};
-use tpm2::{TpmAlgId, TpmCc, TpmContext, add_command_capability};
+use tpm2::{add_command_capability, TpmAlgId, TpmCc, TpmContext};
 
 const AK_ECC_CERT: &str = "0x01c10002";
 const AK_ECC_TEMPLATE: &str = "0x01c10003";

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use aws_nitro_enclaves_nsm_api::api::{Request as NsmRequest, Response as NsmResponse};
 use dstack_types::TeeSimulatorConfig;
 use mock_attestation::{nsm::NsmGenerator, parse_seed, server::MockCollateralState};

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -17,20 +17,15 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use aws_nitro_enclaves_nsm_api::api::{Request as NsmRequest, Response as NsmResponse};
 use dstack_types::TeeSimulatorConfig;
 use mock_attestation::{nsm::NsmGenerator, parse_seed, server::MockCollateralState};
+use tpm2::{TpmAlgId, TpmCc, TpmContext, add_command_capability};
 
 const AK_ECC_CERT: &str = "0x01c10002";
 const AK_ECC_TEMPLATE: &str = "0x01c10003";
-const TPM2_CC_NV_WRITE: u32 = 0x0000_0137;
-const TPM2_CC_NV_DEFINE_SPACE: u32 = 0x0000_012a;
-const TPM2_CC_NV_READ: u32 = 0x0000_014e;
-const TPM2_CC_NV_READ_PUBLIC: u32 = 0x0000_0169;
-const TPM2_CC_GET_CAPABILITY: u32 = 0x0000_017a;
 const TPM2_CC_AWS_NSM_REQUEST: u32 = 0x2000_0001;
-const TPM2_CAP_COMMANDS: u32 = 2;
 const VTPM_PROXY_IOC_NEW_DEV: libc::c_ulong = 0xc014_a100;
 const VTPM_PROXY_FLAG_TPM2: u32 = 1;
 
@@ -379,12 +374,12 @@ fn proxy_tpm_commands(
                 .context("NitroTPM vendor command without an NV request")?;
             nsm_response = Some(handle_nsm_vendor_command(generator, template, backend)?);
             tpm_success_response()
-        } else if code == TPM2_CC_NV_READ && nsm_response.is_some() {
+        } else if code == TpmCc::NvRead.to_u32() && nsm_response.is_some() {
             nv_read_response(
                 &command,
                 nsm_response.as_deref().context("missing NSM response")?,
             )?
-        } else if code == TPM2_CC_NV_READ_PUBLIC && nsm_response.is_some() {
+        } else if code == TpmCc::NvReadPublic.to_u32() && nsm_response.is_some() {
             let mut response = transact(backend, &command)?;
             set_nv_public_size(
                 &mut response,
@@ -399,11 +394,11 @@ fn proxy_tpm_commands(
             // single NV index at 2 KiB. Define the backing index at that limit;
             // the proxy virtualizes its public size and reads after the vendor
             // command, while swtpm still handles its lifecycle and auth setup.
-            if code == TPM2_CC_NV_DEFINE_SPACE && command.ends_with(&8192u16.to_be_bytes()) {
+            if code == TpmCc::NvDefineSpace.to_u32() && command.ends_with(&8192u16.to_be_bytes()) {
                 let end = command.len();
                 command[end - 2..].copy_from_slice(&2048u16.to_be_bytes());
             }
-            if code == TPM2_CC_NV_WRITE {
+            if code == TpmCc::NvWrite.to_u32() {
                 if let Some(template) = parse_nv_write(&command)? {
                     nv_write = Some(template);
                 }
@@ -419,39 +414,9 @@ fn proxy_tpm_commands(
 }
 
 fn advertise_nsm_vendor_command(code: u32, response: &mut Vec<u8>) -> Result<()> {
-    if code != TPM2_CC_GET_CAPABILITY || response.len() < 19 {
-        return Ok(());
+    if code == TpmCc::GetCapability.to_u32() {
+        *response = add_command_capability(response, TPM2_CC_AWS_NSM_REQUEST)?;
     }
-    let response_code = read_be_u32(&response[6..10], "TPM response code")?;
-    let capability = read_be_u32(&response[11..15], "TPM capability")?;
-    if response_code != 0 || capability != TPM2_CAP_COMMANDS || response[10] != 0 {
-        return Ok(());
-    }
-    let count = read_be_u32(&response[15..19], "TPM command attribute count")? as usize;
-    let attributes_end = 19usize
-        .checked_add(count.checked_mul(4).context("TPM command count overflow")?)
-        .context("TPM command attributes overflow")?;
-    anyhow::ensure!(
-        response.len() >= attributes_end,
-        "truncated TPM command attributes"
-    );
-    if response[19..attributes_end].chunks_exact(4).any(|value| {
-        read_be_u32(value, "TPM command attributes")
-            .is_ok_and(|attributes| attributes == TPM2_CC_AWS_NSM_REQUEST)
-    }) {
-        return Ok(());
-    }
-    let insertion = response[19..attributes_end]
-        .chunks_exact(4)
-        .position(|value| {
-            read_be_u32(value, "TPM command attributes")
-                .is_ok_and(|attributes| attributes & 0x2000_ffff > TPM2_CC_AWS_NSM_REQUEST)
-        })
-        .map_or(attributes_end, |index| 19 + index * 4);
-    response.splice(insertion..insertion, TPM2_CC_AWS_NSM_REQUEST.to_be_bytes());
-    response[15..19].copy_from_slice(&((count + 1) as u32).to_be_bytes());
-    let response_size = response.len() as u32;
-    response[2..6].copy_from_slice(&response_size.to_be_bytes());
     Ok(())
 }
 
@@ -488,9 +453,15 @@ fn handle_nsm_vendor_command(
     let request: NsmRequest = serde_cbor::from_slice(&template.request)?;
     let response = match request {
         NsmRequest::Attestation { user_data, .. } => {
+            let mut tpm = TpmContext::from_stream(
+                backend
+                    .try_clone()
+                    .context("failed to clone NitroTPM stream")?,
+                "NitroTPM backend",
+            );
             let pcrs = [4u16, 7, 8, 12, 14]
                 .into_iter()
-                .map(|index| Ok((index, read_sha384_pcr(backend, index)?)))
+                .map(|index| Ok((index, tpm.pcr_read_single(index.into(), TpmAlgId::Sha384)?)))
                 .collect::<Result<_>>()?;
             let document = generator.attest_with_pcrs(
                 user_data.as_ref().map(|v| v.as_slice()).unwrap_or_default(),
@@ -501,35 +472,6 @@ fn handle_nsm_vendor_command(
         _ => anyhow::bail!("unsupported NitroTPM NSM request"),
     };
     Ok(serde_cbor::to_vec(&response)?)
-}
-
-fn read_sha384_pcr(backend: &mut UnixStream, index: u16) -> Result<Vec<u8>> {
-    anyhow::ensure!(index < 24, "invalid PCR index {index}");
-    let mut command = Vec::with_capacity(20);
-    command.extend_from_slice(&0x8001u16.to_be_bytes());
-    command.extend_from_slice(&20u32.to_be_bytes());
-    command.extend_from_slice(&0x0000_017eu32.to_be_bytes());
-    command.extend_from_slice(&1u32.to_be_bytes());
-    command.extend_from_slice(&0x000cu16.to_be_bytes());
-    command.push(3);
-    let mut selection = [0u8; 3];
-    selection[index as usize / 8] = 1 << (index % 8);
-    command.extend_from_slice(&selection);
-
-    let response = transact(backend, &command)?;
-    anyhow::ensure!(response.len() >= 30, "truncated TPM PCR_Read response");
-    anyhow::ensure!(
-        read_be_u32(&response[6..10], "TPM PCR_Read response code")? == 0,
-        "TPM PCR_Read failed"
-    );
-    anyhow::ensure!(
-        read_be_u32(&response[24..28], "TPM PCR digest count")? == 1,
-        "unexpected TPM PCR digest count"
-    );
-    let size = read_be_u16(&response[28..30], "TPM PCR digest size")? as usize;
-    anyhow::ensure!(size == 48, "unexpected SHA-384 PCR size {size}");
-    anyhow::ensure!(response.len() >= 30 + size, "truncated TPM PCR digest");
-    Ok(response[30..30 + size].to_vec())
 }
 
 fn set_nv_public_size(response: &mut [u8], size: usize) -> Result<()> {
@@ -586,34 +528,4 @@ fn transact(stream: &mut UnixStream, command: &[u8]) -> Result<Vec<u8>> {
 
 fn tpm_success_response() -> Vec<u8> {
     [0x80, 0x01, 0, 0, 0, 10, 0, 0, 0, 0].to_vec()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn get_capability_advertises_nsm_vendor_command() {
-        let mut response = Vec::new();
-        response.extend_from_slice(&0x8001u16.to_be_bytes());
-        response.extend_from_slice(&23u32.to_be_bytes());
-        response.extend_from_slice(&0u32.to_be_bytes());
-        response.push(0);
-        response.extend_from_slice(&TPM2_CAP_COMMANDS.to_be_bytes());
-        response.extend_from_slice(&1u32.to_be_bytes());
-        response.extend_from_slice(&0x2000_1000u32.to_be_bytes());
-
-        advertise_nsm_vendor_command(TPM2_CC_GET_CAPABILITY, &mut response).unwrap();
-
-        assert_eq!(read_be_u32(&response[2..6], "size").unwrap(), 27);
-        assert_eq!(read_be_u32(&response[15..19], "count").unwrap(), 2);
-        assert_eq!(
-            read_be_u32(&response[19..23], "vendor command").unwrap(),
-            TPM2_CC_AWS_NSM_REQUEST
-        );
-        assert_eq!(
-            read_be_u32(&response[23..27], "existing command").unwrap(),
-            0x2000_1000
-        );
-    }
 }

--- a/dstack/tpm2/src/commands.rs
+++ b/dstack/tpm2/src/commands.rs
@@ -8,6 +8,7 @@
 
 use anyhow::{Context, Result};
 use std::collections::HashSet;
+use std::io::{Read, Write};
 use tracing::debug;
 
 use super::constants::*;
@@ -30,6 +31,13 @@ impl TpmContext {
         };
 
         Ok(Self { device })
+    }
+
+    /// Create a TPM context over an already connected byte stream.
+    pub fn from_stream(stream: impl Read + Write + 'static, name: impl Into<String>) -> Self {
+        Self {
+            device: TpmDevice::from_stream(stream, name),
+        }
     }
 
     /// Get the device path

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -7,7 +7,7 @@
 //! Provides low-level communication with TPM devices via /dev/tpmrm0 or /dev/tpm0.
 
 use anyhow::{bail, Context, Result};
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -18,8 +18,12 @@ use super::marshal::*;
 const TPM_MAX_COMMAND_SIZE: usize = 4096;
 
 /// TPM device handle
+trait ReadWrite: Read + Write {}
+
+impl<T: Read + Write> ReadWrite for T {}
+
 pub struct TpmDevice {
-    file: File,
+    transport: Box<dyn ReadWrite>,
     path: String,
 }
 
@@ -36,9 +40,17 @@ impl TpmDevice {
             .with_context(|| format!("failed to open TPM device: {}", device_path))?;
 
         Ok(Self {
-            file,
+            transport: Box::new(file),
             path: device_path.to_string(),
         })
+    }
+
+    /// Create a TPM device over an already connected byte stream.
+    pub fn from_stream(stream: impl Read + Write + 'static, name: impl Into<String>) -> Self {
+        Self {
+            transport: Box::new(stream),
+            path: name.into(),
+        }
     }
 
     /// Detect and open the default TPM device
@@ -59,19 +71,26 @@ impl TpmDevice {
 
     /// Send a command to the TPM and receive the response
     pub fn transmit(&mut self, command: &[u8]) -> Result<Vec<u8>> {
-        // Write command
-        self.file
+        self.transport
             .write_all(command)
             .context("failed to write TPM command")?;
 
-        // Read response
-        let mut response = vec![0u8; TPM_MAX_COMMAND_SIZE];
-        let n = self
-            .file
-            .read(&mut response)
-            .context("failed to read TPM response")?;
-
-        response.truncate(n);
+        // Read the fixed header first so stream transports cannot return a
+        // partial response and leave bytes for the next transaction.
+        let mut header = [0u8; 10];
+        self.transport
+            .read_exact(&mut header)
+            .context("failed to read TPM response header")?;
+        let response_size = u32::from_be_bytes(header[2..6].try_into().unwrap()) as usize;
+        if !(header.len()..=TPM_MAX_COMMAND_SIZE).contains(&response_size) {
+            bail!("invalid TPM response size: {response_size}");
+        }
+        let mut response = Vec::with_capacity(response_size);
+        response.extend_from_slice(&header);
+        response.resize(response_size, 0);
+        self.transport
+            .read_exact(&mut response[header.len()..])
+            .context("failed to read TPM response body")?;
         Ok(response)
     }
 

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -294,6 +294,17 @@ impl TpmResponse {
         }
     }
 
+    /// Serialize this response back to TPM wire format.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let size = 10 + self.data.len();
+        let mut response = Vec::with_capacity(size);
+        response.extend_from_slice(&self.tag.to_u16().to_be_bytes());
+        response.extend_from_slice(&(size as u32).to_be_bytes());
+        response.extend_from_slice(&self.response_code.to_be_bytes());
+        response.extend_from_slice(&self.data);
+        response
+    }
+
     /// Get a response buffer for parsing the data
     pub fn data_buffer(&self) -> ResponseBuffer<'_> {
         ResponseBuffer::new(&self.data)
@@ -309,9 +320,75 @@ impl TpmResponse {
     }
 }
 
+/// Add a command to a successful TPM_CAP_COMMANDS response.
+///
+/// Responses for other capabilities, TPM errors, and paginated command lists
+/// are returned unchanged.
+pub fn add_command_capability(response: &[u8], command_code: u32) -> Result<Vec<u8>> {
+    let mut response = TpmResponse::parse(response)?;
+    if !response.is_success() {
+        return Ok(response.to_bytes());
+    }
+    let mut buf = response.data_buffer();
+    let more_data = buf.get_u8()? != 0;
+    let capability = buf.get_u32()?;
+    if capability != TpmCap::Commands as u32 || more_data {
+        return Ok(response.to_bytes());
+    }
+    let count = buf.get_u32()? as usize;
+    let mut attributes = Vec::with_capacity(count + 1);
+    for _ in 0..count {
+        attributes.push(buf.get_u32()?);
+    }
+    if attributes.contains(&command_code) {
+        return Ok(response.to_bytes());
+    }
+    const COMMAND_INDEX_AND_VENDOR_MASK: u32 = 0x2000_ffff;
+    let sort_key = command_code & COMMAND_INDEX_AND_VENDOR_MASK;
+    let insertion = attributes
+        .iter()
+        .position(|attributes| attributes & COMMAND_INDEX_AND_VENDOR_MASK > sort_key)
+        .unwrap_or(attributes.len());
+    attributes.insert(insertion, command_code);
+
+    let mut data = Vec::with_capacity(9 + attributes.len() * 4);
+    data.push(u8::from(more_data));
+    data.extend_from_slice(&(TpmCap::Commands as u32).to_be_bytes());
+    data.extend_from_slice(&(attributes.len() as u32).to_be_bytes());
+    for attributes in attributes {
+        data.extend_from_slice(&attributes.to_be_bytes());
+    }
+    response.data = data;
+    Ok(response.to_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn adds_a_vendor_command_to_command_capabilities() {
+        let response = TpmResponse {
+            tag: TpmSt::NoSessions,
+            response_code: 0,
+            data: [
+                &[0],
+                &(TpmCap::Commands as u32).to_be_bytes(),
+                &1u32.to_be_bytes(),
+                &0x2000_1000u32.to_be_bytes(),
+            ]
+            .concat(),
+        }
+        .to_bytes();
+        let response = add_command_capability(&response, 0x2000_0001).unwrap();
+        let response = TpmResponse::parse(&response).unwrap();
+        let mut data = response.data_buffer();
+        assert_eq!(data.get_u8().unwrap(), 0);
+        assert_eq!(data.get_u32().unwrap(), TpmCap::Commands as u32);
+        assert_eq!(data.get_u32().unwrap(), 2);
+        assert_eq!(data.get_u32().unwrap(), 0x2000_0001);
+        assert_eq!(data.get_u32().unwrap(), 0x2000_1000);
+    }
 
     #[test]
     fn test_command_builder() {

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -6,7 +6,7 @@
 //!
 //! Provides low-level communication with TPM devices via /dev/tpmrm0 or /dev/tpm0.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -371,13 +371,13 @@ mod tests {
         let response = TpmResponse {
             tag: TpmSt::NoSessions,
             response_code: 0,
-            data: [
-                &[0],
-                &(TpmCap::Commands as u32).to_be_bytes(),
-                &1u32.to_be_bytes(),
-                &0x2000_1000u32.to_be_bytes(),
-            ]
-            .concat(),
+            data: {
+                let mut data = vec![0];
+                data.extend_from_slice(&(TpmCap::Commands as u32).to_be_bytes());
+                data.extend_from_slice(&1u32.to_be_bytes());
+                data.extend_from_slice(&0x2000_1000u32.to_be_bytes());
+                data
+            },
         }
         .to_bytes();
         let response = add_command_capability(&response, 0x2000_0001).unwrap();

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -7,7 +7,7 @@
 //! Provides low-level communication with TPM devices via /dev/tpmrm0 or /dev/tpm0.
 
 use anyhow::{Context, Result, bail};
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -22,8 +22,13 @@ trait ReadWrite: Read + Write {}
 
 impl<T: Read + Write> ReadWrite for T {}
 
+enum TpmTransport {
+    Device(File),
+    Stream(Box<dyn ReadWrite>),
+}
+
 pub struct TpmDevice {
-    transport: Box<dyn ReadWrite>,
+    transport: TpmTransport,
     path: String,
 }
 
@@ -40,7 +45,7 @@ impl TpmDevice {
             .with_context(|| format!("failed to open TPM device: {}", device_path))?;
 
         Ok(Self {
-            transport: Box::new(file),
+            transport: TpmTransport::Device(file),
             path: device_path.to_string(),
         })
     }
@@ -48,7 +53,7 @@ impl TpmDevice {
     /// Create a TPM device over an already connected byte stream.
     pub fn from_stream(stream: impl Read + Write + 'static, name: impl Into<String>) -> Self {
         Self {
-            transport: Box::new(stream),
+            transport: TpmTransport::Stream(Box::new(stream)),
             path: name.into(),
         }
     }
@@ -69,29 +74,40 @@ impl TpmDevice {
         &self.path
     }
 
-    /// Send a command to the TPM and receive the response
+    /// Send a command to the TPM and receive the response.
     pub fn transmit(&mut self, command: &[u8]) -> Result<Vec<u8>> {
-        self.transport
-            .write_all(command)
-            .context("failed to write TPM command")?;
-
-        // Read the fixed header first so stream transports cannot return a
-        // partial response and leave bytes for the next transaction.
-        let mut header = [0u8; 10];
-        self.transport
-            .read_exact(&mut header)
-            .context("failed to read TPM response header")?;
-        let response_size = u32::from_be_bytes(header[2..6].try_into().unwrap()) as usize;
-        if !(header.len()..=TPM_MAX_COMMAND_SIZE).contains(&response_size) {
-            bail!("invalid TPM response size: {response_size}");
+        match &mut self.transport {
+            TpmTransport::Device(file) => {
+                file.write_all(command)
+                    .context("failed to write TPM command")?;
+                let mut response = vec![0u8; TPM_MAX_COMMAND_SIZE];
+                let size = file
+                    .read(&mut response)
+                    .context("failed to read TPM response")?;
+                response.truncate(size);
+                Ok(response)
+            }
+            TpmTransport::Stream(stream) => {
+                stream
+                    .write_all(command)
+                    .context("failed to write TPM command")?;
+                let mut header = [0u8; 10];
+                stream
+                    .read_exact(&mut header)
+                    .context("failed to read TPM response header")?;
+                let response_size = u32::from_be_bytes(header[2..6].try_into().unwrap()) as usize;
+                if !(header.len()..=TPM_MAX_COMMAND_SIZE).contains(&response_size) {
+                    bail!("invalid TPM response size: {response_size}");
+                }
+                let mut response = Vec::with_capacity(response_size);
+                response.extend_from_slice(&header);
+                response.resize(response_size, 0);
+                stream
+                    .read_exact(&mut response[header.len()..])
+                    .context("failed to read TPM response body")?;
+                Ok(response)
+            }
         }
-        let mut response = Vec::with_capacity(response_size);
-        response.extend_from_slice(&header);
-        response.resize(response_size, 0);
-        self.transport
-            .read_exact(&mut response[header.len()..])
-            .context("failed to read TPM response body")?;
-        Ok(response)
     }
 
     /// Execute a TPM command and parse the response

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -383,6 +383,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn stream_transport_reads_a_framed_response() {
+        use std::os::unix::net::UnixStream;
+        use std::thread;
+
+        let (client, mut server) = UnixStream::pair().unwrap();
+        let command = TpmCommand::new(TpmCc::GetRandom).finalize();
+        let command_len = command.len();
+        let server_thread = thread::spawn(move || {
+            let mut received = vec![0; command_len];
+            server.read_exact(&mut received).unwrap();
+            let response = TpmResponse {
+                tag: TpmSt::NoSessions,
+                response_code: 0,
+                data: vec![0, 0],
+            }
+            .to_bytes();
+            server.write_all(&response[..10]).unwrap();
+            server.write_all(&response[10..]).unwrap();
+        });
+
+        let mut device = TpmDevice::from_stream(client, "test stream");
+        let response = device.execute(&command).unwrap();
+        assert!(response.is_success());
+        assert_eq!(response.data, [0, 0]);
+        server_thread.join().unwrap();
+    }
+
+    #[test]
     fn adds_a_vendor_command_to_command_capabilities() {
         let response = TpmResponse {
             tag: TpmSt::NoSessions,

--- a/dstack/tpm2/src/device.rs
+++ b/dstack/tpm2/src/device.rs
@@ -6,7 +6,7 @@
 //!
 //! Provides low-level communication with TPM devices via /dev/tpmrm0 or /dev/tpm0.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -95,7 +95,8 @@ impl TpmDevice {
                 stream
                     .read_exact(&mut header)
                     .context("failed to read TPM response header")?;
-                let response_size = u32::from_be_bytes(header[2..6].try_into().unwrap()) as usize;
+                let response_size =
+                    u32::from_be_bytes([header[2], header[3], header[4], header[5]]) as usize;
                 if !(header.len()..=TPM_MAX_COMMAND_SIZE).contains(&response_size) {
                     bail!("invalid TPM response size: {response_size}");
                 }

--- a/dstack/tpm2/src/lib.rs
+++ b/dstack/tpm2/src/lib.rs
@@ -44,6 +44,6 @@ pub use constants::*;
 pub use types::*;
 
 // Re-export device for advanced usage
-pub use device::{TpmCommand, TpmDevice, TpmResponse};
+pub use device::{TpmCommand, TpmDevice, TpmResponse, add_command_capability};
 pub use marshal::{CommandBuffer, Marshal, ResponseBuffer, Unmarshal};
 pub use session::AuthSession;

--- a/dstack/tpm2/src/lib.rs
+++ b/dstack/tpm2/src/lib.rs
@@ -44,6 +44,6 @@ pub use constants::*;
 pub use types::*;
 
 // Re-export device for advanced usage
-pub use device::{TpmCommand, TpmDevice, TpmResponse, add_command_capability};
+pub use device::{add_command_capability, TpmCommand, TpmDevice, TpmResponse};
 pub use marshal::{CommandBuffer, Marshal, ResponseBuffer, Unmarshal};
 pub use session::AuthSession;


### PR DESCRIPTION
## Problem

The NitroTPM simulator previously generated an NSM attestation document with five all-zero PCR values. That did not reflect the live swtpm state, so the simulated Nitro evidence could disagree with measurements actually extended into the TPM.

NitroTPM also implements the AWS NSM vendor command at `0x2000_0001`, but swtpm's standard `TPM2_GetCapability(TPM_CAP_COMMANDS)` response does not know about the command implemented by this proxy. Software that enumerates commands could therefore conclude that NSM attestation is unavailable.

## Root cause

The first fix correctly queried the live PCRs and amended the command capability response, but it constructed and parsed TPM packets directly in `tee-simulator/src/tpm.rs`. That duplicated definitions already present in the repository's `tpm2` crate:

- TPM command tags and command codes
- SHA-384 algorithm identifiers and digest sizes
- PCR selection encoding
- response header sizes and field offsets
- `TPM_CAP_COMMANDS` response layout

Those literals made the simulator code difficult to review and easy to break when packet layouts changed.

## Fix

Extend the existing pure-Rust `tpm2` crate and use its typed APIs:

- Add a stream transport for an already-connected TPM byte stream, while preserving the existing single-read semantics required by Linux TPM character devices.
- Use `TpmContext::pcr_read_single(..., TpmAlgId::Sha384)` to obtain PCRs 4, 7, 8, 12, and 14 from the live NitroTPM backend.
- Parse and serialize command capability responses inside `tpm2`, then add the AWS vendor command through `add_command_capability`.
- Replace standard TPM command-number constants in the simulator with `TpmCc`.
- Keep only `0x2000_0001` in the simulator because it is the AWS-specific NSM vendor command, not a standard TPM command represented by the generic library.

This removes the hand-written `PCR_Read` packet, hard-coded response offsets, SHA-384 digest length, PCR bitmap layout, and capability list splicing from the simulator.

## Scope

This PR addresses one simulator product bug. It is based directly on `master` and does not include the acceptance-test infrastructure from #841.

## Verification

- `cargo test -p tpm2`: 7 passed, 0 failed; doc test passed.
- `cargo test -p dstack-tee-simulator --all-targets`: 7 passed, 0 failed.
- `cargo clippy -p tpm2 -p dstack-tee-simulator --all-targets -- -D warnings`: passed.
- `git diff --check origin/master...HEAD`: passed.

Focused coverage includes capability insertion ordering and framed Unix-stream TPM responses.
