### PR TITLE
fix(attestation): reject trailing encoded bytes

### DIFF
--- a/dstack/dstack-attest/src/attestation.rs
+++ b/dstack/dstack-attest/src/attestation.rs
@@ -734,7 +734,7 @@ impl VersionedAttestation {
             bail!("Empty attestation bytes");
         };
         if first == 0x00 {
-            let mut input = &bytes[..];
+            let mut input = bytes;
             let legacy = LegacyVersionedAttestation::decode(&mut input)
                 .context("Failed to decode legacy VersionedAttestation")?;
             if !input.is_empty() {

--- a/dstack/dstack-attest/src/attestation.rs
+++ b/dstack/dstack-attest/src/attestation.rs
@@ -734,8 +734,15 @@ impl VersionedAttestation {
             bail!("Empty attestation bytes");
         };
         if first == 0x00 {
-            let legacy = LegacyVersionedAttestation::decode(&mut &bytes[..])
+            let mut input = &bytes[..];
+            let legacy = LegacyVersionedAttestation::decode(&mut input)
                 .context("Failed to decode legacy VersionedAttestation")?;
+            if !input.is_empty() {
+                bail!(
+                    "Trailing bytes after legacy VersionedAttestation: {}",
+                    input.len()
+                );
+            }
             return match legacy {
                 LegacyVersionedAttestation::V0 { attestation } => Ok(Self::V0 { attestation }),
             };
@@ -3035,5 +3042,39 @@ mod tests {
             ])
         );
         Ok(())
+    }
+
+    #[test]
+    fn versioned_wire_formats_reject_malformed_boundaries() {
+        assert!(VersionedAttestation::from_bytes(&[]).is_err());
+        assert!(VersionedAttestation::from_bytes(&[0xff]).is_err());
+        assert!(VersionedAttestation::from_bytes(&vec![0xff; MAX_ATTESTATION_BYTES + 1]).is_err());
+
+        let legacy = dummy_tdx_attestation([0x31; 64]).into_versioned();
+        assert!(matches!(legacy, VersionedAttestation::V0 { .. }));
+        let legacy_bytes = legacy.to_bytes().unwrap();
+        let decoded = VersionedAttestation::from_bytes(&legacy_bytes).unwrap();
+        assert_eq!(decoded.into_v1().report_data().unwrap(), [0x31; 64]);
+        assert!(VersionedAttestation::from_bytes(&legacy_bytes[..legacy_bytes.len() - 1]).is_err());
+        assert!(
+            VersionedAttestation::from_bytes(&[legacy_bytes.as_slice(), &[0xaa]].concat()).is_err()
+        );
+
+        let current = dummy_tdx_attestation([0x32; 64])
+            .into_v1()
+            .into_dstack_pod("versioned-boundary".into());
+        let current = VersionedAttestation::V1 {
+            attestation: current,
+        };
+        let current_bytes = current.to_bytes().unwrap();
+        let decoded = VersionedAttestation::from_bytes(&current_bytes).unwrap();
+        assert_eq!(decoded.into_v1().report_data().unwrap(), [0x32; 64]);
+        assert!(
+            VersionedAttestation::from_bytes(&current_bytes[..current_bytes.len() - 1]).is_err()
+        );
+        assert!(
+            VersionedAttestation::from_bytes(&[current_bytes.as_slice(), &[0xaa]].concat())
+                .is_err()
+        );
     }
 }

--- a/dstack/dstack-attest/src/v1.rs
+++ b/dstack/dstack-attest/src/v1.rs
@@ -278,8 +278,17 @@ impl Attestation {
     }
 
     pub fn from_msgpack(bytes: &[u8]) -> Result<Self> {
-        let value: Self =
-            rmp_serde::from_slice(bytes).context("failed to decode attestation from msgpack")?;
+        let mut cursor = std::io::Cursor::new(bytes);
+        let mut decoder = rmp_serde::Deserializer::new(&mut cursor);
+        let value =
+            Self::deserialize(&mut decoder).context("failed to decode attestation from msgpack")?;
+        drop(decoder);
+        if cursor.position() != bytes.len() as u64 {
+            bail!(
+                "trailing bytes after attestation msgpack: {}",
+                bytes.len() as u64 - cursor.position()
+            );
+        }
         if value.version != ATTESTATION_VERSION {
             bail!(
                 "unsupported attestation version: expected {}, got {}",


### PR DESCRIPTION
## Problem

Attestation decoders accepted a valid encoded object followed by arbitrary trailing bytes. That allowed two components to disagree about what exact byte string had been authenticated or consumed.

## Root cause and fix

Require complete input consumption and reject any bytes remaining after the expected encoded value.

## Implementation

The branch records the following focused implementation work:

- `fix(attestation): reject trailing legacy bytes`
- `fix(attestation): reject trailing msgpack bytes`

Changed paths:

- `dstack/dstack-attest/src/attestation.rs`
- `dstack/dstack-attest/src/v1.rs`

## Scope

This PR addresses one logical `attestation` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-attestation-trailing-bytes`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
