### PR TITLE
[STACKED on #873] fix(kms): persist private keys owner-only

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -6580,9 +6580,9 @@ dependencies = [
 
 [[package]]
 name = "safe-write"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8066891189c8e6c7d189c4c19d841721606b4cac7212160ed3b3fa97d448fbab"
+checksum = "3ed1f9442e2f57be7e5e7cc1246ca44bd94ac20ef8fb070621253674ac4cff4c"
 dependencies = [
  "fs-err",
 ]

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -143,7 +143,7 @@ rand = "0.8.5"
 regorus = { version = "0.10.1", default-features = false, features = ["full-opa", "arc"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-safe-write = "0.1.2"
+safe-write = "0.1.3"
 rustix = { version = "0.38", features = ["fs"] }
 nix = "0.29.0"
 # Vendored: 6.0.2 does not build for musl. See vendor/README.md.

--- a/dstack/kms/src/onboard_service.rs
+++ b/dstack/kms/src/onboard_service.rs
@@ -25,7 +25,7 @@ use ra_tls::{
     cert::{CaCert, CertRequest},
     rcgen::{Certificate, KeyPair, PKCS_ECDSA_P256_SHA256},
 };
-use safe_write::safe_write;
+use safe_write::{safe_write, safe_write_with_mode};
 use sha2::Digest;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::info;
@@ -572,10 +572,10 @@ impl Keys {
     }
 
     fn store_keys(&self, cfg: &KmsConfig) -> Result<()> {
-        safe_write(cfg.tmp_ca_key(), self.tmp_ca_key.serialize_pem())?;
-        safe_write(cfg.root_ca_key(), self.ca_key.serialize_pem())?;
-        safe_write(cfg.rpc_key(), self.rpc_key.serialize_pem())?;
-        safe_write(cfg.k256_key(), self.k256_key.to_bytes())?;
+        safe_write_with_mode(cfg.tmp_ca_key(), self.tmp_ca_key.serialize_pem(), 0o600)?;
+        safe_write_with_mode(cfg.root_ca_key(), self.ca_key.serialize_pem(), 0o600)?;
+        safe_write_with_mode(cfg.rpc_key(), self.rpc_key.serialize_pem(), 0o600)?;
+        safe_write_with_mode(cfg.k256_key(), self.k256_key.to_bytes(), 0o600)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

KMS wrote private-key files with permissions derived from the generic `safe_write()` path. A permissive environment could leave CA or service private keys readable by other local users.

## Fix

The upstream [`safe-write`](https://github.com/kvinwang/safe-write) crate now provides:

```rust
safe_write_with_mode(path, content, mode)
```

Version `0.1.3` has been published to crates.io and tagged as `v0.1.3` upstream. KMS now uses that API with mode `0o600` for:

- temporary CA private key;
- root CA private key;
- RPC private key;
- K256 private key.

This keeps atomic-write behavior centralized in its owning crate instead of duplicating it in KMS.

## Changed paths

- `dstack/Cargo.toml`
- `dstack/Cargo.lock`
- `dstack/kms/src/onboard_service.rs`

## Dependency and merge order

- Parent PR: #873 (merged)
- GitHub base branch: `codex/fix-kms-bootstrap-once`

## Verification

- Upstream `safe-write`: all unit and documentation tests passed.
- Upstream `cargo publish --dry-run`: passed.
- `safe-write v0.1.3`: published successfully to crates.io.
- `cargo test -p dstack-kms onboard_service::tests --no-fail-fast`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
