### PR TITLE
fix(gateway): reject mismatched certificate keys

### DIFF
--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -439,4 +439,35 @@ mod tests {
         // Should not resolve different domain
         assert!(!store.has_cert_for_sni("example.org"));
     }
+
+    #[test]
+    fn mismatched_key_update_retains_previous_certificate() {
+        let original = make_test_cert_data();
+        let mut mismatched = make_test_cert_data();
+        mismatched.cert_pem = original.cert_pem.clone();
+
+        let resolver = CertResolver::new();
+        resolver
+            .update_cert("example.com", &original)
+            .expect("failed to install original certificate");
+        let original_not_after = resolver
+            .get()
+            .get_cert_data("example.com")
+            .expect("original certificate missing")
+            .not_after;
+
+        let error = resolver
+            .update_cert("example.com", &mismatched)
+            .expect_err("mismatched key must be rejected");
+        assert!(error.to_string().contains("failed to parse certificate"));
+        assert_eq!(
+            resolver
+                .get()
+                .get_cert_data("example.com")
+                .expect("original certificate was lost")
+                .not_after,
+            original_not_after
+        );
+        assert!(resolver.get().has_cert_for_sni("app.example.com"));
+    }
 }

--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -291,7 +291,11 @@ fn parse_certified_key(cert_pem: &str, key_pem: &str) -> Result<CertifiedKey> {
     let signing_key = rustls::crypto::aws_lc_rs::sign::any_supported_type(&key)
         .map_err(|e| anyhow::anyhow!("failed to create signing key: {:?}", e))?;
 
-    Ok(CertifiedKey::new(certs, signing_key))
+    let certified_key = CertifiedKey::new(certs, signing_key);
+    certified_key
+        .keys_match()
+        .context("certificate and private key do not match")?;
+    Ok(certified_key)
 }
 
 /// Format expiry timestamp as human-readable string


### PR DESCRIPTION
## Problem

Gateway loaded a certificate and private key without checking that their public keys matched. Reload appeared accepted, but the TLS listener then failed to use the identity.

## Root cause and fix

Compare the public keys before publication and reject mismatched certificate/key material.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): reject mismatched certificate keys`
- `test(gateway): retain cert on mismatched hot reload`

Changed paths:

- `dstack/gateway/src/cert_store.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-cert-key-match`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
