### PR TITLE
fix(simulator): retry interrupted vTPM reads

### DIFF
--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -359,6 +359,7 @@ fn proxy_tpm_commands(
         let size = loop {
             match proxy.read(&mut command) {
                 Ok(size) => break size,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(error) if error.raw_os_error() == Some(libc::EPIPE) => {
                     thread::sleep(Duration::from_millis(10));
                 }


### PR DESCRIPTION
## Problem

Reads from the vTPM device can return `EINTR` when a signal interrupts the blocking operation. The simulator treated that transient interruption as a quote failure instead of resuming the read.

## Root cause and fix

Retry the read on `Interrupted` and preserve real I/O errors, matching normal Unix blocking-I/O semantics.

## Implementation

The branch records the following focused implementation work:

- `fix(simulator): retry interrupted vTPM reads`

Changed paths:

- `dstack/tee-simulator/src/tpm.rs`

## Scope

This PR addresses one logical `simulator` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-simulator-interrupted-vtpm-read`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
