### PR TITLE
fix(vmm): reap VM launcher children on SvStop

### DIFF
--- a/dstack/supervisor/src/process.rs
+++ b/dstack/supervisor/src/process.rs
@@ -83,6 +83,17 @@ impl ProcessStateRT {
     pub(crate) fn is_started(&self) -> bool {
         self.started
     }
+
+    /// An explicit stop may arrive just after the process exited on its own
+    /// (VM launchers exit cleanly after reaping their children). Report such
+    /// a clean exit as the intended stop, but keep non-zero exit codes and
+    /// errors visible for diagnostics. `stopped_at` recorded by the wait task
+    /// is left untouched.
+    fn normalize_clean_exit(&mut self) {
+        if matches!(self.status, ProcessStatus::Exited(0)) {
+            self.status = ProcessStatus::Stopped;
+        }
+    }
 }
 
 impl ProcessStateRT {
@@ -289,17 +300,11 @@ impl Process {
             if is_running {
                 bail!("Missing kill tx for process");
             }
-            state.status = ProcessStatus::Stopped;
-            state.stopped_at = Some(SystemTime::now());
+            state.normalize_clean_exit();
             return Ok(());
         };
         if !is_running {
-            // A process may exit cleanly just before an explicit stop reaches
-            // Supervisor (VM launchers do this after reaping their children).
-            // The requested persistent state is nevertheless stopped, not a
-            // stale natural-exit observation.
-            state.status = ProcessStatus::Stopped;
-            state.stopped_at = Some(SystemTime::now());
+            state.normalize_clean_exit();
             return Ok(());
         }
         match stop_tx.send(()) {

--- a/dstack/supervisor/src/process.rs
+++ b/dstack/supervisor/src/process.rs
@@ -289,8 +289,19 @@ impl Process {
             if is_running {
                 bail!("Missing kill tx for process");
             }
+            state.status = ProcessStatus::Stopped;
+            state.stopped_at = Some(SystemTime::now());
             return Ok(());
         };
+        if !is_running {
+            // A process may exit cleanly just before an explicit stop reaches
+            // Supervisor (VM launchers do this after reaping their children).
+            // The requested persistent state is nevertheless stopped, not a
+            // stale natural-exit observation.
+            state.status = ProcessStatus::Stopped;
+            state.stopped_at = Some(SystemTime::now());
+            return Ok(());
+        }
         match stop_tx.send(()) {
             Ok(()) => Ok(()),
             Err(()) => match is_running {

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -468,7 +468,7 @@ impl App {
         Ok(())
     }
 
-    async fn stop_vm_process(&self, id: &str) -> Result<()> {
+    pub(crate) async fn stop_vm_process(&self, id: &str) -> Result<()> {
         let Some(info) = self.supervisor.info(id).await? else {
             return Ok(());
         };

--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -814,6 +814,11 @@ impl VmmRpc for RpcHandler {
         // the VM-aware stop path so the launcher can reap those children; the
         // same helper preserves generic Supervisor stop semantics for every
         // other process type.
+        self.app
+            .supervisor
+            .info(&request.id)
+            .await?
+            .context("Supervisor process not found")?;
         self.app.stop_vm_process(&request.id).await
     }
 

--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -810,8 +810,11 @@ impl VmmRpc for RpcHandler {
     }
 
     async fn sv_stop(self, request: Id) -> Result<()> {
-        self.app.supervisor.stop(&request.id).await?;
-        Ok(())
+        // VM launcher processes own QEMU and swtpm children. Route them through
+        // the VM-aware stop path so the launcher can reap those children; the
+        // same helper preserves generic Supervisor stop semantics for every
+        // other process type.
+        self.app.stop_vm_process(&request.id).await
     }
 
     async fn sv_remove(self, request: Id) -> Result<()> {


### PR DESCRIPTION
## Problem

`SvStop` stopped VM services without reaping their launcher child processes. Repeated stop/start operations could leave zombies and stale launcher state even though VMM reported the VM stopped.

## Root cause and fix

Wait for and reap launcher children as part of `SvStop`, preserving the launcher exit result instead of orphaning the process.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): reap VM launcher children on SvStop`
- `fix(vmm): keep SvStop unknown IDs rejected`

Changed paths:

- `dstack/supervisor/src/process.rs`
- `dstack/vmm/src/app.rs`
- `dstack/vmm/src/main_service.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-svstop-child-reaping`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
