### PR TITLE
fix(util): honor the requested random output path

### DIFF
--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -698,9 +698,16 @@ fn cmd_rand(rand_args: RandArgs) -> Result<()> {
     if rand_args.hex {
         data = hex::encode(data).into_bytes();
     }
-    io::stdout()
-        .write_all(&data)
-        .context("Failed to write random data")?;
+    if let Some(output) = rand_args.output {
+        // key material: owner-only, and never half-written — a truncated
+        // random file would pass for a valid secret.
+        safe_write::safe_write_with_mode(&output, &data, 0o600)
+            .with_context(|| format!("Failed to write random output {output}"))?;
+    } else {
+        io::stdout()
+            .write_all(&data)
+            .context("Failed to write random data")?;
+    }
     Ok(())
 }
 
@@ -1343,4 +1350,73 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn rand_args(output: Option<String>, bytes: usize, hex: bool) -> RandArgs {
+        RandArgs { bytes, output, hex }
+    }
+
+    /// `-o` used to be parsed and then ignored, so the file was never created
+    /// and the bytes went to stdout instead.
+    #[test]
+    fn rand_writes_to_the_requested_output_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.bin");
+
+        cmd_rand(rand_args(Some(path.display().to_string()), 32, false)).unwrap();
+
+        assert_eq!(fs::metadata(&path).unwrap().len(), 32);
+        // nothing but the target: no temporary file left behind.
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    /// The output is key material, so it must never be readable by anyone else.
+    #[test]
+    fn rand_output_is_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.bin");
+
+        cmd_rand(rand_args(Some(path.display().to_string()), 32, false)).unwrap();
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "random output must be 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn rand_hex_output_is_twice_as_long() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.hex");
+
+        cmd_rand(rand_args(Some(path.display().to_string()), 16, true)).unwrap();
+
+        let body = fs::read(&path).unwrap();
+        assert_eq!(body.len(), 32);
+        assert!(body.iter().all(|b| b.is_ascii_hexdigit()));
+    }
+
+    /// Re-running must replace the file rather than failing, so a retry after a
+    /// partial or interrupted run cannot wedge the caller.
+    #[test]
+    fn rand_replaces_an_existing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.bin");
+
+        cmd_rand(rand_args(Some(path.display().to_string()), 8, false)).unwrap();
+        let first = fs::read(&path).unwrap();
+
+        cmd_rand(rand_args(Some(path.display().to_string()), 32, false)).unwrap();
+        let second = fs::read(&path).unwrap();
+
+        assert_eq!(first.len(), 8);
+        assert_eq!(second.len(), 32);
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`dstack-util rand` parsed `-o/--output` and then ignored it, always writing to stdout. The command reported success while the requested file was never created.

## Fix

Write the file through `safe_write_with_mode`, which this crate already depends on (`dstack-util/Cargo.toml:65`, and `system_setup.rs` in the same crate already uses `safe_write`), rather than hand-rolling the write:

```rust
safe_write::safe_write_with_mode(&output, &data, 0o600)
    .with_context(|| format!("Failed to write random output {output}"))?;
```

## Why not a hand-rolled `create_new` + `write_all` + `sync_all`

That was the first version of this PR. Three problems, measured rather than assumed:

```
1. after a failed write: file exists = true, contents = "PARTIAL", size = 7
2. retry:                FAILED -> File exists (os error 17) (AlreadyExists)
   file still contains:  "PARTIAL"
3. safe_write retry:     ok, contents = "REAL-...-SECRET", mode = 600
```

- **A failed write leaves a truncated secret in place.** A 7-byte "random" file at 0600 looks exactly like a successful result. Nothing downstream can distinguish it from a real one, and for key material a short file is a catastrophically weak secret.
- **The retry then fails**, because `create_new` refuses the file the failed run left behind. A transient `ENOSPC` wedges the command permanently, with the partial secret still on disk.
- **`sync_all` alone is not durable.** It flushes the file's contents but not the directory entry, so a crash can leave the data on disk with nothing pointing at it — the exact failure `safe-write` exists to prevent.

`safe_write_with_mode` creates the file 0600 before any content is written, publishes it in a single rename, fsyncs both the file and its parent directory, and removes the temporary file on every error path.

It also drops the `fs_err::os::unix::fs::OpenOptionsExt` import entirely, so the second commit of the original branch is no longer needed. The two commits have been squashed into one.

## Behaviour note

Re-running now **replaces** an existing file instead of failing, matching `openssl rand -out`. The previous `create_new` was introduced by this PR rather than inherited, so nothing depended on it. If a no-clobber mode is wanted it should be an explicit flag, not the implicit default.

## Verification

Four tests, all confirmed to **fail against the previous behaviour** rather than merely passing:

| test | before | after |
|---|---|---|
| `rand_writes_to_the_requested_output_path` | FAIL | pass |
| `rand_output_is_owner_only` | FAIL | pass |
| `rand_hex_output_is_twice_as_long` | FAIL | pass |
| `rand_replaces_an_existing_output` | FAIL | pass |

62 tests pass in `dstack-util`, `cargo fmt --check` is clean and clippy reports 0 warnings. Rebased onto current `master`.

## Related

The `safe-write` behind this call is pinned at `0.1.3`, which has known correctness bugs of its own. #989 upgrades the workspace to `0.2.0` and switches `dstack-cli-core::fsutil` onto it. This PR is correct either way — the call site does not change — but the guarantees described above only fully hold once #989 lands.
