### PR TITLE
fix(os): omit nondeterministic package logs

### DIFF
--- a/os/mkosi/mkosi.postinst
+++ b/os/mkosi/mkosi.postinst
@@ -5,3 +5,9 @@ set -euo pipefail
 B=${BUILDROOT:?}
 rm -f "$B/etc/machine-id" "$B/var/lib/dbus/machine-id"
 : > "$B/etc/machine-id"
+
+# Package-manager logs contain wall-clock timestamps from image assembly.
+# They are build diagnostics, not guest runtime state, so omit them from the
+# measured image to keep clean builds reproducible.
+rm -f "$B/var/log/alternatives.log" "$B/var/log/dpkg.log"
+rm -rf "$B/var/log/apt"


### PR DESCRIPTION
## Problem

The mkosi final image retained package-manager logs containing timestamps and ordering-dependent data. Identical sources therefore produced different image bytes and measurements.

## Root cause and fix

Remove those nondeterministic logs during image finalization so reproducible inputs produce stable artifacts.

## Implementation

The branch records the following focused implementation work:

- `fix(os): omit nondeterministic package logs`

Changed paths:

- `os/mkosi/mkosi.postinst`

## Scope

This PR addresses one logical `os` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-os-deterministic-package-logs`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
