### PR TITLE
fix(guest): report ZFS pool creation errors

### DIFF
--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -2380,11 +2380,20 @@ impl<'a> Stage0<'a> {
             match opts.storage_fs {
                 FsType::Zfs => {
                     info!("Creating ZFS filesystem");
-                    cmd! {
-                        zpool create -o autoexpand=on dstack $fs_dev;
-                        zfs create -o mountpoint=$mount_point -o atime=off -o checksum=blake3 dstack/data;
+                    let output = Command::new("zpool")
+                        .args(["create", "-o", "autoexpand=on", "dstack"])
+                        .arg(&fs_dev)
+                        .output()
+                        .context("Failed to run zpool create")?;
+                    if !output.status.success() {
+                        bail!(
+                            "Failed to create zpool ({}): {}",
+                            output.status,
+                            String::from_utf8_lossy(&output.stderr).trim()
+                        );
                     }
-                    .context("Failed to create zpool")?;
+                    cmd!(zfs create -o mountpoint=$mount_point -o atime=off -o checksum=blake3 dstack/data)
+                        .context("Failed to create ZFS dataset")?;
                 }
                 FsType::Ext4 => {
                     info!("Creating ext4 filesystem");


### PR DESCRIPTION
## Problem

The ZFS setup path discarded the command failure that occurs while creating the application pool. Boot then continued and failed later against a missing pool, obscuring the actual `zpool create` error.

## Root cause and fix

Propagate the pool-creation command error immediately, including its diagnostic output, so provisioning stops at the real failure.

## Implementation

The branch records the following focused implementation work:

- `fix(guest): report ZFS pool creation errors`

Changed paths:

- `dstack/dstack-util/src/system_setup.rs`

## Scope

This PR addresses one logical `guest` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-guest-zfs-pool-errors`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
