### PR TITLE
fix(guest): safely write attestation outputs

### DIFF
--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -395,7 +395,7 @@ fn cmd_quote_report(args: QuoteReportArgs) -> Result<()> {
     let json =
         serde_json::to_string_pretty(&request).context("Failed to serialize request JSON")?;
     if let Some(output_path) = args.output {
-        fs::write(&output_path, json).context("Failed to write quote report")?;
+        safe_write::safe_write(&output_path, json).context("Failed to write quote report")?;
     } else {
         println!("{json}");
     }
@@ -430,7 +430,7 @@ fn cmd_attest(args: AttestArgs) -> Result<()> {
     if args.hex {
         let encoded = hex::encode(&attestation);
         if let Some(output) = args.output {
-            fs::write(&output, encoded).context("Failed to write attestation hex")?;
+            safe_write::safe_write(&output, encoded).context("Failed to write attestation hex")?;
         } else {
             println!("{encoded}");
         }
@@ -440,7 +440,7 @@ fn cmd_attest(args: AttestArgs) -> Result<()> {
     let output = args
         .output
         .unwrap_or_else(|| PathBuf::from("attestation.bin"));
-    fs::write(&output, &attestation).context("Failed to write attestation sample")?;
+    safe_write::safe_write(&output, &attestation).context("Failed to write attestation sample")?;
     Ok(())
 }
 
@@ -531,7 +531,7 @@ fn cmd_attest_json(args: AttestJsonArgs) -> Result<()> {
 
     let output = serde_json::to_string_pretty(&json).context("Failed to serialize JSON")?;
     if let Some(path) = args.output {
-        fs::write(&path, output).context("Failed to write JSON output")?;
+        safe_write::safe_write(&path, output).context("Failed to write JSON output")?;
     } else {
         println!("{output}");
     }
@@ -549,7 +549,8 @@ fn cmd_attest_strip(args: AttestStripArgs) -> Result<()> {
     let output = args
         .output
         .unwrap_or_else(|| PathBuf::from("attestation.strip.bin"));
-    fs::write(&output, stripped.to_scale()?).context("Failed to write stripped attestation")?;
+    safe_write::safe_write(&output, stripped.to_scale()?)
+        .context("Failed to write stripped attestation")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Use the repository's existing `safe-write` dependency for attestation output files instead of maintaining another atomic-write implementation.

## Changes

- Write quote reports, encoded attestations, JSON attestations, and stripped attestations with `safe_write::safe_write`.
- Support text and binary output through the library's existing byte-oriented API.
- Remove the extra `dstack-cli-core` dependency and custom byte-write helpers from this PR.

## Verification

- `cargo check --manifest-path dstack/Cargo.toml -p dstack-util`
- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `git diff --check`
