### PR TITLE
fix(gateway): reject registration identity collisions

### DIFF
--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -944,7 +944,18 @@ impl ProxyState {
         if public_key.is_empty() {
             bail!("public_key is empty");
         }
+        if self
+            .state
+            .instances
+            .values()
+            .any(|instance| instance.id != id && instance.public_key == public_key)
+        {
+            bail!("WireGuard public key is already registered to another instance");
+        }
         if let Some(existing) = self.state.instances.get_mut(id) {
+            if existing.app_id != app_id {
+                bail!("instance_id is already registered to a different app");
+            }
             let pubkey_changed = existing.public_key != public_key;
             if pubkey_changed {
                 info!("public key changed for instance {id}, new key: {public_key}");


### PR DESCRIPTION
## Problem

Two registrations could claim the same application/instance identity with different credentials or endpoints. Gateway overwrote or collided state rather than exposing the conflict.

## Root cause and fix

Check the existing identity binding and reject a claim already owned by different registration state.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): reject registration identity collisions`

Changed paths:

- `dstack/gateway/src/main_service.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-registration-collisions`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
