### PR TITLE
fix(gateway): encrypt and validate persisted DNS credentials

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
 name = "dstack-gateway"
 version = "0.6.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "arc-swap",
  "base64 0.22.1",

--- a/dstack/gateway/Cargo.toml
+++ b/dstack/gateway/Cargo.toml
@@ -16,6 +16,7 @@ rocket = { workspace = true, features = ["mtls", "json"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
+aes-gcm.workspace = true
 serde = { workspace = true, features = ["derive"] }
 ipnet = { workspace = true, features = ["serde"] }
 fs-err.workspace = true

--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -328,6 +328,17 @@ impl AdminRpc for AdminRpcHandler {
     ) -> Result<DnsCredentialInfo> {
         let kv_store = self.state.kv_store();
 
+        validate_dns_credential_name(&request.name)?;
+        validate_cloudflare_secret(&request.cf_api_token)?;
+        validate_cloudflare_api_url(request.cf_api_url.as_deref())?;
+        if kv_store
+            .list_dns_credentials()
+            .iter()
+            .any(|credential| credential.name == request.name)
+        {
+            bail!("DNS credential name already exists");
+        }
+
         // Validate provider type
         let provider = match request.provider_type.as_str() {
             "cloudflare" => DnsProvider::Cloudflare {
@@ -373,18 +384,28 @@ impl AdminRpc for AdminRpcHandler {
             .get_dns_credential(&request.id)
             .context("dns credential not found")?;
 
-        // Update name if provided
+        // Update name if provided.
         if let Some(name) = request.name {
+            validate_dns_credential_name(&name)?;
+            if kv_store
+                .list_dns_credentials()
+                .iter()
+                .any(|credential| credential.id != request.id && credential.name == name)
+            {
+                bail!("DNS credential name already exists");
+            }
             cred.name = name;
         }
 
-        // Update provider fields if provided
+        // Update provider fields if provided.
         match &mut cred.provider {
             DnsProvider::Cloudflare { api_token, api_url } => {
                 if let Some(new_token) = request.cf_api_token {
+                    validate_cloudflare_secret(&new_token)?;
                     *api_token = new_token;
                 }
                 if let Some(new_url) = request.cf_api_url {
+                    validate_cloudflare_api_url(Some(&new_url))?;
                     *api_url = Some(new_url);
                 }
             }
@@ -781,6 +802,32 @@ fn dns_cred_to_proto(cred: DnsCredential) -> DnsCredentialInfo {
         dns_txt_ttl: Some(cred.dns_txt_ttl),
         max_dns_wait: Some(cred.max_dns_wait.as_secs() as u32),
     }
+}
+
+fn validate_dns_credential_name(name: &str) -> Result<()> {
+    let name = name.trim();
+    if name.is_empty() || name.len() > 128 {
+        bail!("DNS credential name must be between 1 and 128 bytes");
+    }
+    Ok(())
+}
+
+fn validate_cloudflare_secret(token: &str) -> Result<()> {
+    if token.trim().is_empty() {
+        bail!("Cloudflare API token must not be empty");
+    }
+    Ok(())
+}
+
+fn validate_cloudflare_api_url(api_url: Option<&str>) -> Result<()> {
+    let Some(api_url) = api_url else {
+        return Ok(());
+    };
+    let parsed = reqwest::Url::parse(api_url).context("invalid Cloudflare API URL")?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        bail!("Cloudflare API URL must use HTTP or HTTPS and include a host");
+    }
+    Ok(())
 }
 
 fn redact_token(token: &str) -> String {

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -37,7 +37,12 @@ use tracing::warn;
 
 use std::{collections::BTreeMap, net::Ipv4Addr, path::Path, time::Duration};
 
+use aes_gcm::{
+    aead::{Aead, Payload},
+    Aes256Gcm, KeyInit, Nonce,
+};
 use anyhow::{Context, Result};
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use wavekv::{node::NodeState, types::NodeId, Node};
@@ -187,6 +192,13 @@ pub struct DnsCredential {
     pub created_at: u64,
     /// Last update timestamp
     pub updated_at: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EncryptedDnsCredential {
+    version: u8,
+    nonce: [u8; 12],
+    ciphertext: Vec<u8>,
 }
 
 /// DNS provider configuration
@@ -450,6 +462,8 @@ pub struct KvStore {
     ephemeral: Node,
     /// This gateway's node ID
     my_node_id: NodeId,
+    /// Cluster-shared key used only for DNS credential envelopes.
+    dns_credential_key: [u8; 32],
 }
 
 impl KvStore {
@@ -458,6 +472,7 @@ impl KvStore {
         my_node_id: NodeId,
         peer_ids: Vec<NodeId>,
         data_dir: impl AsRef<Path>,
+        dns_credential_key: [u8; 32],
     ) -> Result<Self> {
         let persistent =
             Node::new_with_persistence(my_node_id, peer_ids.clone(), data_dir.as_ref())
@@ -479,6 +494,7 @@ impl KvStore {
             persistent,
             ephemeral,
             my_node_id,
+            dns_credential_key,
         })
     }
 
@@ -727,16 +743,68 @@ impl KvStore {
 
     // ==================== DNS Credential Management ====================
 
-    /// Get a DNS credential by ID
-    pub fn get_dns_credential(&self, cred_id: &str) -> Option<DnsCredential> {
-        self.persistent.read().decode(&keys::dns_cred(cred_id))
+    fn decrypt_dns_credential(&self, key: &str, bytes: &[u8]) -> Option<DnsCredential> {
+        if let Ok(envelope) = decode::<EncryptedDnsCredential>(bytes) {
+            if envelope.version != 1 {
+                warn!("unsupported DNS credential envelope version for key {key}");
+                return None;
+            }
+            let cipher = Aes256Gcm::new_from_slice(&self.dns_credential_key).ok()?;
+            let plaintext = cipher
+                .decrypt(
+                    Nonce::from_slice(&envelope.nonce),
+                    Payload {
+                        msg: &envelope.ciphertext,
+                        aad: key.as_bytes(),
+                    },
+                )
+                .map_err(|_| warn!("failed to decrypt DNS credential for key {key}"))
+                .ok()?;
+            return decode(&plaintext)
+                .map_err(|error| warn!("failed to decode DNS credential for key {key}: {error:?}"))
+                .ok();
+        }
+
+        // Compatibility with credentials written before envelope encryption.
+        // The next successful update rewrites the value using the encrypted format.
+        decode(bytes)
+            .map_err(|error| {
+                warn!("failed to decode legacy DNS credential for key {key}: {error:?}")
+            })
+            .ok()
     }
 
-    /// Save a DNS credential
+    /// Get a DNS credential by ID.
+    pub fn get_dns_credential(&self, cred_id: &str) -> Option<DnsCredential> {
+        let key = keys::dns_cred(cred_id);
+        let state = self.persistent.read();
+        let entry = state.get(&key)?;
+        self.decrypt_dns_credential(&key, entry.value.as_deref()?)
+    }
+
+    /// Save a DNS credential in an authenticated encrypted envelope.
     pub fn save_dns_credential(&self, cred: &DnsCredential) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::dns_cred(&cred.id), cred)?;
+        let key = keys::dns_cred(&cred.id);
+        let plaintext = encode(cred)?;
+        let cipher = Aes256Gcm::new_from_slice(&self.dns_credential_key)
+            .context("invalid DNS credential encryption key")?;
+        let mut nonce = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut nonce);
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: &plaintext,
+                    aad: key.as_bytes(),
+                },
+            )
+            .map_err(|_| anyhow::anyhow!("failed to encrypt DNS credential"))?;
+        let envelope = EncryptedDnsCredential {
+            version: 1,
+            nonce,
+            ciphertext,
+        };
+        self.persistent.write().put_encoded(key, &envelope)?;
         Ok(())
     }
 
@@ -748,9 +816,10 @@ impl KvStore {
 
     /// List all DNS credentials
     pub fn list_dns_credentials(&self) -> Vec<DnsCredential> {
-        self.persistent
-            .read()
-            .iter_decoded_values(keys::DNS_CRED_PREFIX)
+        let state = self.persistent.read();
+        state
+            .iter_by_prefix(keys::DNS_CRED_PREFIX)
+            .filter_map(|(key, entry)| self.decrypt_dns_credential(key, entry.value.as_deref()?))
             .collect()
     }
 

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -27,6 +27,7 @@ use rand::seq::IteratorRandom;
 use rinja::Template as _;
 use safe_write::safe_write;
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 use smallvec::{smallvec, SmallVec};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
@@ -151,9 +152,22 @@ impl ProxyInner {
         let config = Arc::new(config);
 
         // Initialize WaveKV store without peers (peers will be added dynamically from bootnode)
+        let dns_credential_key = sha2::Sha256::digest(
+            [
+                b"dstack-gateway:dns-credential:v1\0".as_slice(),
+                config.admin.auth_token.as_bytes(),
+            ]
+            .concat(),
+        )
+        .into();
         let kv_store = Arc::new(
-            KvStore::new(config.sync.node_id, vec![], &config.sync.data_dir)
-                .context("failed to initialize WaveKV store")?,
+            KvStore::new(
+                config.sync.node_id,
+                vec![],
+                &config.sync.data_dir,
+                dns_credential_key,
+            )
+            .context("failed to initialize WaveKV store")?,
         );
         info!(
             "WaveKV store initialized: node_id={}, sync_enabled={}",


### PR DESCRIPTION
## Problem

DNS provider credentials were persisted as unchecked plaintext/config data. Disk disclosure exposed the API secret, while corrupt records failed only during a later provider request.

## Root cause and fix

Encrypt credentials at rest and validate schema plus decryption before installing them into live DNS state.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): encrypt persisted DNS credentials`
- `fix(gateway): validate DNS credential inputs`
- `build(gateway): lock credential encryption dependency`

Changed paths:

- `dstack/Cargo.lock`
- `dstack/gateway/Cargo.toml`
- `dstack/gateway/src/admin_service.rs`
- `dstack/gateway/src/kv/mod.rs`
- `dstack/gateway/src/main_service.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-dns-credential-storage`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
