### PR TITLE
fix(vmm): keep Host API on the private vsock listener

### DIFF
--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -88,7 +88,6 @@ async fn run_external_api(app: App, figment: Figment, api_auth: Authenticator) -
     let external_api = rocket::custom(figment)
         .mount("/", main_routes::routes())
         .mount("/guest", ra_rpc::prpc_routes!(App, GuestApiHandler))
-        .mount("/api", ra_rpc::prpc_routes!(App, HostApiHandler))
         .mount(
             "/prpc",
             ra_rpc::prpc_routes!(App, RpcHandler, trim: "Teepod."),


### PR DESCRIPTION
## Problem

VMM could expose the Host API on a general/public vsock listener after listener setup was refactored. That crossed the intended trust boundary: guest-facing peers could reach host-management RPCs.

## Root cause and fix

Keep Host API routing attached only to the private vsock listener and leave the public listener with its intended guest surface.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): keep Host API on private vsock listener`

Changed paths:

- `dstack/vmm/src/main.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-private-host-api`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
