### PR TITLE
fix(cert): reject mismatched CA keys

### DIFF
--- a/dstack/ra-tls/src/cert.rs
+++ b/dstack/ra-tls/src/cert.rs
@@ -45,6 +45,13 @@ impl CaCert {
     /// Instantiate a new CA certificate with a given private key and pem cert.
     pub fn new(pem_cert: String, pem_key: String) -> Result<Self> {
         let key = KeyPair::from_pem(&pem_key).context("Failed to parse key")?;
+        let (_, parsed_pem) = x509_parser::pem::parse_x509_pem(pem_cert.as_bytes())
+            .context("Failed to parse cert PEM")?;
+        let parsed_cert = parsed_pem.parse_x509().context("Failed to parse cert DER")?;
+        anyhow::ensure!(
+            parsed_cert.public_key().raw == key.public_key_der(),
+            "CA certificate does not match private key"
+        );
         let cert =
             CertificateParams::from_ca_cert_pem(&pem_cert).context("Failed to parse cert")?;
         // TODO: load the cert from the file directly, blocked by https://github.com/rustls/rcgen/issues/274

--- a/dstack/ra-tls/src/cert.rs
+++ b/dstack/ra-tls/src/cert.rs
@@ -47,7 +47,9 @@ impl CaCert {
         let key = KeyPair::from_pem(&pem_key).context("Failed to parse key")?;
         let (_, parsed_pem) = x509_parser::pem::parse_x509_pem(pem_cert.as_bytes())
             .context("Failed to parse cert PEM")?;
-        let parsed_cert = parsed_pem.parse_x509().context("Failed to parse cert DER")?;
+        let parsed_cert = parsed_pem
+            .parse_x509()
+            .context("Failed to parse cert DER")?;
         anyhow::ensure!(
             parsed_cert.public_key().raw == key.public_key_der(),
             "CA certificate does not match private key"


### PR DESCRIPTION
## Problem

Certificate tooling accepted a CA certificate and private key independently without proving they matched. It could issue leaves signed by a key that did not correspond to the advertised CA, so clients rejected the chain.

## Root cause and fix

Compare the derived public keys before signing and reject a mismatched CA certificate/key pair.

## Implementation

The branch records the following focused implementation work:

- `fix(cert): reject mismatched CA key`

Changed paths:

- `dstack/ra-tls/src/cert.rs`

## Scope

This PR addresses one logical `cert` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-ra-tls-ca-key-match`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
