### PR TITLE
fix(gateway): reject invalid reported ports

### DIFF
--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1471,22 +1471,27 @@ impl GatewayRpc for RpcHandler {
         let app_id = hex::encode(&app_info.app_id);
         let instance_id = hex::encode(&app_info.instance_id);
         let compose_hash = hex::encode(&app_info.compose_hash);
-        let port_policy = request.port_policy.map(|p| {
-            let ports = p
-                .ports
-                .into_iter()
-                .filter_map(|attr| {
-                    // Wire format is uint32 to avoid varint shenanigans, but valid TCP
-                    // ports fit in u16. Drop out-of-range entries instead of truncating.
-                    let port = u16::try_from(attr.port).ok()?;
-                    Some((port, crate::kv::PortFlags { pp: attr.pp }))
+        let port_policy = request
+            .port_policy
+            .map(|policy| -> Result<PortPolicy> {
+                let ports = policy
+                    .ports
+                    .into_iter()
+                    .map(|attr| {
+                        let port = u16::try_from(attr.port)
+                            .with_context(|| format!("port {} out of u16 range", attr.port))?;
+                        if port == 0 {
+                            bail!("port must be between 1 and 65535");
+                        }
+                        Ok((port, crate::kv::PortFlags { pp: attr.pp }))
+                    })
+                    .collect::<Result<_>>()?;
+                Ok(PortPolicy {
+                    ports,
+                    restrict_mode: policy.restrict_mode,
                 })
-                .collect();
-            PortPolicy {
-                ports,
-                restrict_mode: p.restrict_mode,
-            }
-        });
+            })
+            .transpose()?;
         self.state.do_register_cvm(
             &app_id,
             &instance_id,


### PR DESCRIPTION
## Problem

Gateway trusted the port numbers reported during registration without checking the valid TCP/UDP range or reserved zero value. Invalid values survived registration and only failed when a listener or proxy address was constructed.

## Root cause and fix

Validate every reported port at registration and reject zero/out-of-range values before updating gateway state.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): reject invalid reported ports`

Changed paths:

- `dstack/gateway/src/main_service.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-reported-ports`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
