### PR TITLE
fix(gateway): publish debug keys safely

### DIFF
--- a/dstack/gateway/src/gen_debug_key.rs
+++ b/dstack/gateway/src/gen_debug_key.rs
@@ -165,7 +165,8 @@ mod tests {
         barrier.wait();
         let successes = workers
             .into_iter()
-            .filter(|worker| worker.join().unwrap())
+            .map(|worker| worker.join().unwrap())
+            .filter(|succeeded| *succeeded)
             .count();
         assert_eq!(successes, 1);
         assert!(fs::read_to_string(&concurrent).unwrap().starts_with("row-"));

--- a/dstack/gateway/src/gen_debug_key.rs
+++ b/dstack/gateway/src/gen_debug_key.rs
@@ -6,15 +6,18 @@
 // Example: cargo run --bin gen_debug_key -- https://daee134c3b9f66aa2401c3b5ea64f1d34038f45d-3000.tdxlab.dstack.org:12004
 
 use anyhow::{Context, Result};
-use base64::{engine::general_purpose::STANDARD, Engine as _};
-use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, RawQuoteArgs};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use dstack_guest_agent_rpc::{RawQuoteArgs, dstack_guest_client::DstackGuestClient};
 use http_client::prpc::PrpcClient;
 use ra_tls::attestation::QuoteContentType;
 use ra_tls::rcgen::KeyPair;
 use serde::{Deserialize, Serialize};
+use std::{fs::OpenOptions, io::Write as _, path::Path};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DebugKeyData {
+    /// This artifact is accepted only by the explicit insecure debug path.
+    debug_only: bool,
     /// Private key in PEM format
     key_pem: String,
     /// TDX quote in base64 format
@@ -25,12 +28,49 @@ struct DebugKeyData {
     vm_config: String,
 }
 
+fn write_new_debug_key(path: &Path, content: &[u8]) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs_err::create_dir_all(parent).context("Failed to create debug key directory")?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Debug key output path has no UTF-8 file name")?;
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    use std::os::unix::fs::OpenOptionsExt as _;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let result = (|| -> Result<()> {
+        let mut output = options
+            .open(&temporary)
+            .context("Failed to create private debug key temporary file")?;
+        output
+            .write_all(content)
+            .context("Failed to write private debug key temporary file")?;
+        output
+            .sync_all()
+            .context("Failed to sync private debug key temporary file")?;
+        drop(output);
+        fs_err::hard_link(&temporary, path)
+            .context("Refusing to overwrite existing debug key file")?;
+        Ok(())
+    })();
+    let _ = fs_err::remove_file(&temporary);
+    result
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 2 {
         eprintln!("Usage: {} <simulator_url>", args[0]);
-        eprintln!("Example: {} https://daee134c3b9f66aa2401c3b5ea64f1d34038f45d-3000.tdxlab.dstack.org:12004", args[0]);
+        eprintln!(
+            "Example: {} https://daee134c3b9f66aa2401c3b5ea64f1d34038f45d-3000.tdxlab.dstack.org:12004",
+            args[0]
+        );
         std::process::exit(1);
     }
     let simulator_url = &args[1];
@@ -56,6 +96,7 @@ async fn main() -> Result<()> {
 
     // Create debug key data structure
     let debug_data = DebugKeyData {
+        debug_only: true,
         key_pem,
         quote_base64: STANDARD.encode(&quote_response.quote),
         event_log: quote_response.event_log,
@@ -66,7 +107,8 @@ async fn main() -> Result<()> {
     let json_content =
         serde_json::to_string_pretty(&debug_data).context("Failed to serialize debug key data")?;
     let output_file = "debug_key.json";
-    fs_err::write(output_file, json_content).context("Failed to write debug key file")?;
+    write_new_debug_key(Path::new(output_file), json_content.as_bytes())
+        .context("Failed to publish debug key file")?;
 
     println!("✓ Successfully generated debug key data:");
     println!("  - {output_file}");
@@ -81,4 +123,58 @@ async fn main() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_new_debug_key;
+    use std::{
+        fs,
+        sync::{Arc, Barrier},
+    };
+
+    #[test]
+    fn debug_key_artifact_safety_matrix() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = directory.path().join("debug_key.json");
+        write_new_debug_key(&output, br#"{"debug_only":true}"#).unwrap();
+        assert_eq!(fs::read(&output).unwrap(), br#"{"debug_only":true}"#);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                fs::metadata(&output).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        assert!(write_new_debug_key(&output, b"replacement").is_err());
+        assert_eq!(fs::read(&output).unwrap(), br#"{"debug_only":true}"#);
+
+        let concurrent = directory.path().join("concurrent.json");
+        let barrier = Arc::new(Barrier::new(9));
+        let workers: Vec<_> = (0..8)
+            .map(|index| {
+                let barrier = barrier.clone();
+                let concurrent = concurrent.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    write_new_debug_key(&concurrent, format!("row-{index}").as_bytes()).is_ok()
+                })
+            })
+            .collect();
+        barrier.wait();
+        let successes = workers
+            .into_iter()
+            .filter(|worker| worker.join().unwrap())
+            .count();
+        assert_eq!(successes, 1);
+        assert!(fs::read_to_string(&concurrent).unwrap().starts_with("row-"));
+        assert!(fs::read_dir(directory.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")
+        }));
+    }
 }

--- a/dstack/gateway/src/gen_debug_key.rs
+++ b/dstack/gateway/src/gen_debug_key.rs
@@ -6,8 +6,8 @@
 // Example: cargo run --bin gen_debug_key -- https://daee134c3b9f66aa2401c3b5ea64f1d34038f45d-3000.tdxlab.dstack.org:12004
 
 use anyhow::{Context, Result};
-use base64::{Engine as _, engine::general_purpose::STANDARD};
-use dstack_guest_agent_rpc::{RawQuoteArgs, dstack_guest_client::DstackGuestClient};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, RawQuoteArgs};
 use http_client::prpc::PrpcClient;
 use ra_tls::attestation::QuoteContentType;
 use ra_tls::rcgen::KeyPair;

--- a/dstack/gateway/src/main.rs
+++ b/dstack/gateway/src/main.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context, Result};
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use anyhow::{Context, Result, anyhow};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use clap::Parser;
 use config::{Config, TlsConfig};
-use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, GetTlsKeyArgs};
+use dstack_guest_agent_rpc::{GetTlsKeyArgs, dstack_guest_client::DstackGuestClient};
 use dstack_kms_rpc::SignCertRequest;
 use http_client::prpc::PrpcClient;
 use ra_rpc::{client::RaClient, prpc_routes as prpc, rocket_helper::QuoteVerifier};
@@ -17,7 +17,7 @@ use ra_tls::{
 };
 use rocket::{
     fairing::AdHoc,
-    figment::{providers::Serialized, Figment},
+    figment::{Figment, providers::Serialized},
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -43,6 +43,8 @@ mod web_routes;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DebugKeyData {
+    /// This artifact is accepted only by the explicit insecure debug path.
+    debug_only: bool,
     /// Private key in PEM format
     key_pem: String,
     /// TDX quote in base64 format
@@ -70,7 +72,7 @@ struct Args {
 
 #[cfg(unix)]
 fn set_max_ulimit() -> Result<()> {
-    use nix::sys::resource::{getrlimit, setrlimit, Resource};
+    use nix::sys::resource::{Resource, getrlimit, setrlimit};
     let (soft, hard) = getrlimit(Resource::RLIMIT_NOFILE)?;
     if soft < hard {
         setrlimit(Resource::RLIMIT_NOFILE, hard, hard)?;
@@ -157,6 +159,10 @@ async fn gen_debug_certs(
     let json_content = fs_err::read_to_string(&config.debug.key_file).context(ctx)?;
     let debug_data: DebugKeyData =
         serde_json::from_str(&json_content).context("Failed to parse debug key JSON")?;
+    anyhow::ensure!(
+        debug_data.debug_only,
+        "Refusing to consume an artifact that is not explicitly labeled debug_only"
+    );
 
     let key_pem = debug_data.key_pem;
     let quote_bin = STANDARD
@@ -230,7 +236,7 @@ fn write_cert(path: &str, cert: &str) -> Result<()> {
 #[rocket::main]
 async fn main() -> Result<()> {
     {
-        use tracing_subscriber::{fmt, EnvFilter};
+        use tracing_subscriber::{EnvFilter, fmt};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }

--- a/dstack/gateway/src/main.rs
+++ b/dstack/gateway/src/main.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, anyhow};
-use base64::{Engine as _, engine::general_purpose::STANDARD};
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Parser;
 use config::{Config, TlsConfig};
-use dstack_guest_agent_rpc::{GetTlsKeyArgs, dstack_guest_client::DstackGuestClient};
+use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, GetTlsKeyArgs};
 use dstack_kms_rpc::SignCertRequest;
 use http_client::prpc::PrpcClient;
 use ra_rpc::{client::RaClient, prpc_routes as prpc, rocket_helper::QuoteVerifier};
@@ -17,7 +17,7 @@ use ra_tls::{
 };
 use rocket::{
     fairing::AdHoc,
-    figment::{Figment, providers::Serialized},
+    figment::{providers::Serialized, Figment},
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -72,7 +72,7 @@ struct Args {
 
 #[cfg(unix)]
 fn set_max_ulimit() -> Result<()> {
-    use nix::sys::resource::{Resource, getrlimit, setrlimit};
+    use nix::sys::resource::{getrlimit, setrlimit, Resource};
     let (soft, hard) = getrlimit(Resource::RLIMIT_NOFILE)?;
     if soft < hard {
         setrlimit(Resource::RLIMIT_NOFILE, hard, hard)?;
@@ -236,7 +236,7 @@ fn write_cert(path: &str, cert: &str) -> Result<()> {
 #[rocket::main]
 async fn main() -> Result<()> {
     {
-        use tracing_subscriber::{EnvFilter, fmt};
+        use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }


### PR DESCRIPTION
## Problem

Gateway debug keys were written in place with ambient permissions. Readers could observe partial content and unintended local users could read the key.

## Root cause and fix

Publish the complete key atomically with explicit restrictive permissions.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): publish debug keys safely`
- `fix(test): consume debug key workers`

Changed paths:

- `dstack/gateway/src/gen_debug_key.rs`
- `dstack/gateway/src/main.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-debug-key-publication`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
