### PR TITLE
fix(mkosi): install and stage the volume helper

### DIFF
--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -65,7 +65,8 @@ if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
   cargo build --locked --release --manifest-path "$ROOT/dstack/Cargo.toml" \
     -p dstack-guest-agent -p dstack-util -p dstack-volume
   install -m0755 "$CARGO_TARGET_DIR/release/dstack-guest-agent" \
-    "$CARGO_TARGET_DIR/release/dstack-util" "$DEST/usr/bin/"
+    "$CARGO_TARGET_DIR/release/dstack-util" \
+    "$CARGO_TARGET_DIR/release/dstack-volume" "$DEST/usr/bin/"
   if [[ $FLAVOR == dev ]]; then
     cargo build --locked --release --manifest-path "$ROOT/dstack/Cargo.toml" \
       -p dstack-tee-simulator

--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -63,7 +63,7 @@ if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
   # hosts with different CPU counts while retaining parallel crate builds.
   export RUSTFLAGS="${RUSTFLAGS:-} $target_remap $home_remap --remap-path-prefix=$ROOT=/usr/src/dstack --remap-path-prefix=$build_root=/usr/src/dstack-build -C codegen-units=1 -C strip=debuginfo"
   cargo build --locked --release --manifest-path "$ROOT/dstack/Cargo.toml" \
-    -p dstack-guest-agent -p dstack-util
+    -p dstack-guest-agent -p dstack-util -p dstack-volume
   install -m0755 "$CARGO_TARGET_DIR/release/dstack-guest-agent" \
     "$CARGO_TARGET_DIR/release/dstack-util" "$DEST/usr/bin/"
   if [[ $FLAVOR == dev ]]; then

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -3,7 +3,8 @@
   "required_rootfs_paths": {
     "dstack-guest": [
       "usr/bin/dstack-guest-agent",
-      "usr/bin/dstack-util"
+      "usr/bin/dstack-util",
+      "usr/bin/dstack-volume"
     ],
     "container": [
       "usr/bin/docker",


### PR DESCRIPTION
## Problem

The mkosi guest image invoked the volume setup helper during boot but did not install/stage that helper into the image. The unit therefore failed with a missing executable when initializing application volumes.

## Root cause and fix

Install the helper and stage it at the path referenced by the boot unit.

## Implementation

The branch records the following focused implementation work:

- `fix(os/mkosi): install the volume helper`
- `fix(os/mkosi): stage the volume helper`

Changed paths:

- `os/mkosi/components/dstack-rust/dstack-rust-build.sh`
- `os/mkosi/parity.json`

## Scope

This PR addresses one logical `mkosi` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-mkosi-volume-helper`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
