### PR TITLE
fix(gateway): reject zero DNS timing values

### DIFF
--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -340,7 +340,14 @@ impl AdminRpc for AdminRpcHandler {
         let now = now_secs();
         let id = generate_cred_id();
         let dns_txt_ttl = request.dns_txt_ttl.unwrap_or(60);
-        let max_dns_wait = Duration::from_secs(request.max_dns_wait.unwrap_or(60 * 5).into());
+        let max_dns_wait_secs = request.max_dns_wait.unwrap_or(60 * 5);
+        if dns_txt_ttl == 0 {
+            bail!("dns_txt_ttl must be greater than zero");
+        }
+        if max_dns_wait_secs == 0 {
+            bail!("max_dns_wait must be greater than zero");
+        }
+        let max_dns_wait = Duration::from_secs(max_dns_wait_secs.into());
         let cred = DnsCredential {
             id: id.clone(),
             name: request.name,


### PR DESCRIPTION
## Problem

Gateway accepted zero DNS refresh/retry timing values. Those values produced a tight loop with no delay, consuming CPU and repeatedly hitting the DNS provider.

## Root cause and fix

Reject zero durations during configuration validation so every DNS loop has a positive pacing interval.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): reject zero DNS timing values`

Changed paths:

- `dstack/gateway/src/admin_service.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-dns-timings`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
