### PR TITLE
fix(simulator): reject occupied mountpoints

### DIFF
--- a/dstack/tee-simulator/src/main.rs
+++ b/dstack/tee-simulator/src/main.rs
@@ -72,6 +72,13 @@ fn run_backend<B: TeeBackend>(
             B::PLATFORM
         );
     }
+    if is_mounted(mountpoint)? {
+        bail!(
+            "refusing to mount the {} simulator over an existing mount at {}",
+            B::PLATFORM,
+            mountpoint.display()
+        );
+    }
     B::prepare_mountpoint(mountpoint)?;
 
     let fs = B::create_filesystem(config)?;
@@ -97,6 +104,31 @@ fn run_backend<B: TeeBackend>(
         .context("failed to notify systemd")?;
     session.run().context("fuse session failed")?;
     Ok(())
+}
+
+fn is_mounted(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let target = path
+        .canonicalize()
+        .with_context(|| format!("failed to resolve mountpoint {}", path.display()))?;
+    let mountinfo = fs_err::read_to_string("/proc/self/mountinfo")
+        .context("failed to read process mount table")?;
+    Ok(mountinfo.lines().any(|line| {
+        line.split_whitespace()
+            .nth(4)
+            .map(decode_mountinfo_path)
+            .is_some_and(|mounted| Path::new(&mounted) == target)
+    }))
+}
+
+fn decode_mountinfo_path(value: &str) -> String {
+    value
+        .replace(r"\134", "\\")
+        .replace(r"\040", " ")
+        .replace(r"\011", "\t")
+        .replace(r"\012", "\n")
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
## Problem

The simulator mounted its FUSE filesystem over a directory that could already contain files or be in use. Mounting hid existing contents and could expose simulator devices at an unintended location.

## Root cause and fix

Require the mountpoint to be empty and unoccupied before mounting; fail without changing it otherwise.

## Implementation

The branch records the following focused implementation work:

- `fix(simulator): reject occupied mountpoints`

Changed paths:

- `dstack/tee-simulator/src/main.rs`

## Scope

This PR addresses one logical `simulator` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-simulator-occupied-mountpoints`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
