### PR TITLE
fix(guest): write generated credentials atomically

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -6577,11 +6577,12 @@ dependencies = [
 
 [[package]]
 name = "safe-write"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8066891189c8e6c7d189c4c19d841721606b4cac7212160ed3b3fa97d448fbab"
+checksum = "b5a9dc0fc219eaa0265dbbee50170a469de86252d30b946c265c396b065b7f9f"
 dependencies = [
  "fs-err",
+ "tempfile",
 ]
 
 [[package]]

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -143,7 +143,7 @@ rand = "0.8.5"
 regorus = { version = "0.10.1", default-features = false, features = ["full-opa", "arc"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-safe-write = "0.1.2"
+safe-write = "0.2.0"
 rustix = { version = "0.38", features = ["fs"] }
 nix = "0.29.0"
 # Vendored: 6.0.2 does not build for musl. See vendor/README.md.

--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -17,6 +17,7 @@ use ra_tls::{
     kdf::{derive_key, derive_p256_key_pair_from_bytes},
     rcgen::KeyPair,
 };
+use safe_write::{safe_write, safe_write_with_mode};
 use scale::Encode;
 use std::path::Path;
 use std::{
@@ -793,8 +794,9 @@ fn cmd_gen_ra_cert(args: GenRaCertArgs) -> Result<()> {
     let ca_cert = fs::read_to_string(args.ca_cert)?;
     let ca_key = fs::read_to_string(args.ca_key)?;
     let cert_pair = generate_ra_cert(ca_cert, ca_key)?;
-    fs::write(&args.cert_path, cert_pair.cert_pem).context("Failed to write certificate")?;
-    fs::write(&args.key_path, cert_pair.key_pem).context("Failed to write private key")?;
+    safe_write(&args.cert_path, &cert_pair.cert_pem).context("Failed to write certificate")?;
+    safe_write_with_mode(&args.key_path, &cert_pair.key_pem, 0o600)
+        .context("Failed to write private key")?;
     Ok(())
 }
 
@@ -819,8 +821,9 @@ fn cmd_gen_ca_cert(args: GenCaCertArgs) -> Result<()> {
     let cert = req
         .self_signed()
         .context("Failed to self-sign certificate")?;
-    fs::write(&args.cert, cert.pem()).context("Failed to write certificate")?;
-    fs::write(&args.key, key.serialize_pem()).context("Failed to write private key")?;
+    safe_write(&args.cert, cert.pem()).context("Failed to write certificate")?;
+    safe_write_with_mode(&args.key, key.serialize_pem(), 0o600)
+        .context("Failed to write private key")?;
     Ok(())
 }
 
@@ -835,7 +838,7 @@ fn cmd_gen_app_keys(args: GenAppKeysArgs) -> Result<()> {
     };
     let app_keys = make_app_keys(&key, &disk_key, &k256_key, args.ca_level, key_provider)?;
     let app_keys = serde_json::to_string(&app_keys).context("Failed to serialize app keys")?;
-    fs::write(&args.output, app_keys).context("Failed to write app keys")?;
+    safe_write_with_mode(&args.output, &app_keys, 0o600).context("Failed to write app keys")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

`dstack-util gen-ra-cert`, `gen-ca-cert` and `gen-app-keys` truncated and rewrote their destination files in place. A crash or a full disk during the write left a partial certificate, private key, or app-keys JSON on disk that the next boot then tried to load.

## Fix

Write those files with `safe-write`, the crate the workspace already uses for the same job in `kms`, `gateway`, `dstack-attest`, and `dstack-util`'s own system setup. The payload goes to a temporary file in the target directory, is fsynced, renamed over the destination, and the parent directory is flushed afterwards. A reader only ever observes the old file or the complete new one.

Private keys and app keys go through `safe_write_with_mode(.., 0o600)`, so the mode is applied at creation time and the secret never exists on disk with wider permissions -- not even briefly between a rename and a follow-up `chmod`.

The workspace `safe-write` pin moves from 0.1.2 to 0.2.0: `safe_write_with_mode` landed in 0.1.3, and 0.2.0 carries the durability and temp-file permission fixes this change depends on.

Changed paths:

- `dstack/Cargo.toml`
- `dstack/Cargo.lock`
- `dstack/dstack-util/src/main.rs`

## Scope

This PR addresses one logical `guest` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `cargo check -p dstack-util`: passed.
- `cargo clippy -p dstack-util --all-targets`: clean.
- `cargo fmt -p dstack-util -- --check`: clean.
- `cargo check --workspace` with the `safe-write` 0.2.0 bump: passed, no other crate needed a change.