### PR TITLE
feat(vmm-cli): separate environment encryption KMS URL

### DIFF
--- a/dstack/vmm/src/vmm-cli.py
+++ b/dstack/vmm/src/vmm-cli.py
@@ -925,9 +925,10 @@ class VmmCLI:
         app_id = args.app_id or self.calc_app_id(compose_content)
         print(f"App ID: {app_id}")
         if envs:
-            encrypt_pubkey = self.get_app_env_encrypt_pub_key(
-                app_id, args.kms_url[0] if args.kms_url else None
+            encrypt_url = args.kms_encrypt_url or (
+                args.kms_url[0] if args.kms_url else None
             )
+            encrypt_pubkey = self.get_app_env_encrypt_pub_key(app_id, encrypt_url)
             print(f"Encrypting environment variables with key: {encrypt_pubkey}")
             envs_list = [{"key": k, "value": v} for k, v in envs.items()]
             params["encrypted_env"] = encrypt_env(envs_list, encrypt_pubkey)
@@ -1791,6 +1792,11 @@ def main():
         "--hugepages", action="store_true", help="Enable hugepages for the VM"
     )
     deploy_parser.add_argument("--kms-url", action="append", type=str, help="KMS URL")
+    deploy_parser.add_argument(
+        "--kms-encrypt-url",
+        type=str,
+        help="Controller-reachable KMS URL used only to encrypt --env-file",
+    )
     deploy_parser.add_argument(
         "--gateway-url", action="append", type=str, help="Gateway URL"
     )


### PR DESCRIPTION
## Problem

VMM CLI reused the regular KMS URL for environment encryption. Deployments intentionally using a separate encryption KMS sent seal/unseal traffic to the wrong service.

## Root cause and fix

Add a dedicated environment-encryption KMS URL and use it only for the environment encryption path.

## Implementation

The branch records the following focused implementation work:

- `feat(vmm-cli): separate environment encryption KMS URL`

Changed paths:

- `dstack/vmm/src/vmm-cli.py`

## Scope

This PR addresses one logical `vmm-cli` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-cli-encryption-kms-url`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
