### PR TITLE
fix(simulator): identify simulated Nitro Enclave guests

### DIFF
--- a/dstack/dstack-types/src/lib.rs
+++ b/dstack/dstack-types/src/lib.rs
@@ -2227,6 +2227,7 @@ impl Platform {
         match product_name.map(str::trim) {
             Some("dstack" | "qemu") => return Some(Self::Dstack),
             Some("Google Compute Engine") => return Some(Self::Gcp),
+            Some("Nitro Enclave") => return Some(Self::NitroEnclave),
             _ => {}
         }
 
@@ -2282,6 +2283,14 @@ mod platform_tests {
         assert_eq!(
             Platform::detect_from_dmi(Some("Google Compute Engine"), Some("Amazon EC2")),
             Some(Platform::Gcp)
+        );
+    }
+
+    #[test]
+    fn detects_nitro_enclave_from_simulated_dmi() {
+        assert_eq!(
+            Platform::detect_from_dmi(Some("Nitro Enclave"), Some("AWS Nitro Enclaves")),
+            Some(Platform::NitroEnclave)
         );
     }
 }

--- a/dstack/dstack-util/src/system_setup/config_id_verifier.rs
+++ b/dstack/dstack-util/src/system_setup/config_id_verifier.rs
@@ -94,6 +94,9 @@ fn verify_mr_config_id_for_mode(mode: TeeVariant, local: LocalMrConfigValues<'_>
         // in measure_app_info); there is no host-supplied claim to cross-check.
         // The key_provider_id pin is enforced by verify_key_provider_id.
         TeeVariant::DstackAwsNitroTpm => Ok(()),
+        // Nitro Enclave binds the image through the signed NSM document and
+        // the app ID through its runtime event. It has no TDX mr_config_id.
+        TeeVariant::DstackNitroEnclave => Ok(()),
         _ => verify_tdx_mr_config_id(local),
     }
 }
@@ -437,5 +440,24 @@ mod tests {
             ..local_without_scripts
         };
         verify_mr_config_v3_document(&document.to_string(), local_with_script).unwrap();
+    }
+
+    #[test]
+    fn nitro_enclave_does_not_require_tdx_mr_config() -> Result<()> {
+        let compose_hash = [0u8; 32];
+        let gpu_policy_hash = [0u8; 32];
+        let app_id = [0u8; 20];
+        let instance_id = [0u8; 20];
+        let local = LocalMrConfigValues {
+            compose_hash: &compose_hash,
+            gpu_policy_hash: &gpu_policy_hash,
+            init_script_hashes: &[],
+            app_id: &app_id,
+            instance_id: &instance_id,
+            key_provider: KeyProviderKind::None,
+            key_provider_id: &[],
+        };
+
+        verify_mr_config_id_for_mode(TeeVariant::DstackNitroEnclave, local)
     }
 }


### PR DESCRIPTION
## Problem

Simulated Nitro Enclave guests were not identified as Nitro in guest-side platform detection. Code selecting attestation and measurement behavior therefore took the generic/non-Nitro path even though the guest used the Nitro simulator.

## Root cause and fix

Recognize the DMI identity installed by the guest-side simulator and skip the TDX-only MR_CONFIG_ID check for Nitro Enclave guests.

The simulator remains the single owner of simulated DMI identity. The VMM does not override QEMU SMBIOS.

## Implementation

- `fix(simulator): detect Nitro Enclave DMI`
- `fix(guest): skip TDX config check on Nitro Enclave`

Changed paths:

- `dstack/dstack-types/src/lib.rs`
- `dstack/dstack-util/src/system_setup/config_id_verifier.rs`

## Scope

This PR addresses one logical simulator finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `cargo test -p dstack-types detects_nitro_enclave_from_simulated_dmi`: passed
- `cargo test -p dstack-util nitro_enclave_does_not_require_tdx_mr_config`: passed
- `git diff --check origin/master...HEAD`: passed
