### PR TITLE
feat(gateway): configure app-address DNS resolution

### DIFF
--- a/dstack/gateway/src/config.rs
+++ b/dstack/gateway/src/config.rs
@@ -178,10 +178,10 @@ pub struct ProxyConfig {
     pub cert_key: Option<PathBuf>,
     pub app_address_ns_prefix: String,
     pub app_address_ns_compat: bool,
-    /// Optional dedicated DNS server for app-address TXT lookups.
-    /// The system resolver is used when this is not configured.
+    /// Dedicated DNS servers for app-address TXT lookups.
+    /// The system resolver is used when this list is empty.
     #[serde(default)]
-    pub app_address_dns_server: Option<SocketAddr>,
+    pub app_address_dns_servers: Vec<SocketAddr>,
     /// Maximum concurrent connections per app. 0 means unlimited.
     pub max_connections_per_app: u64,
     /// Port the dstack guest-agent listens on inside each CVM. Used by the

--- a/dstack/gateway/src/config.rs
+++ b/dstack/gateway/src/config.rs
@@ -9,7 +9,7 @@ use ipnet::Ipv4Net;
 use load_config::load_config;
 use rocket::figment::Figment;
 use serde::{Deserialize, Serialize};
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tracing::info;
@@ -178,6 +178,10 @@ pub struct ProxyConfig {
     pub cert_key: Option<PathBuf>,
     pub app_address_ns_prefix: String,
     pub app_address_ns_compat: bool,
+    /// Optional dedicated DNS server for app-address TXT lookups.
+    /// The system resolver is used when this is not configured.
+    #[serde(default)]
+    pub app_address_dns_server: Option<SocketAddr>,
     /// Maximum concurrent connections per app. 0 means unlimited.
     pub max_connections_per_app: u64,
     /// Port the dstack guest-agent listens on inside each CVM. Used by the

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -323,7 +323,7 @@ impl ProxyInner {
             AppAddressResolver::new(
                 config.proxy.app_address_ns_prefix.clone(),
                 config.proxy.app_address_ns_compat,
-                config.proxy.app_address_dns_server,
+                config.proxy.app_address_dns_servers.clone(),
             )
             .context("failed to create app address resolver")?,
         );

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -323,6 +323,7 @@ impl ProxyInner {
             AppAddressResolver::new(
                 config.proxy.app_address_ns_prefix.clone(),
                 config.proxy.app_address_ns_compat,
+                config.proxy.app_address_dns_server,
             )
             .context("failed to create app address resolver")?,
         );

--- a/dstack/gateway/src/proxy/tls_passthough.rs
+++ b/dstack/gateway/src/proxy/tls_passthough.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
+use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
@@ -10,6 +11,8 @@ use anyhow::{bail, Context, Result};
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::TokioResolver;
+use hickory_resolver::config::{NameServerConfig, ResolverConfig};
+use hickory_resolver::name_server::TokioConnectionProvider;
 use proxy_protocol::ProxyHeader;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinSet, time::timeout};
 use tracing::{debug, info, warn};
@@ -59,11 +62,15 @@ pub(crate) struct AppAddressResolver {
 }
 
 impl AppAddressResolver {
-    pub(crate) fn new(prefix: String, compat: bool) -> Result<Self> {
+    pub(crate) fn new(
+        prefix: String,
+        compat: bool,
+        dns_server: Option<SocketAddr>,
+    ) -> Result<Self> {
         Ok(Self {
             prefix,
             compat,
-            resolver: app_address_tokio_resolver_from_system_conf()?,
+            resolver: app_address_tokio_resolver(dns_server)?,
         })
     }
 
@@ -72,8 +79,19 @@ impl AppAddressResolver {
     }
 }
 
-fn app_address_tokio_resolver_from_system_conf() -> Result<TokioResolver> {
-    let mut builder = TokioResolver::builder_tokio().context("failed to read system dns config")?;
+fn app_address_tokio_resolver(dns_server: Option<SocketAddr>) -> Result<TokioResolver> {
+    let mut builder = if let Some(dns_server) = dns_server {
+        let mut name_server = NameServerConfig::udp_and_tcp(dns_server.ip());
+        for connection in &mut name_server.connections {
+            connection.port = dns_server.port();
+        }
+        TokioResolver::builder_with_config(
+            ResolverConfig::from_parts(None, Vec::new(), vec![name_server]),
+            TokioConnectionProvider::default(),
+        )
+    } else {
+        TokioResolver::builder_tokio().context("failed to read system dns config")?
+    };
 
     // App-address records may appear shortly after a CVM/app is registered.
     // Reusing one resolver enables positive TXT caching, but we do not want a
@@ -317,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_app_address() -> Result<()> {
-        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false)?;
+        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false, None)?;
         let app_addr = resolver
             .resolve("3327603e03f5bd1f830812ca4a789277fc31f577.app.dstack.org")
             .await?;

--- a/dstack/gateway/src/proxy/tls_passthough.rs
+++ b/dstack/gateway/src/proxy/tls_passthough.rs
@@ -8,11 +8,11 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use hickory_resolver::config::{NameServerConfig, ResolverConfig};
 use hickory_resolver::lookup::Lookup;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::TokioResolver;
-use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use proxy_protocol::ProxyHeader;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinSet, time::timeout};
 use tracing::{debug, info, warn};
@@ -62,15 +62,11 @@ pub(crate) struct AppAddressResolver {
 }
 
 impl AppAddressResolver {
-    pub(crate) fn new(
-        prefix: String,
-        compat: bool,
-        dns_server: Option<SocketAddr>,
-    ) -> Result<Self> {
+    pub(crate) fn new(prefix: String, compat: bool, dns_servers: Vec<SocketAddr>) -> Result<Self> {
         Ok(Self {
             prefix,
             compat,
-            resolver: app_address_tokio_resolver(dns_server)?,
+            resolver: app_address_tokio_resolver(dns_servers)?,
         })
     }
 
@@ -79,18 +75,24 @@ impl AppAddressResolver {
     }
 }
 
-fn app_address_tokio_resolver(dns_server: Option<SocketAddr>) -> Result<TokioResolver> {
-    let mut builder = if let Some(dns_server) = dns_server {
-        let mut name_server = NameServerConfig::udp_and_tcp(dns_server.ip());
-        for connection in &mut name_server.connections {
-            connection.port = dns_server.port();
-        }
+fn app_address_tokio_resolver(dns_servers: Vec<SocketAddr>) -> Result<TokioResolver> {
+    let mut builder = if dns_servers.is_empty() {
+        TokioResolver::builder_tokio().context("failed to read system dns config")?
+    } else {
+        let name_servers = dns_servers
+            .into_iter()
+            .map(|dns_server| {
+                let mut name_server = NameServerConfig::udp_and_tcp(dns_server.ip());
+                for connection in &mut name_server.connections {
+                    connection.port = dns_server.port();
+                }
+                name_server
+            })
+            .collect();
         TokioResolver::builder_with_config(
-            ResolverConfig::from_parts(None, Vec::new(), vec![name_server]),
+            ResolverConfig::from_parts(None, Vec::new(), name_servers),
             TokioRuntimeProvider::default(),
         )
-    } else {
-        TokioResolver::builder_tokio().context("failed to read system dns config")?
     };
 
     // App-address records may appear shortly after a CVM/app is registered.
@@ -335,7 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_app_address() -> Result<()> {
-        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false, None)?;
+        let resolver = AppAddressResolver::new("_dstack-app-address".to_string(), false, vec![])?;
         let app_addr = resolver
             .resolve("3327603e03f5bd1f830812ca4a789277fc31f577.app.dstack.org")
             .await?;

--- a/dstack/gateway/src/proxy/tls_passthough.rs
+++ b/dstack/gateway/src/proxy/tls_passthough.rs
@@ -12,7 +12,7 @@ use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::TokioResolver;
 use hickory_resolver::config::{NameServerConfig, ResolverConfig};
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use proxy_protocol::ProxyHeader;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinSet, time::timeout};
 use tracing::{debug, info, warn};
@@ -87,7 +87,7 @@ fn app_address_tokio_resolver(dns_server: Option<SocketAddr>) -> Result<TokioRes
         }
         TokioResolver::builder_with_config(
             ResolverConfig::from_parts(None, Vec::new(), vec![name_server]),
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         )
     } else {
         TokioResolver::builder_tokio().context("failed to read system dns config")?


### PR DESCRIPTION
## Problem

App-address DNS resolution was fixed to the existing/default scheme and could not be configured for deployments using another resolver/domain arrangement. Valid app addresses therefore remained unresolvable through Gateway.

## Root cause and fix

Add explicit multi-server app-address DNS configuration and use it when constructing/resolving application names.

## Implementation

The branch records the following focused implementation work:

- `feat(gateway): configure app-address DNS servers`
- `fix(gateway): use public DNS runtime provider`

Changed paths:

- `dstack/gateway/src/config.rs`
- `dstack/gateway/src/main_service.rs`
- `dstack/gateway/src/proxy/tls_passthough.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/feat-gateway-app-address-dns`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.