### PR TITLE
fix(verifier): keep oneshot output machine-readable

### DIFF
--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -72,7 +72,7 @@ fn health() -> Json<serde_json::Value> {
     }))
 }
 
-async fn run_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()> {
+async fn run_oneshot(file_path: &str, config: &Config) -> anyhow::Result<bool> {
     use std::fs;
 
     info!("Running in oneshot mode for file: {}", file_path);
@@ -110,52 +110,9 @@ async fn run_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()> {
     })?;
     info!("Stored verification result at {}", output_path);
 
-    // Output results
-    println!("\n=== Verification Results ===");
-    println!("Valid: {}", response.is_valid);
-    println!("Quote verified: {}", response.details.quote_verified);
-    println!(
-        "Event log verified: {}",
-        response.details.event_log_verified
-    );
-    println!(
-        "OS image hash verified: {}",
-        response.details.os_image_hash_verified
-    );
-    println!(
-        "ACPI tables verified: {}",
-        response.details.acpi_tables_verified
-    );
-
-    if let Some(tcb_status) = &response.details.tcb_status {
-        println!("TCB status: {}", tcb_status);
-    }
-
-    if !response.details.advisory_ids.is_empty() {
-        println!("Advisory IDs: {:?}", response.details.advisory_ids);
-    }
-
-    if let Some(reason) = &response.reason {
-        println!("Reason: {}", reason);
-    }
-
-    if let Some(report_data) = &response.details.report_data {
-        println!("Report data: {}", report_data);
-    }
-
-    if let Some(app_info) = &response.details.app_info {
-        println!("\n=== App Info ===");
-        println!("App ID: {}", hex::encode(&app_info.app_id));
-        println!("Instance ID: {}", hex::encode(&app_info.instance_id));
-        println!("Compose hash: {}", hex::encode(&app_info.compose_hash));
-    }
-
-    // Exit with appropriate code
-    if !response.is_valid {
-        std::process::exit(1);
-    }
-
-    Ok(())
+    // Emit exactly one machine-readable document on stdout.
+    println!("{}", serde_json::to_string(&response)?);
+    Ok(response.is_valid)
 }
 
 async fn run_cert_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()> {
@@ -277,11 +234,24 @@ async fn main() -> Result<()> {
     let config: Config = figment.extract().context("Failed to load configuration")?;
     // Check for oneshot modes
     if let Some(file_path) = cli.verify {
-        if let Err(e) = run_oneshot(&file_path, &config).await {
-            error!("Oneshot verification failed: {:#}", e);
-            std::process::exit(1);
+        let (response, exit_code) = match run_oneshot(&file_path, &config).await {
+            Ok(is_valid) => (None, if is_valid { 0 } else { 1 }),
+            Err(error) => {
+                error!("Oneshot verification failed: {error:#}");
+                (
+                    Some(VerificationResponse {
+                        is_valid: false,
+                        details: VerificationDetails::default(),
+                        reason: Some(format!("Internal error: {error:#}")),
+                    }),
+                    1,
+                )
+            }
+        };
+        if let Some(response) = response {
+            println!("{}", serde_json::to_string(&response)?);
         }
-        std::process::exit(0);
+        std::process::exit(exit_code);
     }
     if let Some(file_path) = cli.verify_cert {
         if let Err(e) = run_cert_oneshot(&file_path, &config).await {

--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -219,7 +219,11 @@ async fn main() -> Result<()> {
     {
         use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        fmt().with_env_filter(filter).with_ansi(false).init();
+        fmt()
+            .with_env_filter(filter)
+            .with_ansi(false)
+            .with_writer(std::io::stderr)
+            .init();
     }
 
     let cli = Cli::parse();


### PR DESCRIPTION
## Problem

Verifier oneshot mode mixed logs/human text with its structured result on stdout. Automation expecting JSON could not parse the output even when verification succeeded.

## Root cause and fix

Keep stdout exclusively machine-readable in oneshot mode and route diagnostics away from the result stream.

## Implementation

The branch records the following focused implementation work:

- `fix(verifier): emit structured oneshot results`
- `fix(verifier): keep oneshot stdout machine-readable`

Changed paths:

- `dstack/verifier/src/main.rs`

## Scope

This PR addresses one logical `verifier` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-verifier-oneshot-output`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
