### PR TITLE
fix(guest): safely write KMS key output

### DIFF
--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -644,7 +644,7 @@ async fn cmd_get_keys(args: GetKeysArgs) -> Result<()> {
     // Step 5: Output result
     let json = serde_json::to_string_pretty(&keys).context("Failed to serialize app keys")?;
     if let Some(output_path) = args.output {
-        fs::write(&output_path, &json).context("Failed to write app keys")?;
+        safe_write_with_mode(&output_path, &json, 0o600).context("Failed to write app keys")?;
         eprintln!("App keys written to: {}", output_path.display());
     } else {
         println!("{json}");


### PR DESCRIPTION
## Summary

Protect the KMS key output with the repository's existing `safe-write` dependency.

## Changes

- Replace the direct KMS key output write with `safe_write_with_mode(..., 0o600)`.
- Publish the complete file atomically.
- Set owner-only permissions when the temporary file is created, independently of the ambient umask.
- Avoid an additional dependency or local atomic-write implementation.

## Verification

- `cargo check --manifest-path dstack/Cargo.toml -p dstack-util`
- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `git diff --check`
