### PR TITLE
fix(vmm): pass cloud image measurements to guests

### DIFF
--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -4,7 +4,7 @@
 
 use crate::config::{Config, Networking, ProcessAnnotation, Protocol};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use bon::Builder;
 use dstack_kms_rpc::kms_client::KmsClient;
 use dstack_types::mr_config::MrConfigV3;
@@ -1525,7 +1525,7 @@ pub(crate) fn needs_swtpm(
 mod tests {
     use super::*;
     use crate::config::{
-        CvmPlatform, Networking, NetworkingMode, TdxAttestationVariantConfig, load_config_figment,
+        load_config_figment, CvmPlatform, Networking, NetworkingMode, TdxAttestationVariantConfig,
     };
     use dstack_types::{
         TdxImageMeasurement, TdxMrtdCandidates, TdxOsImageMeasurement,
@@ -1597,31 +1597,25 @@ mod tests {
     #[test]
     fn gpu_config_has_gpus_only_when_resolved_gpu_list_is_non_empty() {
         assert!(!GpuConfig::default().has_gpus());
-        assert!(
-            !GpuConfig {
-                attach_mode: AttachMode::All,
-                ..Default::default()
-            }
-            .has_gpus()
-        );
-        assert!(
-            !GpuConfig {
-                bridges: vec![GpuSpec {
-                    slot: "0000:01:00.0".into(),
-                }],
-                ..Default::default()
-            }
-            .has_gpus()
-        );
-        assert!(
-            GpuConfig {
-                gpus: vec![GpuSpec {
-                    slot: "0000:02:00.0".into(),
-                }],
-                ..Default::default()
-            }
-            .has_gpus()
-        );
+        assert!(!GpuConfig {
+            attach_mode: AttachMode::All,
+            ..Default::default()
+        }
+        .has_gpus());
+        assert!(!GpuConfig {
+            bridges: vec![GpuSpec {
+                slot: "0000:01:00.0".into(),
+            }],
+            ..Default::default()
+        }
+        .has_gpus());
+        assert!(GpuConfig {
+            gpus: vec![GpuSpec {
+                slot: "0000:02:00.0".into(),
+            }],
+            ..Default::default()
+        }
+        .has_gpus());
     }
 
     #[test]

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -4,7 +4,7 @@
 
 use crate::config::{Config, Networking, ProcessAnnotation, Protocol};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bon::Builder;
 use dstack_kms_rpc::kms_client::KmsClient;
 use dstack_types::mr_config::MrConfigV3;
@@ -1394,6 +1394,9 @@ fn make_vm_config(
     let platform = cfg.cvm.resolved_platform();
     let is_amd_sev_snp = platform == crate::config::CvmPlatform::AmdSevSnp && !manifest.no_tee;
     let is_tdx = platform == crate::config::CvmPlatform::Tdx && !manifest.no_tee;
+    let is_gcp_tdx = manifest.simulated_tee == Some(dstack_types::TeeVariant::DstackGcpTdx);
+    let is_aws_nitro_tpm =
+        manifest.simulated_tee == Some(dstack_types::TeeVariant::DstackAwsNitroTpm);
     let tdx_attestation_variant = if is_tdx {
         tdx_attestation_variant_from_requirements(requirements).unwrap_or_else(|| {
             cfg.cvm
@@ -1444,6 +1447,24 @@ fn make_vm_config(
     let num_nics = resolved_networks(manifest, &cfg.cvm).len() as u32;
     let num_verity_volumes = manifest.volumes.len() as u32;
     let swtpm = manifest.swtpm;
+    let gcp_measurement = if is_gcp_tdx {
+        Some(
+            image
+                .gcp_measurement
+                .clone()
+                .context("GCP TDX image is missing measurement.gcp.cbor measurement material")?,
+        )
+    } else {
+        None
+    };
+    let aws_measurement =
+        if is_aws_nitro_tpm {
+            Some(image.aws_measurement.clone().context(
+                "AWS NitroTPM image is missing measurement.aws.cbor measurement material",
+            )?)
+        } else {
+            None
+        };
     let mut config = serde_json::to_value(dstack_types::VmConfig {
         os_image_hash,
         cpu_count: effective_vcpus,
@@ -1464,8 +1485,8 @@ fn make_vm_config(
         ovmf_variant: image.info.ovmf_variant,
         tdx_attestation_variant,
         tdx_measurement,
-        gcp_measurement: None,
-        aws_measurement: None,
+        gcp_measurement,
+        aws_measurement,
     })?;
     // For backward compatibility
     config["spec_version"] = serde_json::Value::from(1);
@@ -1504,7 +1525,7 @@ pub(crate) fn needs_swtpm(
 mod tests {
     use super::*;
     use crate::config::{
-        load_config_figment, CvmPlatform, Networking, NetworkingMode, TdxAttestationVariantConfig,
+        CvmPlatform, Networking, NetworkingMode, TdxAttestationVariantConfig, load_config_figment,
     };
     use dstack_types::{
         TdxImageMeasurement, TdxMrtdCandidates, TdxOsImageMeasurement,
@@ -1576,25 +1597,31 @@ mod tests {
     #[test]
     fn gpu_config_has_gpus_only_when_resolved_gpu_list_is_non_empty() {
         assert!(!GpuConfig::default().has_gpus());
-        assert!(!GpuConfig {
-            attach_mode: AttachMode::All,
-            ..Default::default()
-        }
-        .has_gpus());
-        assert!(!GpuConfig {
-            bridges: vec![GpuSpec {
-                slot: "0000:01:00.0".into(),
-            }],
-            ..Default::default()
-        }
-        .has_gpus());
-        assert!(GpuConfig {
-            gpus: vec![GpuSpec {
-                slot: "0000:02:00.0".into(),
-            }],
-            ..Default::default()
-        }
-        .has_gpus());
+        assert!(
+            !GpuConfig {
+                attach_mode: AttachMode::All,
+                ..Default::default()
+            }
+            .has_gpus()
+        );
+        assert!(
+            !GpuConfig {
+                bridges: vec![GpuSpec {
+                    slot: "0000:01:00.0".into(),
+                }],
+                ..Default::default()
+            }
+            .has_gpus()
+        );
+        assert!(
+            GpuConfig {
+                gpus: vec![GpuSpec {
+                    slot: "0000:02:00.0".into(),
+                }],
+                ..Default::default()
+            }
+            .has_gpus()
+        );
     }
 
     #[test]
@@ -1794,6 +1821,8 @@ mod tests {
             digest: Some(hex_of(0xaa, 32)),
             tdx_measurement,
             sev_measurement: None,
+            gcp_measurement: None,
+            aws_measurement: None,
         }
     }
 

--- a/dstack/vmm/src/app/image.rs
+++ b/dstack/vmm/src/app/image.rs
@@ -6,11 +6,11 @@ use fs_err as fs;
 use path_absolutize::Absolutize;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use dstack_types::{
-    AwsOsImageMeasurementDocument, GCP_MEASUREMENT_FILENAME, GcpOsImageMeasurementDocument,
-    SNP_MEASUREMENT_FILENAME, SevOsImageMeasurementDocument, TDX_MEASUREMENT_FILENAME,
-    TdxOsImageMeasurementDocument,
+    AwsOsImageMeasurementDocument, GcpOsImageMeasurementDocument, SevOsImageMeasurementDocument,
+    TdxOsImageMeasurementDocument, GCP_MEASUREMENT_FILENAME, SNP_MEASUREMENT_FILENAME,
+    TDX_MEASUREMENT_FILENAME,
 };
 use serde::{Deserialize, Serialize};
 

--- a/dstack/vmm/src/app/image.rs
+++ b/dstack/vmm/src/app/image.rs
@@ -6,12 +6,15 @@ use fs_err as fs;
 use path_absolutize::Absolutize;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use dstack_types::{
-    SevOsImageMeasurementDocument, TdxOsImageMeasurementDocument, SNP_MEASUREMENT_FILENAME,
-    TDX_MEASUREMENT_FILENAME,
+    AwsOsImageMeasurementDocument, GCP_MEASUREMENT_FILENAME, GcpOsImageMeasurementDocument,
+    SNP_MEASUREMENT_FILENAME, SevOsImageMeasurementDocument, TDX_MEASUREMENT_FILENAME,
+    TdxOsImageMeasurementDocument,
 };
 use serde::{Deserialize, Serialize};
+
+const AWS_MEASUREMENT_FILENAME: &str = "measurement.aws.cbor";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ImageInfo {
@@ -79,6 +82,10 @@ pub struct Image {
     pub tdx_measurement: Option<TdxOsImageMeasurementDocument>,
     /// AMD SEV-SNP no-image-download measurement material.
     pub sev_measurement: Option<SevOsImageMeasurementDocument>,
+    /// GCP TDX no-image-download measurement material.
+    pub gcp_measurement: Option<GcpOsImageMeasurementDocument>,
+    /// AWS NitroTPM no-image-download measurement material.
+    pub aws_measurement: Option<AwsOsImageMeasurementDocument>,
 }
 
 impl Image {
@@ -148,6 +155,18 @@ impl Image {
             )),
             _ => None,
         };
+        let gcp_measurement = load_measurement_document(
+            &base_path,
+            &sha256sum,
+            GCP_MEASUREMENT_FILENAME,
+            GcpOsImageMeasurementDocument::new,
+        )?;
+        let aws_measurement = load_measurement_document(
+            &base_path,
+            &sha256sum,
+            AWS_MEASUREMENT_FILENAME,
+            AwsOsImageMeasurementDocument::new,
+        )?;
         if info.version.is_empty() {
             // Older images does not have version field. Fallback to the version of the image folder name
             info.version = guess_version(&base_path).unwrap_or_default();
@@ -163,6 +182,8 @@ impl Image {
             digest,
             tdx_measurement,
             sev_measurement,
+            gcp_measurement,
+            aws_measurement,
         }
         .ensure_exists()
     }
@@ -196,6 +217,24 @@ impl Image {
         }
         Ok(self)
     }
+}
+
+fn load_measurement_document<T>(
+    base_path: &Path,
+    checksum_file: &Option<Vec<u8>>,
+    filename: &str,
+    constructor: impl FnOnce(Vec<u8>, Vec<u8>) -> T,
+) -> Result<Option<T>> {
+    let path = base_path.join(filename);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let Some(checksum_file) = checksum_file else {
+        return Ok(None);
+    };
+    let measurement =
+        fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    Ok(Some(constructor(checksum_file.clone(), measurement)))
 }
 
 fn guess_version(base_path: &Path) -> Option<String> {

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -4,20 +4,20 @@
 
 //! QEMU launch preparation and command construction.
 use super::{
-    effective_vcpu_count,
+    GpuConfig, VmWorkDir, effective_vcpu_count,
     host_share::create_shared_disk,
     hugepage_numa_nodes,
     image::Image,
     mr_config::{snp_host_data, tdx_mr_config_id},
     network::{mac_address_for_vm_index, resolved_networks, validate_resolved_networks},
-    pci_numa_node, round_up, GpuConfig, VmWorkDir,
+    pci_numa_node, round_up,
 };
 use crate::{
     app::Manifest,
     config::{CvmConfig, CvmPlatform, Networking, NetworkingMode, ProcessAnnotation},
     vm_launcher::{ChildCommand, LaunchSpec},
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bon::Builder;
 use dstack_types::shared_filenames::HOST_SHARED_DISK_LABEL;
 use fs_err as fs;
@@ -966,17 +966,17 @@ mod tests {
     use std::path::PathBuf;
 
     use rocket::figment::{
-        providers::{Format, Toml},
         Figment,
+        providers::{Format, Toml},
     };
 
     use super::{
-        amd_sev_snp_memory_backend_arg, parse_amd_sev_snp_qmp_capabilities, virtio_pci_device,
         PreparedQemuLaunch, PreparedVolume, QemuCommandBuilder, VmConfig,
+        amd_sev_snp_memory_backend_arg, parse_amd_sev_snp_qmp_capabilities, virtio_pci_device,
     };
     use crate::app::image::{Image, ImageInfo};
-    use crate::app::{needs_swtpm, GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir};
-    use crate::config::{Config, CvmPlatform, Protocol, DEFAULT_CONFIG};
+    use crate::app::{GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir, needs_swtpm};
+    use crate::config::{Config, CvmPlatform, DEFAULT_CONFIG, Protocol};
     use dstack_types::{KeyProviderKind, TeeVariant};
 
     #[test]
@@ -1088,6 +1088,8 @@ mod tests {
                 digest: None,
                 tdx_measurement: None,
                 sev_measurement: None,
+                gcp_measurement: None,
+                aws_measurement: None,
             },
             cid: 100,
             workdir: PathBuf::from("/does-not-exist/vm-1"),
@@ -1120,28 +1122,36 @@ mod tests {
         .unwrap();
 
         assert_eq!(process.command, "/not-installed/qemu-system-x86_64");
-        assert!(process
-            .args
-            .windows(2)
-            .any(|args| args == ["-machine", "q35,kernel-irqchip=split,hpet=off"]));
-        assert!(process
-            .args
-            .windows(2)
-            .any(|args| args == ["-kernel", "/does-not-exist/kernel"]));
-        assert!(process
-            .args
-            .windows(2)
-            .any(|args| args == ["-append", "console=hvc0"]));
+        assert!(
+            process
+                .args
+                .windows(2)
+                .any(|args| args == ["-machine", "q35,kernel-irqchip=split,hpet=off"])
+        );
+        assert!(
+            process
+                .args
+                .windows(2)
+                .any(|args| args == ["-kernel", "/does-not-exist/kernel"])
+        );
+        assert!(
+            process
+                .args
+                .windows(2)
+                .any(|args| args == ["-append", "console=hvc0"])
+        );
         assert!(process.args.windows(2).any(|args| {
             args == [
                 "-drive",
                 "file=/does-not-exist/volume.img,if=none,id=vol0,format=raw,readonly=on",
             ]
         }));
-        assert!(process
-            .args
-            .iter()
-            .any(|arg| { arg == "virtio-blk-pci,drive=vol0" }));
+        assert!(
+            process
+                .args
+                .iter()
+                .any(|arg| { arg == "virtio-blk-pci,drive=vol0" })
+        );
         let volume_position = process
             .args
             .iter()
@@ -1164,14 +1174,18 @@ mod tests {
         assert!(netdevs[0].contains("hostfwd=tcp:127.0.0.1:18080-:8080"));
         assert!(netdevs[1].contains("user,id=net1"));
         assert!(!netdevs[1].contains("hostfwd="));
-        assert!(process
-            .args
-            .iter()
-            .any(|arg| arg.contains("virtio-net-pci,netdev=net0")));
-        assert!(process
-            .args
-            .iter()
-            .any(|arg| arg.contains("virtio-net-pci,netdev=net1")));
+        assert!(
+            process
+                .args
+                .iter()
+                .any(|arg| arg.contains("virtio-net-pci,netdev=net0"))
+        );
+        assert!(
+            process
+                .args
+                .iter()
+                .any(|arg| arg.contains("virtio-net-pci,netdev=net1"))
+        );
 
         prepared.swtpm_socket = Some(PathBuf::from("/does-not-exist/vm-1/swtpm/swtpm.sock"));
         let process = QemuCommandBuilder {
@@ -1188,9 +1202,11 @@ mod tests {
                 "socket,id=chrtpm,path=/does-not-exist/vm-1/swtpm/swtpm.sock",
             ]
         }));
-        assert!(process
-            .args
-            .windows(2)
-            .any(|args| args == ["-tpmdev", "emulator,id=tpm0,chardev=chrtpm"]));
+        assert!(
+            process
+                .args
+                .windows(2)
+                .any(|args| args == ["-tpmdev", "emulator,id=tpm0,chardev=chrtpm"])
+        );
     }
 }

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -4,20 +4,20 @@
 
 //! QEMU launch preparation and command construction.
 use super::{
-    GpuConfig, VmWorkDir, effective_vcpu_count,
+    effective_vcpu_count,
     host_share::create_shared_disk,
     hugepage_numa_nodes,
     image::Image,
     mr_config::{snp_host_data, tdx_mr_config_id},
     network::{mac_address_for_vm_index, resolved_networks, validate_resolved_networks},
-    pci_numa_node, round_up,
+    pci_numa_node, round_up, GpuConfig, VmWorkDir,
 };
 use crate::{
     app::Manifest,
     config::{CvmConfig, CvmPlatform, Networking, NetworkingMode, ProcessAnnotation},
     vm_launcher::{ChildCommand, LaunchSpec},
 };
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use bon::Builder;
 use dstack_types::shared_filenames::HOST_SHARED_DISK_LABEL;
 use fs_err as fs;
@@ -966,17 +966,17 @@ mod tests {
     use std::path::PathBuf;
 
     use rocket::figment::{
-        Figment,
         providers::{Format, Toml},
+        Figment,
     };
 
     use super::{
-        PreparedQemuLaunch, PreparedVolume, QemuCommandBuilder, VmConfig,
         amd_sev_snp_memory_backend_arg, parse_amd_sev_snp_qmp_capabilities, virtio_pci_device,
+        PreparedQemuLaunch, PreparedVolume, QemuCommandBuilder, VmConfig,
     };
     use crate::app::image::{Image, ImageInfo};
-    use crate::app::{GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir, needs_swtpm};
-    use crate::config::{Config, CvmPlatform, DEFAULT_CONFIG, Protocol};
+    use crate::app::{needs_swtpm, GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir};
+    use crate::config::{Config, CvmPlatform, Protocol, DEFAULT_CONFIG};
     use dstack_types::{KeyProviderKind, TeeVariant};
 
     #[test]
@@ -1122,36 +1122,28 @@ mod tests {
         .unwrap();
 
         assert_eq!(process.command, "/not-installed/qemu-system-x86_64");
-        assert!(
-            process
-                .args
-                .windows(2)
-                .any(|args| args == ["-machine", "q35,kernel-irqchip=split,hpet=off"])
-        );
-        assert!(
-            process
-                .args
-                .windows(2)
-                .any(|args| args == ["-kernel", "/does-not-exist/kernel"])
-        );
-        assert!(
-            process
-                .args
-                .windows(2)
-                .any(|args| args == ["-append", "console=hvc0"])
-        );
+        assert!(process
+            .args
+            .windows(2)
+            .any(|args| args == ["-machine", "q35,kernel-irqchip=split,hpet=off"]));
+        assert!(process
+            .args
+            .windows(2)
+            .any(|args| args == ["-kernel", "/does-not-exist/kernel"]));
+        assert!(process
+            .args
+            .windows(2)
+            .any(|args| args == ["-append", "console=hvc0"]));
         assert!(process.args.windows(2).any(|args| {
             args == [
                 "-drive",
                 "file=/does-not-exist/volume.img,if=none,id=vol0,format=raw,readonly=on",
             ]
         }));
-        assert!(
-            process
-                .args
-                .iter()
-                .any(|arg| { arg == "virtio-blk-pci,drive=vol0" })
-        );
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| { arg == "virtio-blk-pci,drive=vol0" }));
         let volume_position = process
             .args
             .iter()
@@ -1174,18 +1166,14 @@ mod tests {
         assert!(netdevs[0].contains("hostfwd=tcp:127.0.0.1:18080-:8080"));
         assert!(netdevs[1].contains("user,id=net1"));
         assert!(!netdevs[1].contains("hostfwd="));
-        assert!(
-            process
-                .args
-                .iter()
-                .any(|arg| arg.contains("virtio-net-pci,netdev=net0"))
-        );
-        assert!(
-            process
-                .args
-                .iter()
-                .any(|arg| arg.contains("virtio-net-pci,netdev=net1"))
-        );
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| arg.contains("virtio-net-pci,netdev=net0")));
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| arg.contains("virtio-net-pci,netdev=net1")));
 
         prepared.swtpm_socket = Some(PathBuf::from("/does-not-exist/vm-1/swtpm/swtpm.sock"));
         let process = QemuCommandBuilder {
@@ -1202,11 +1190,9 @@ mod tests {
                 "socket,id=chrtpm,path=/does-not-exist/vm-1/swtpm/swtpm.sock",
             ]
         }));
-        assert!(
-            process
-                .args
-                .windows(2)
-                .any(|args| args == ["-tpmdev", "emulator,id=tpm0,chardev=chrtpm"])
-        );
+        assert!(process
+            .args
+            .windows(2)
+            .any(|args| args == ["-tpmdev", "emulator,id=tpm0,chardev=chrtpm"]));
     }
 }


### PR DESCRIPTION
## Problem

Cloud images carry provider measurement metadata, but VMM dropped it when constructing guest configuration. The guest could boot yet could not report or compare the expected cloud TPM/Nitro measurements because that data never crossed the VMM-to-guest boundary.

## Root cause and fix

Load the image measurement document and pass the relevant provider measurements into the guest launch configuration.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): pass cloud image measurements to guests`
- `style(vmm): apply repository rustfmt`

Changed paths:

- `dstack/vmm/src/app.rs`
- `dstack/vmm/src/app/image.rs`
- `dstack/vmm/src/app/qemu.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-cloud-image-measurements`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
