### PR TITLE
fix(attestation): validate V2 event preimages

### DIFF
--- a/dstack/cc-eventlog/src/tdx.rs
+++ b/dstack/cc-eventlog/src/tdx.rs
@@ -187,10 +187,10 @@ pub fn validate_v2_preimages(events: &[TdxEvent]) -> Result<()> {
         if advertised.as_slice() != event.digest.as_slice() {
             bail!("V2 runtime event {index} digest does not match its preimage");
         }
-        let canonical = event
-            .to_runtime_event()
-            .expect("runtime event was checked above")
-            .preimage();
+        let Some(runtime_event) = event.to_runtime_event() else {
+            continue;
+        };
+        let canonical = runtime_event.preimage();
         if supplied != canonical {
             bail!("V2 runtime event {index} preimage is not the canonical event representation");
         }

--- a/dstack/cc-eventlog/src/tdx.rs
+++ b/dstack/cc-eventlog/src/tdx.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use dstack_types::EventLogVersion;
 use scale::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha384 as Sha384Digest};
 
 use crate::{
     runtime_events::{RuntimeEvent, DSTACK_RUNTIME_EVENT_TYPE},
@@ -166,6 +167,37 @@ pub fn fill_v2_preimages(events: &mut [TdxEvent]) {
     }
 }
 
+/// Validate the externally supplied digest preimage of every V2 runtime event.
+///
+/// The preimage must be present, valid hex, hash to the advertised digest, and
+/// equal the canonical representation reconstructed from the public event
+/// fields. This binds RTMR replay and displayed fields to the same bytes.
+pub fn validate_v2_preimages(events: &[TdxEvent]) -> Result<()> {
+    for (index, event) in events.iter().enumerate() {
+        if !event.is_runtime_event() || !matches!(event.version, EventLogVersion::V2) {
+            continue;
+        }
+        let supplied_hex = event
+            .preimage
+            .as_deref()
+            .with_context(|| format!("V2 runtime event {index} is missing its digest preimage"))?;
+        let supplied = hex::decode(supplied_hex)
+            .with_context(|| format!("V2 runtime event {index} has a malformed digest preimage"))?;
+        let advertised = Sha384Digest::digest(&supplied);
+        if advertised.as_slice() != event.digest.as_slice() {
+            bail!("V2 runtime event {index} digest does not match its preimage");
+        }
+        let canonical = event
+            .to_runtime_event()
+            .expect("runtime event was checked above")
+            .preimage();
+        if supplied != canonical {
+            bail!("V2 runtime event {index} preimage is not the canonical event representation");
+        }
+    }
+    Ok(())
+}
+
 pub fn is_tdx_acpi_data_event(event: &TdxEvent) -> bool {
     event.imr == 0
         && event.event_type == TDX_ACPI_DATA_EVENT_TYPE
@@ -207,7 +239,7 @@ pub fn read_event_log() -> Result<Vec<TdxEvent>> {
 mod tests {
     use super::*;
     use ez_hash::{Hasher, Sha384};
-    use sha2::{Digest as _, Sha384 as Sha384Hasher};
+    use sha2::Sha384 as Sha384Hasher;
 
     fn acpi_data_event(digest_byte: u8) -> TdxEvent {
         TdxEvent {
@@ -316,5 +348,47 @@ mod tests {
         let tdx: TdxEvent = runtime.into();
         let json = serde_json::to_string(&tdx).unwrap();
         assert!(!json.contains("preimage"));
+    }
+
+    fn v2_event() -> TdxEvent {
+        let mut event = TdxEvent::from(RuntimeEvent::new(
+            "app-id".into(),
+            b"fixture".to_vec(),
+            EventLogVersion::V2,
+        ));
+        event.fill_preimage();
+        event
+    }
+
+    #[test]
+    fn validates_v2_digest_preimage_before_use() {
+        validate_v2_preimages(&[v2_event()]).expect("valid V2 preimage");
+    }
+
+    #[test]
+    fn rejects_missing_or_malformed_v2_preimage() {
+        let mut missing = v2_event();
+        missing.preimage = None;
+        assert!(validate_v2_preimages(&[missing]).is_err());
+
+        let mut malformed = v2_event();
+        malformed.preimage = Some("not-hex".into());
+        assert!(validate_v2_preimages(&[malformed]).is_err());
+    }
+
+    #[test]
+    fn rejects_v2_preimage_digest_mismatch() {
+        let mut event = v2_event();
+        event.digest[0] ^= 1;
+        assert!(validate_v2_preimages(&[event]).is_err());
+    }
+
+    #[test]
+    fn rejects_noncanonical_v2_preimage_with_matching_digest() {
+        let mut event = v2_event();
+        let supplied = br#"{"type":134217729,"name":"app-id","payload":"66697874757265"}"#;
+        event.preimage = Some(hex::encode(supplied));
+        event.digest = Sha384Hasher::digest(supplied).to_vec();
+        assert!(validate_v2_preimages(&[event]).is_err());
     }
 }

--- a/dstack/dstack-attest/src/attestation.rs
+++ b/dstack/dstack-attest/src/attestation.rs
@@ -1096,6 +1096,15 @@ impl AttestationV1 {
             }
         };
 
+        match &platform {
+            PlatformEvidence::Tdx { event_log, .. }
+            | PlatformEvidence::GcpTdx { event_log, .. } => {
+                cc_eventlog::tdx::validate_v2_preimages(event_log)
+                    .context("Failed to validate TDX V2 event digest preimages")?;
+            }
+            _ => {}
+        }
+
         Ok(VerifiedAttestation {
             quote: platform_into_legacy_quote(platform),
             runtime_events,
@@ -2058,8 +2067,6 @@ impl Attestation {
     pub fn from_tdx_quote(quote: Vec<u8>, event_log: &[u8]) -> Result<Self> {
         let tdx_eventlog: Vec<TdxEvent> =
             serde_json::from_slice(event_log).context("Failed to parse tdx_event_log")?;
-        cc_eventlog::tdx::validate_v2_preimages(&tdx_eventlog)
-            .context("Failed to validate TDX V2 event digest preimages")?;
         let runtime_events = tdx_eventlog
             .iter()
             .flat_map(|event| event.to_runtime_event())
@@ -2293,6 +2300,18 @@ impl Attestation {
                 DstackVerifiedReport::DstackAwsNitroTpm(report)
             }
         };
+
+        match &self.quote {
+            AttestationQuote::DstackTdx(q) => {
+                cc_eventlog::tdx::validate_v2_preimages(&q.event_log)
+                    .context("Failed to validate TDX V2 event digest preimages")?;
+            }
+            AttestationQuote::DstackGcpTdx(q) => {
+                cc_eventlog::tdx::validate_v2_preimages(&q.tdx_quote.event_log)
+                    .context("Failed to validate TDX V2 event digest preimages")?;
+            }
+            _ => {}
+        }
 
         Ok(VerifiedAttestation {
             quote: self.quote,

--- a/dstack/dstack-attest/src/attestation.rs
+++ b/dstack/dstack-attest/src/attestation.rs
@@ -2058,6 +2058,8 @@ impl Attestation {
     pub fn from_tdx_quote(quote: Vec<u8>, event_log: &[u8]) -> Result<Self> {
         let tdx_eventlog: Vec<TdxEvent> =
             serde_json::from_slice(event_log).context("Failed to parse tdx_event_log")?;
+        cc_eventlog::tdx::validate_v2_preimages(&tdx_eventlog)
+            .context("Failed to validate TDX V2 event digest preimages")?;
         let runtime_events = tdx_eventlog
             .iter()
             .flat_map(|event| event.to_runtime_event())


### PR DESCRIPTION
## Problem

V2 event-log verification trusted the supplied event digest without reconstructing the digest from the event preimage. A mutated preimage could therefore be paired with an unchanged digest and escape semantic validation.

## Root cause and fix

Recompute each supported V2 event digest from its preimage and reject entries whose encoded content does not match the measured digest.

## Implementation

The branch records the following focused implementation work:

- `fix(attestation): validate V2 event preimages`

Changed paths:

- `dstack/cc-eventlog/src/tdx.rs`
- `dstack/dstack-attest/src/attestation.rs`

## Scope

This PR addresses one logical `attestation` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-attestation-v2-event-preimages`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
