### PR TITLE
fix(guest-agent): reject inverted certificate validity

### DIFF
--- a/dstack/guest-agent/src/rpc_service.rs
+++ b/dstack/guest-agent/src/rpc_service.rs
@@ -269,8 +269,18 @@ pub async fn get_info(state: &AppState, external: bool) -> Result<AppInfo> {
     })
 }
 
+fn validate_cert_validity(not_before: Option<u64>, not_after: Option<u64>) -> Result<()> {
+    if let (Some(not_before), Some(not_after)) = (not_before, not_after) {
+        if not_before >= not_after {
+            anyhow::bail!("not_before must be earlier than not_after");
+        }
+    }
+    Ok(())
+}
+
 impl DstackGuestRpc for InternalRpcHandler {
     async fn get_tls_key(self, request: GetTlsKeyArgs) -> anyhow::Result<GetTlsKeyResponse> {
+        validate_cert_validity(request.not_before, request.not_after)?;
         let mut seed = [0u8; 32];
         SystemRandom::new()
             .fill(&mut seed)
@@ -1248,6 +1258,19 @@ pNs85uhOZE8z2jr8Pg==
 
         // Empty algorithm should default to secp256k1
         assert_eq!(resp_default.key, resp_secp.key);
+    }
+
+    #[test]
+    fn test_tls_certificate_validity_order() {
+        assert!(validate_cert_validity(None, None).is_ok());
+        assert!(validate_cert_validity(Some(10), Some(11)).is_ok());
+        assert_eq!(
+            validate_cert_validity(Some(11), Some(11))
+                .unwrap_err()
+                .to_string(),
+            "not_before must be earlier than not_after"
+        );
+        assert!(validate_cert_validity(Some(12), Some(11)).is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Certificate parsing did not reject `not_before > not_after`. Such a certificate can never be valid but was accepted into configuration and failed only when TLS attempted to use it.

## Root cause and fix

Validate validity ordering and reject every certificate whose end precedes its start.

## Implementation

The branch records the following focused implementation work:

- `fix(guest-agent): reject inverted certificate validity`

Changed paths:

- `dstack/guest-agent/src/rpc_service.rs`

## Scope

This PR addresses one logical `guest-agent` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-guest-agent-cert-validity`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
