### PR TITLE
fix(attest): commit event log after measurement

### DIFF
--- a/dstack/dstack-attest/src/lib.rs
+++ b/dstack/dstack-attest/src/lib.rs
@@ -150,8 +150,6 @@ pub fn emit_runtime_event(event: &str, payload: &[u8]) -> anyhow::Result<()> {
     let event = RuntimeEvent::new(event.to_string(), payload.to_vec(), version);
     let mode = detect_tee_variant()?;
 
-    event.emit().context("Failed to emit runtime event")?;
-
     if mode.has_tdx() {
         let digest = event.sha384_digest();
         let event_type = event.cc_event_type();
@@ -173,6 +171,11 @@ pub fn emit_runtime_event(event: &str, payload: &[u8]) -> anyhow::Result<()> {
             bank => anyhow::bail!("unsupported TPM PCR bank: {bank}"),
         }
     }
+
+    // Commit the userspace log only after the platform register accepted the
+    // measurement. A device failure must never leave an unmeasured event in
+    // the trusted replay log.
+    event.emit().context("Failed to emit runtime event")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

The event log was committed before the corresponding PCR/measurement operation succeeded. A crash or measurement error could leave a log claiming an event that was never measured.

## Root cause and fix

Complete the measurement first and append/publish its event-log entry only after success.

## Implementation

The branch records the following focused implementation work:

- `fix(attest): commit event log after measurement`

Changed paths:

- `dstack/dstack-attest/src/lib.rs`

## Scope

This PR addresses one logical `attest` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-attest-event-log-order`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
