### PR TITLE
fix(kms): send the Finish response before shutting down

### DIFF
--- a/dstack/kms/src/main.rs
+++ b/dstack/kms/src/main.rs
@@ -63,13 +63,18 @@ async fn run_onboard_service(kms_config: KmsConfig, figment: Figment) -> Result<
 
     // Remove section tls
 
-    let _ = rocket::custom(figment)
+    let rocket = rocket::custom(figment)
         .mount("/", rocket::routes![index, finish])
         .mount(
             "/prpc",
             ra_rpc::prpc_routes!(OnboardState, OnboardHandler, trim: "Onboard."),
         )
-        .manage(state)
+        .manage(state.clone())
+        .ignite()
+        .await
+        .map_err(|err| anyhow!(err.to_string()))?;
+    state.set_shutdown(rocket.shutdown())?;
+    let _ = rocket
         .launch()
         .await
         .map_err(|err| anyhow!(err.to_string()))?;

--- a/dstack/kms/src/onboard_service.rs
+++ b/dstack/kms/src/onboard_service.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{bail, Context, Result};
 use dstack_kms_rpc::{
@@ -45,6 +45,7 @@ pub struct OnboardState {
     config: KmsConfig,
     attestation_verifier: Arc<AttestationVerifier>,
     bootstrap_lock: Arc<AsyncMutex<()>>,
+    shutdown: Arc<OnceLock<rocket::Shutdown>>,
 }
 
 impl OnboardState {
@@ -57,7 +58,16 @@ impl OnboardState {
             config,
             attestation_verifier,
             bootstrap_lock: Arc::new(AsyncMutex::new(())),
+            shutdown: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Hand the Rocket shutdown handle to the service so `finish` can stop the
+    /// server after its response has been sent.
+    pub fn set_shutdown(&self, shutdown: rocket::Shutdown) -> Result<()> {
+        self.shutdown
+            .set(shutdown)
+            .map_err(|_| anyhow::anyhow!("onboard shutdown handle is already set"))
     }
 }
 
@@ -199,7 +209,15 @@ impl OnboardRpc for OnboardHandler {
     }
 
     async fn finish(self) -> anyhow::Result<()> {
-        std::process::exit(0);
+        let shutdown = self
+            .state
+            .shutdown
+            .get()
+            .context("onboard shutdown handle is unavailable")?;
+        // Graceful shutdown lets Rocket finish sending this response before the
+        // server stops, so the client learns that onboarding succeeded.
+        shutdown.clone().notify();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Problem

`Onboard.Finish` called `std::process::exit(0)` from inside the RPC handler, so the
process died before Rocket could write the response. The onboarding client saw an EOF /
connection reset and could not tell whether finalization had succeeded.

## Fix

Use Rocket's graceful shutdown, which is what the web UI's `GET /finish` route has always
done. Rocket finishes in-flight responses and then stops accepting connections, so the
client gets its response. `run_onboard_service` returns normally afterwards and `main`
continues into the regular KMS startup path — the same thing that already happens after
the web-UI flow, so no caller sees new behavior.

The shutdown handle only exists after ignition, so the launch is split into `ignite()` and
`launch()` with the handle stashed in `OnboardState` in between. It is written once, before
any request can be served, so a `OnceLock` is enough.

## Scope change since the first revision

The earlier revision also rewrote JSON `null` response bodies to an empty body in
`ra-rpc/src/rocket_helper.rs`. That has been **dropped from this PR**: it was a
transport-layer workaround for a codec-layer problem, and it silently changed the wire
format of every unit-returning RPC in vmm and gateway, which does not belong in a KMS
fix. It is being fixed properly upstream in prpc instead
(https://github.com/Phala-Network/prpc/pull/1), where codegen emits an empty body
for unit responses so the JSON codec matches the protobuf codec. dstack will pick it up
with a `prpc-build` bump in a separate PR.

This PR is no longer stacked: #874 is merged, so it targets `master` directly.

## Verification

- `cargo clippy -p dstack-kms --all-features`: clean.
- `cargo fmt`: clean.