### PR TITLE
[STACKED on #859] fix(vmm): reject empty and zero ResizeVm updates

### DIFF
--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -397,6 +397,29 @@ fn networks_from_vm_config(
     }
 }
 
+fn validate_resize_request(request: &ResizeVmRequest) -> Result<()> {
+    if request.vcpu.is_none()
+        && request.memory.is_none()
+        && request.disk_size.is_none()
+        && request.image.is_none()
+    {
+        bail!("resize request contains no updates");
+    }
+    if request.vcpu == Some(0) {
+        bail!("vcpu must be greater than zero");
+    }
+    if request.memory == Some(0) {
+        bail!("memory must be greater than zero");
+    }
+    if request.disk_size == Some(0) {
+        bail!("disk_size must be greater than zero");
+    }
+    if request.image.as_deref() == Some("") {
+        bail!("image must not be empty");
+    }
+    Ok(())
+}
+
 impl RpcHandler {
     fn resolve_gpus(&self, gpu_cfg: &rpc::GpuConfig) -> Result<GpuConfig> {
         resolve_gpus_with_config(gpu_cfg, &self.app.config.cvm)
@@ -683,6 +706,7 @@ impl VmmRpc for RpcHandler {
     #[tracing::instrument(skip(self, request), fields(id = request.id))]
     async fn resize_vm(self, request: ResizeVmRequest) -> Result<()> {
         info!("Resizing VM: {:?}", request);
+        validate_resize_request(&request)?;
         let vm_work_dir = self.app.work_dir(&request.id);
         let mut manifest = vm_work_dir.manifest().context("failed to read manifest")?;
         self.apply_resource_updates(
@@ -1003,6 +1027,30 @@ mod tests {
             create_manifest_from_vm_config(test_vm_configuration(), &test_cvm_config()).unwrap();
 
         assert!(manifest.networks.is_empty());
+    }
+
+    #[test]
+    fn resize_request_rejects_empty_zero_and_empty_image_updates() {
+        let mut request = ResizeVmRequest {
+            id: "vm-1".into(),
+            ..Default::default()
+        };
+        assert!(validate_resize_request(&request).is_err());
+
+        request.vcpu = Some(0);
+        assert!(validate_resize_request(&request).is_err());
+        request.vcpu = Some(1);
+        assert!(validate_resize_request(&request).is_ok());
+
+        request.vcpu = None;
+        request.memory = Some(0);
+        assert!(validate_resize_request(&request).is_err());
+        request.memory = None;
+        request.disk_size = Some(0);
+        assert!(validate_resize_request(&request).is_err());
+        request.disk_size = None;
+        request.image = Some(String::new());
+        assert!(validate_resize_request(&request).is_err());
     }
 
     #[test]


### PR DESCRIPTION
> **STACKED PR — merge #859 first.**

## Problem

`ResizeVm` represented optional fields with zero/empty values, and the handler treated those values as real updates. An empty request or zero size could overwrite valid persisted limits and produce an unbootable VM definition.

## Root cause and fix

Distinguish omitted fields from valid updates and reject empty requests and zero-valued resize parameters.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): reject empty and zero ResizeVm updates`

Changed paths:

- `dstack/vmm/src/main_service.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #859
- GitHub base branch: `codex/fix-vmm-stopped-manifest-resize`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-vmm-stopped-manifest-resize..origin/codex/fix-vmm-resize-validation`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
