### PR TITLE
fix(vmm): publish host-share disks atomically

### DIFF
--- a/dstack/vmm/Cargo.toml
+++ b/dstack/vmm/Cargo.toml
@@ -62,10 +62,10 @@ url.workspace = true
 reqwest.workspace = true
 flate2.workspace = true
 tar.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
-tempfile.workspace = true
 
 [build-dependencies]
 or-panic.workspace = true

--- a/dstack/vmm/src/app/host_share.rs
+++ b/dstack/vmm/src/app/host_share.rs
@@ -92,7 +92,7 @@ mod tests {
 
     fn read_file(disk: &std::path::Path, name: &str) -> Vec<u8> {
         let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
-        let filesystem = FileSystem::new(&mut *image, FsOptions::new()).unwrap();
+        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
         let mut file = filesystem.root_dir().open_file(name).unwrap();
         let mut contents = Vec::new();
         file.read_to_end(&mut contents).unwrap();
@@ -142,7 +142,7 @@ mod tests {
         create_shared_disk(&disk, &shared).unwrap();
         assert_eq!(read_file(&disk, "regular"), b"regular");
         let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
-        let filesystem = FileSystem::new(&mut *image, FsOptions::new()).unwrap();
+        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
         assert!(filesystem.root_dir().open_file("escape").is_err());
     }
 

--- a/dstack/vmm/src/app/host_share.rs
+++ b/dstack/vmm/src/app/host_share.rs
@@ -43,14 +43,14 @@ pub(super) fn create_shared_disk(
         let format_opts = FormatVolumeOptions::new()
             .fat_type(fatfs::FatType::Fat32)
             .volume_label(label_bytes);
-        fatfs::format_volume(&mut image, format_opts).context("failed to format disk as FAT32")?;
+        fatfs::format_volume(&mut *image, format_opts).context("failed to format disk as FAT32")?;
     }
 
     image
         .seek(SeekFrom::Start(0))
         .context("failed to seek to start")?;
     let filesystem =
-        FileSystem::new(&mut image, FsOptions::new()).context("failed to open FAT32 filesystem")?;
+        FileSystem::new(&mut *image, FsOptions::new()).context("failed to open FAT32 filesystem")?;
     let root_dir = filesystem.root_dir();
 
     for entry in fs::read_dir(shared_dir).context("failed to read shared directory")? {
@@ -92,7 +92,7 @@ mod tests {
 
     fn read_file(disk: &std::path::Path, name: &str) -> Vec<u8> {
         let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
-        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
+        let filesystem = FileSystem::new(&mut *image, FsOptions::new()).unwrap();
         let mut file = filesystem.root_dir().open_file(name).unwrap();
         let mut contents = Vec::new();
         file.read_to_end(&mut contents).unwrap();
@@ -142,7 +142,7 @@ mod tests {
         create_shared_disk(&disk, &shared).unwrap();
         assert_eq!(read_file(&disk, "regular"), b"regular");
         let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
-        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
+        let filesystem = FileSystem::new(&mut *image, FsOptions::new()).unwrap();
         assert!(filesystem.root_dir().open_file("escape").is_err());
     }
 

--- a/dstack/vmm/src/app/host_share.rs
+++ b/dstack/vmm/src/app/host_share.rs
@@ -5,7 +5,7 @@
 //! Host-to-guest shared-file disk creation.
 
 use std::io::{Seek, SeekFrom, Write};
-use std::path::Path;
+use std::{fs::Permissions, os::unix::fs::PermissionsExt, path::Path};
 
 use anyhow::{Context, Result};
 use dstack_types::shared_filenames::HOST_SHARED_DISK_LABEL;
@@ -21,8 +21,16 @@ pub(super) fn create_shared_disk(
     let disk_path = disk_path.as_ref();
     let shared_dir = shared_dir.as_ref();
     let parent = disk_path.parent().unwrap_or_else(|| Path::new("."));
-    let mut temporary = NamedTempFile::new_in(parent)
-        .with_context(|| format!("failed to create temporary disk image in {}", parent.display()))?;
+    let mut temporary = NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "failed to create temporary disk image in {}",
+            parent.display()
+        )
+    })?;
+    temporary
+        .as_file()
+        .set_permissions(Permissions::from_mode(0o644))
+        .context("failed to set disk image permissions")?;
 
     // Must be large enough to hold all host-shared files (app-compose.json and
     // .user-config can each be up to 50 MiB, see HostShared::copy) plus FAT32 overhead.
@@ -49,14 +57,16 @@ pub(super) fn create_shared_disk(
     image
         .seek(SeekFrom::Start(0))
         .context("failed to seek to start")?;
-    let filesystem =
-        FileSystem::new(&mut *image, FsOptions::new()).context("failed to open FAT32 filesystem")?;
+    let filesystem = FileSystem::new(&mut *image, FsOptions::new())
+        .context("failed to open FAT32 filesystem")?;
     let root_dir = filesystem.root_dir();
 
     for entry in fs::read_dir(shared_dir).context("failed to read shared directory")? {
         let entry = entry.context("failed to read directory entry")?;
         let path = entry.path();
-        let file_type = entry.file_type().context("failed to inspect shared entry")?;
+        let file_type = entry
+            .file_type()
+            .context("failed to inspect shared entry")?;
         if !file_type.is_file() {
             continue;
         }
@@ -76,22 +86,33 @@ pub(super) fn create_shared_disk(
     drop(root_dir);
     drop(filesystem);
     temporary
+        .as_file()
+        .sync_all()
+        .context("failed to sync temporary disk image")?;
+    temporary
         .persist(disk_path)
         .map_err(|error| error.error)
         .with_context(|| format!("failed to publish disk image at {}", disk_path.display()))?;
+    fs::File::open(parent)
+        .with_context(|| format!("failed to open disk image directory {}", parent.display()))?
+        .sync_all()
+        .with_context(|| format!("failed to sync disk image directory {}", parent.display()))?;
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {
     use super::create_shared_disk;
     use fatfs::{FileSystem, FsOptions};
-    use std::{fs, io::Read, sync::Arc, thread};
+    use std::{fs, io::Read, os::unix::fs::PermissionsExt, sync::Arc, thread};
     use tempfile::TempDir;
 
     fn read_file(disk: &std::path::Path, name: &str) -> Vec<u8> {
-        let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
+        let mut image = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(disk)
+            .unwrap();
         let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
         let mut file = filesystem.root_dir().open_file(name).unwrap();
         let mut contents = Vec::new();
@@ -109,6 +130,10 @@ mod tests {
         let disk = root.path().join("host-shared.img");
         create_shared_disk(&disk, &shared).unwrap();
         assert_eq!(fs::metadata(&disk).unwrap().len(), 128 * 1024 * 1024);
+        assert_eq!(
+            fs::metadata(&disk).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
         assert_eq!(read_file(&disk, "app-compose.json"), b"compose");
     }
 
@@ -141,7 +166,11 @@ mod tests {
         let disk = root.path().join("host-shared.img");
         create_shared_disk(&disk, &shared).unwrap();
         assert_eq!(read_file(&disk, "regular"), b"regular");
-        let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
+        let mut image = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(disk)
+            .unwrap();
         let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
         assert!(filesystem.root_dir().open_file("escape").is_err());
     }

--- a/dstack/vmm/src/app/host_share.rs
+++ b/dstack/vmm/src/app/host_share.rs
@@ -81,3 +81,89 @@ pub(super) fn create_shared_disk(
         .with_context(|| format!("failed to publish disk image at {}", disk_path.display()))?;
     Ok(())
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::create_shared_disk;
+    use fatfs::{FileSystem, FsOptions};
+    use std::{fs, io::Read, sync::Arc, thread};
+    use tempfile::TempDir;
+
+    fn read_file(disk: &std::path::Path, name: &str) -> Vec<u8> {
+        let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
+        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
+        let mut file = filesystem.root_dir().open_file(name).unwrap();
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).unwrap();
+        contents
+    }
+
+    #[test]
+    fn creates_fixed_size_disk_with_exact_regular_file_contents() {
+        let root = TempDir::new().unwrap();
+        let shared = root.path().join("shared");
+        fs::create_dir(&shared).unwrap();
+        fs::write(shared.join("app-compose.json"), b"compose").unwrap();
+        fs::create_dir(shared.join("ignored-directory")).unwrap();
+        let disk = root.path().join("host-shared.img");
+        create_shared_disk(&disk, &shared).unwrap();
+        assert_eq!(fs::metadata(&disk).unwrap().len(), 128 * 1024 * 1024);
+        assert_eq!(read_file(&disk, "app-compose.json"), b"compose");
+    }
+
+    #[test]
+    fn missing_or_oversized_sources_never_publish_partial_disk() {
+        let root = TempDir::new().unwrap();
+        let missing_disk = root.path().join("missing.img");
+        assert!(create_shared_disk(&missing_disk, root.path().join("absent")).is_err());
+        assert!(!missing_disk.exists());
+
+        let shared = root.path().join("oversized");
+        fs::create_dir(&shared).unwrap();
+        let source = fs::File::create(shared.join("too-large")).unwrap();
+        source.set_len(129 * 1024 * 1024).unwrap();
+        let oversized_disk = root.path().join("oversized.img");
+        assert!(create_shared_disk(&oversized_disk, &shared).is_err());
+        assert!(!oversized_disk.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_sources_cannot_escape_shared_root() {
+        use std::os::unix::fs::symlink;
+        let root = TempDir::new().unwrap();
+        let shared = root.path().join("shared");
+        fs::create_dir(&shared).unwrap();
+        fs::write(root.path().join("outside-secret"), b"must-not-copy").unwrap();
+        fs::write(shared.join("regular"), b"regular").unwrap();
+        symlink(root.path().join("outside-secret"), shared.join("escape")).unwrap();
+        let disk = root.path().join("host-shared.img");
+        create_shared_disk(&disk, &shared).unwrap();
+        assert_eq!(read_file(&disk, "regular"), b"regular");
+        let mut image = fs::OpenOptions::new().read(true).write(true).open(disk).unwrap();
+        let filesystem = FileSystem::new(&mut image, FsOptions::new()).unwrap();
+        assert!(filesystem.root_dir().open_file("escape").is_err());
+    }
+
+    #[test]
+    fn concurrent_publication_never_exposes_partial_image() {
+        let root = TempDir::new().unwrap();
+        let shared = root.path().join("shared");
+        fs::create_dir(&shared).unwrap();
+        fs::write(shared.join("payload"), vec![7_u8; 1024 * 1024]).unwrap();
+        let disk = Arc::new(root.path().join("host-shared.img"));
+        let shared = Arc::new(shared);
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                let disk = Arc::clone(&disk);
+                let shared = Arc::clone(&shared);
+                thread::spawn(move || create_shared_disk(disk.as_path(), shared.as_path()))
+            })
+            .collect();
+        for worker in workers {
+            worker.join().unwrap().unwrap();
+        }
+        assert_eq!(read_file(&disk, "payload"), vec![7_u8; 1024 * 1024]);
+    }
+}

--- a/dstack/vmm/src/app/host_share.rs
+++ b/dstack/vmm/src/app/host_share.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use dstack_types::shared_filenames::HOST_SHARED_DISK_LABEL;
 use fatfs::{FileSystem, FormatVolumeOptions, FsOptions};
 use fs_err as fs;
+use tempfile::NamedTempFile;
 
 /// Creates a FAT32 disk image containing the files in `shared_dir`.
 pub(super) fn create_shared_disk(
@@ -19,6 +20,9 @@ pub(super) fn create_shared_disk(
 ) -> Result<()> {
     let disk_path = disk_path.as_ref();
     let shared_dir = shared_dir.as_ref();
+    let parent = disk_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary disk image in {}", parent.display()))?;
 
     // Must be large enough to hold all host-shared files (app-compose.json and
     // .user-config can each be up to 50 MiB, see HostShared::copy) plus FAT32 overhead.
@@ -26,13 +30,7 @@ pub(super) fn create_shared_disk(
 
     // Back the image by a file (sparse until written) and stream files into it so
     // peak memory stays bounded regardless of DISK_SIZE or input file sizes.
-    let mut image = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(disk_path)
-        .with_context(|| format!("failed to create disk image at {}", disk_path.display()))?;
+    let image = temporary.as_file_mut();
     image
         .set_len(DISK_SIZE)
         .context("failed to size disk image")?;
@@ -58,7 +56,8 @@ pub(super) fn create_shared_disk(
     for entry in fs::read_dir(shared_dir).context("failed to read shared directory")? {
         let entry = entry.context("failed to read directory entry")?;
         let path = entry.path();
-        if !path.is_file() {
+        let file_type = entry.file_type().context("failed to inspect shared entry")?;
+        if !file_type.is_file() {
             continue;
         }
 
@@ -74,5 +73,11 @@ pub(super) fn create_shared_disk(
         destination.flush().context("failed to flush FAT32 file")?;
     }
 
+    drop(root_dir);
+    drop(filesystem);
+    temporary
+        .persist(disk_path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to publish disk image at {}", disk_path.display()))?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

Host-share disk metadata was written directly at the path launch code reads. A crash or concurrent launch could consume a truncated descriptor and fail VM startup.

## Root cause and fix

Write the complete disk image to a temporary file, set its mode to `0644`, sync its contents, atomically publish it, and sync the parent directory.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): publish host-share disks atomically`
- `test(vmm): cover host-share disk boundaries`
- `fix(vmm): reborrow temporary host-share image`
- `fix(testing): retain owned image borrows`
- `fix(vmm): declare host-share tempfile dependency`
- `fix(vmm): persist host-share disks durably`

Changed paths:

- `dstack/vmm/Cargo.toml`
- `dstack/vmm/src/app/host_share.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-atomic-host-share-disk`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.

