### PR TITLE
fix(mkosi): generate volatile SSH host keys after preparation

### DIFF
--- a/os/mkosi/mkosi.postinst
+++ b/os/mkosi/mkosi.postinst
@@ -11,3 +11,7 @@ rm -f "$B/etc/machine-id" "$B/var/lib/dbus/machine-id"
 # measured image to keep clean builds reproducible.
 rm -f "$B/var/log/alternatives.log" "$B/var/log/dpkg.log"
 rm -rf "$B/var/log/apt"
+
+# Host keys must be unique per booted development VM, never shared by all
+# guests built from one image. OpenSSH generates them on first boot.
+rm -f "$B"/etc/ssh/ssh_host_*_key "$B"/etc/ssh/ssh_host_*_key.pub

--- a/os/mkosi/mkosi.skeleton/usr/lib/systemd/system/ssh.service.d/10-dstack-prepare.conf
+++ b/os/mkosi/mkosi.skeleton/usr/lib/systemd/system/ssh.service.d/10-dstack-prepare.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+[Unit]
+Requires=dstack-prepare.service
+After=dstack-prepare.service
+
+[Service]
+# Debian validates host keys before starting sshd. Generate the development
+# VM's volatile keys only after dstack-prepare has mounted the writable /etc
+# overlay, then run the package's original validation step.
+ExecStartPre=
+ExecStartPre=/usr/bin/ssh-keygen -A
+ExecStartPre=/usr/sbin/sshd -t


### PR DESCRIPTION
## Summary

Prevent development images from shipping one shared SSH host private key and generate volatile host keys after the writable `/etc` overlay is ready.

## Changes

- Remove image-build-time SSH host keys from the mkosi artifact.
- Add an independent `ssh.service` drop-in that requires and starts after `dstack-prepare.service`.
- Generate missing host keys with `ssh-keygen -A` after `dstack-prepare` mounts the writable `/etc` overlay.
- Preserve Debian's `sshd -t` validation before the daemon starts.

The mkosi development image intentionally has volatile `/etc` state, so these host keys are per boot. Production images do not install `openssh-server`.

## Verification

- The drop-in is installed under `/usr/lib/systemd/system/ssh.service.d/`, separate from the vendor unit.
- `git diff --check` passed.
