### PR TITLE
[STACKED on #883] fix(util): stage certificate and key together

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "curve25519-dalek",
  "dcap-qvl",
  "dstack-attest",
+ "dstack-cli-core",
  "dstack-gateway-rpc",
  "dstack-kms-rpc",
  "dstack-types",

--- a/dstack/crates/dstack-cli-core/src/fsutil.rs
+++ b/dstack/crates/dstack-cli-core/src/fsutil.rs
@@ -79,6 +79,77 @@ fn write_atomic_inner(path: &Path, contents: &str, mode: Option<u32>) -> Result<
     Ok(())
 }
 
+
+/// Stage two related files completely before committing either destination.
+///
+/// This prevents a predictable second-output failure (for example, an invalid
+/// private-key directory) from leaving a certificate without its matching key.
+pub fn write_atomic_pair(
+    first_path: &Path,
+    first_contents: &[u8],
+    first_mode: Option<u32>,
+    second_path: &Path,
+    second_contents: &[u8],
+    second_mode: Option<u32>,
+) -> Result<()> {
+    anyhow::ensure!(first_path != second_path, "paired output paths must differ");
+    let first_tmp = stage_atomic(first_path, first_contents, first_mode)?;
+    let second_tmp = match stage_atomic(second_path, second_contents, second_mode) {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = std::fs::remove_file(&first_tmp);
+            return Err(error);
+        }
+    };
+    if let Err(error) = std::fs::rename(&first_tmp, first_path)
+        .with_context(|| format!("renaming {} -> {}", first_tmp.display(), first_path.display()))
+    {
+        let _ = std::fs::remove_file(&first_tmp);
+        let _ = std::fs::remove_file(&second_tmp);
+        return Err(error);
+    }
+    std::fs::rename(&second_tmp, second_path)
+        .with_context(|| format!("renaming {} -> {}", second_tmp.display(), second_path.display()))?;
+    sync_parent(first_path);
+    if first_path.parent() != second_path.parent() {
+        sync_parent(second_path);
+    }
+    Ok(())
+}
+
+fn stage_atomic(path: &Path, contents: &[u8], mode: Option<u32>) -> Result<PathBuf> {
+    let tmp = sibling(path, ".tmp");
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(mode);
+    }
+    let mut file = opts
+        .open(&tmp)
+        .with_context(|| format!("creating temp file {}", tmp.display()))?;
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(mode))
+            .with_context(|| format!("setting mode on {}", tmp.display()))?;
+    }
+    file.write_all(contents)
+        .with_context(|| format!("writing {}", tmp.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing {}", tmp.display()))?;
+    Ok(tmp)
+}
+
+fn sync_parent(path: &Path) {
+    if let Some(dir) = path.parent().filter(|dir| !dir.as_os_str().is_empty()) {
+        if let Ok(dir) = File::open(dir) {
+            let _ = dir.sync_all();
+        }
+    }
+}
+
 /// acquire an exclusive advisory lock tied to `path` (held on a sibling
 /// `.lock` file). The lock releases when the returned guard is dropped —
 /// including on process exit, so a crash never leaves a stale lock. Hold it

--- a/dstack/dstack-util/Cargo.toml
+++ b/dstack/dstack-util/Cargo.toml
@@ -46,6 +46,7 @@ toml.workspace = true
 dcap-qvl.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 dstack-types.workspace = true
+dstack-cli-core.workspace = true
 rand.workspace = true
 regorus.workspace = true
 sha3.workspace = true

--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -793,8 +793,10 @@ fn cmd_gen_ra_cert(args: GenRaCertArgs) -> Result<()> {
     let ca_cert = fs::read_to_string(args.ca_cert)?;
     let ca_key = fs::read_to_string(args.ca_key)?;
     let cert_pair = generate_ra_cert(ca_cert, ca_key)?;
-    fs::write(&args.cert_path, cert_pair.cert_pem).context("Failed to write certificate")?;
-    fs::write(&args.key_path, cert_pair.key_pem).context("Failed to write private key")?;
+    dstack_cli_core::fsutil::write_atomic(&args.cert_path, &cert_pair.cert_pem)
+        .context("Failed to write certificate")?;
+    dstack_cli_core::fsutil::write_atomic_mode(&args.key_path, &cert_pair.key_pem, 0o600)
+        .context("Failed to write private key")?;
     Ok(())
 }
 
@@ -819,8 +821,10 @@ fn cmd_gen_ca_cert(args: GenCaCertArgs) -> Result<()> {
     let cert = req
         .self_signed()
         .context("Failed to self-sign certificate")?;
-    fs::write(&args.cert, cert.pem()).context("Failed to write certificate")?;
-    fs::write(&args.key, key.serialize_pem()).context("Failed to write private key")?;
+    dstack_cli_core::fsutil::write_atomic(&args.cert, &cert.pem())
+        .context("Failed to write certificate")?;
+    dstack_cli_core::fsutil::write_atomic_mode(&args.key, &key.serialize_pem(), 0o600)
+        .context("Failed to write private key")?;
     Ok(())
 }
 
@@ -835,7 +839,8 @@ fn cmd_gen_app_keys(args: GenAppKeysArgs) -> Result<()> {
     };
     let app_keys = make_app_keys(&key, &disk_key, &k256_key, args.ca_level, key_provider)?;
     let app_keys = serde_json::to_string(&app_keys).context("Failed to serialize app keys")?;
-    fs::write(&args.output, app_keys).context("Failed to write app keys")?;
+    dstack_cli_core::fsutil::write_atomic_mode(&args.output, &app_keys, 0o600)
+        .context("Failed to write app keys")?;
     Ok(())
 }
 

--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -793,10 +793,15 @@ fn cmd_gen_ra_cert(args: GenRaCertArgs) -> Result<()> {
     let ca_cert = fs::read_to_string(args.ca_cert)?;
     let ca_key = fs::read_to_string(args.ca_key)?;
     let cert_pair = generate_ra_cert(ca_cert, ca_key)?;
-    dstack_cli_core::fsutil::write_atomic(&args.cert_path, &cert_pair.cert_pem)
-        .context("Failed to write certificate")?;
-    dstack_cli_core::fsutil::write_atomic_mode(&args.key_path, &cert_pair.key_pem, 0o600)
-        .context("Failed to write private key")?;
+    dstack_cli_core::fsutil::write_atomic_pair(
+        &args.cert_path,
+        cert_pair.cert_pem.as_bytes(),
+        None,
+        &args.key_path,
+        cert_pair.key_pem.as_bytes(),
+        Some(0o600),
+    )
+    .context("Failed to write certificate and private key")?;
     Ok(())
 }
 
@@ -821,10 +826,15 @@ fn cmd_gen_ca_cert(args: GenCaCertArgs) -> Result<()> {
     let cert = req
         .self_signed()
         .context("Failed to self-sign certificate")?;
-    dstack_cli_core::fsutil::write_atomic(&args.cert, &cert.pem())
-        .context("Failed to write certificate")?;
-    dstack_cli_core::fsutil::write_atomic_mode(&args.key, &key.serialize_pem(), 0o600)
-        .context("Failed to write private key")?;
+    dstack_cli_core::fsutil::write_atomic_pair(
+        &args.cert,
+        cert.pem().as_bytes(),
+        None,
+        &args.key,
+        key.serialize_pem().as_bytes(),
+        Some(0o600),
+    )
+    .context("Failed to write certificate and private key")?;
     Ok(())
 }
 


### PR DESCRIPTION
> **STACKED PR — merge #883 first.**

## Problem

Certificate and private key were replaced as separate writes. A crash or reader between the writes could observe a new certificate paired with the old key, causing TLS loading and handshakes to fail.

## Root cause and fix

Stage the matching certificate/key outputs together and publish the pair through an atomic commit sequence.

## Implementation

The branch records the following focused implementation work:

- `fix(util): stage certificate and key together`

Changed paths:

- `dstack/crates/dstack-cli-core/src/fsutil.rs`
- `dstack/dstack-util/src/main.rs`

## Scope

This PR addresses one logical `util` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #883
- GitHub base branch: `codex/fix-guest-atomic-credentials`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-guest-atomic-credentials..origin/codex/fix-util-atomic-cert-key`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
