### PR TITLE
fix(guest): disable active swap before replacement

### DIFF
--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -2211,6 +2211,31 @@ impl<'a> Stage0<'a> {
         }
     }
 
+    fn active_swap_path(swap_path: &Path) -> Result<Option<PathBuf>> {
+        let canonical_swap_path = fs::canonicalize(swap_path)
+            .with_context(|| format!("Failed to resolve swap path {}", swap_path.display()))?;
+        let swaps = fs::read_to_string("/proc/swaps").context("Failed to read /proc/swaps")?;
+
+        for line in swaps.lines().skip(1) {
+            let Some(encoded_path) = line.split_whitespace().next() else {
+                continue;
+            };
+            let active_path = PathBuf::from(
+                encoded_path
+                    .replace("\\040", " ")
+                    .replace("\\011", "\t")
+                    .replace("\\012", "\n")
+                    .replace("\\134", "\\"),
+            );
+            if active_path == swap_path
+                || fs::canonicalize(&active_path).as_deref() == Ok(canonical_swap_path.as_path())
+            {
+                return Ok(Some(active_path));
+            }
+        }
+        Ok(None)
+    }
+
     async fn setup_swap(&self, swap_size: u64, opts: &DstackOptions) -> Result<()> {
         match opts.storage_fs {
             FsType::Zfs => self.setup_swap_zvol(swap_size).await,
@@ -2221,6 +2246,14 @@ impl<'a> Stage0<'a> {
     async fn setup_swapfile(&self, swap_size: u64) -> Result<()> {
         let swapfile = self.args.mount_point.join("swapfile");
         if swapfile.exists() {
+            if let Some(active_path) = Self::active_swap_path(&swapfile)? {
+                let active_path = active_path.display().to_string();
+                info!("Disabling active swapfile {active_path}");
+                cmd! {
+                    swapoff $active_path;
+                }
+                .context("Failed to disable existing swapfile")?;
+            }
             fs::remove_file(&swapfile).context("Failed to remove swapfile")?;
             info!("Removed existing swapfile");
         }
@@ -2246,6 +2279,15 @@ impl<'a> Stage0<'a> {
         let swapvol_device_path = format!("/dev/zvol/{swapvol_path}");
 
         if Path::new(&swapvol_device_path).exists() {
+            let swapvol_device = Path::new(&swapvol_device_path);
+            if let Some(active_path) = Self::active_swap_path(swapvol_device)? {
+                let active_path = active_path.display().to_string();
+                info!("Disabling active swap zvol {active_path}");
+                cmd! {
+                    swapoff $active_path;
+                }
+                .context("Failed to disable existing swap zvol")?;
+            }
             cmd! {
                 zfs set volmode=none $swapvol_path;
                 zfs destroy $swapvol_path;

--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -2228,7 +2228,7 @@ impl<'a> Stage0<'a> {
                     .replace("\\134", "\\"),
             );
             if active_path == swap_path
-                || fs::canonicalize(&active_path).as_deref() == Ok(canonical_swap_path.as_path())
+                || fs::canonicalize(&active_path).is_ok_and(|path| path == canonical_swap_path)
             {
                 return Ok(Some(active_path));
             }


### PR DESCRIPTION
## Problem

The guest attempted to replace or format a swap device while it could still be active. The operation then failed with a busy device and could modify storage still used by the kernel.

## Root cause and fix

Disable swap and verify the device is inactive before replacement, then recreate and reactivate it through the normal flow.

## Implementation

The branch records the following focused implementation work:

- `fix(guest): disable active swap before replacement`
- `fix(guest): compare resolved swap paths safely`

Changed paths:

- `dstack/dstack-util/src/system_setup.rs`

## Scope

This PR addresses one logical `guest` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-guest-swap-replacement`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
