### PR TITLE
fix(vmm): resize uninitialized stopped VM manifests

### DIFF
--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -437,20 +437,27 @@ impl RpcHandler {
             if disk_size < manifest.disk_size {
                 bail!("Cannot shrink disk size");
             }
-            manifest.disk_size = disk_size;
-
-            info!("Resizing disk to {}GB", disk_size);
-            let hda_path = vm_work_dir.hda_path();
-            let new_size_str = format!("{}G", disk_size);
-            let output = std::process::Command::new("qemu-img")
-                .args(["resize", &hda_path.display().to_string(), &new_size_str])
-                .output()
-                .context("Failed to resize disk")?;
-            if !output.status.success() {
-                bail!(
-                    "Failed to resize disk: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
+            if disk_size > manifest.disk_size {
+                let hda_path = vm_work_dir.hda_path();
+                if hda_path.exists() {
+                    info!("Resizing disk to {}GB", disk_size);
+                    let new_size_str = format!("{}G", disk_size);
+                    let output = std::process::Command::new("qemu-img")
+                        .args(["resize", &hda_path.display().to_string(), &new_size_str])
+                        .output()
+                        .context("Failed to resize disk")?;
+                    if !output.status.success() {
+                        bail!(
+                            "Failed to resize disk: {}",
+                            String::from_utf8_lossy(&output.stderr)
+                        );
+                    }
+                } else {
+                    // A never-started stopped VM has no data disk yet. Its
+                    // first launch creates hda.img from manifest.disk_size.
+                    info!("Recording {}GB disk size for uninitialized VM", disk_size);
+                }
+                manifest.disk_size = disk_size;
             }
         }
 


### PR DESCRIPTION
## Problem

A stopped VM created before its first successful launch can have no initialized runtime manifest. The resize path assumed the manifest already existed and failed instead of applying the requested size to this valid stopped state.

## Root cause and fix

Handle the uninitialized stopped-VM case by updating the persisted configuration from the request rather than requiring launch-time manifest data.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): resize uninitialized stopped VM manifests`

Changed paths:

- `dstack/vmm/src/main_service.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-stopped-manifest-resize`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
