### PR TITLE
fix(certbot): pace and stop the daemon cleanly

### DIFF
--- a/dstack/certbot/cli/src/main.rs
+++ b/dstack/certbot/cli/src/main.rs
@@ -154,8 +154,26 @@ async fn renew(config: &PathBuf, once: bool, force: bool) -> Result<()> {
     if once {
         bot.renew_and_run_hook(force).await?;
     } else {
-        bot.run().await;
+        tokio::select! {
+            _ = bot.run() => unreachable!("certbot daemon returned"),
+            result = shutdown_signal() => result?,
+        }
     }
+    Ok(())
+}
+
+async fn shutdown_signal() -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result?,
+            _ = terminate.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    tokio::signal::ctrl_c().await?;
     Ok(())
 }
 

--- a/dstack/certbot/cli/src/main.rs
+++ b/dstack/certbot/cli/src/main.rs
@@ -180,7 +180,7 @@ async fn shutdown_signal() -> Result<()> {
 #[tokio::main]
 async fn main() -> Result<()> {
     {
-        use tracing_subscriber::{EnvFilter, fmt};
+        use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }

--- a/dstack/certbot/cli/src/main.rs
+++ b/dstack/certbot/cli/src/main.rs
@@ -152,7 +152,7 @@ async fn renew(config: &PathBuf, once: bool, force: bool) -> Result<()> {
         .await
         .context("Failed to build bot")?;
     if once {
-        bot.renew(force).await?;
+        bot.renew_and_run_hook(force).await?;
     } else {
         bot.run().await;
     }
@@ -162,7 +162,7 @@ async fn renew(config: &PathBuf, once: bool, force: bool) -> Result<()> {
 #[tokio::main]
 async fn main() -> Result<()> {
     {
-        use tracing_subscriber::{fmt, EnvFilter};
+        use tracing_subscriber::{EnvFilter, fmt};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }

--- a/dstack/certbot/src/bot.rs
+++ b/dstack/certbot/src/bot.rs
@@ -149,35 +149,33 @@ impl CertBot {
     /// Run the certbot.
     pub async fn run(&self) {
         loop {
-            match self.renew(false).await {
-                Ok(renewed) => {
-                    if !renewed {
-                        continue;
-                    }
-                    if let Some(hook) = &self.config.renewed_hook {
-                        info!("running renewed hook");
-                        let result = std::process::Command::new("/bin/sh")
-                            .arg("-c")
-                            .arg(hook)
-                            .status();
-                        match result {
-                            Ok(status) => {
-                                if !status.success() {
-                                    error!("renewed hook failed with status: {status}");
-                                }
-                            }
-                            Err(err) => {
-                                error!("failed to run renewed hook: {err:?}");
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("failed to run certbot: {e:?}");
-                }
+            if let Err(error) = self.renew_and_run_hook(false).await {
+                error!("failed to run certbot: {error:?}");
             }
             sleep(self.config.renew_interval).await;
         }
+    }
+
+    /// Run one renewal attempt and invoke the configured hook after a commit.
+    pub async fn renew_and_run_hook(&self, force: bool) -> Result<bool> {
+        let renewed = self.renew(force).await?;
+        if !renewed {
+            return Ok(false);
+        }
+        let Some(hook) = &self.config.renewed_hook else {
+            return Ok(true);
+        };
+        info!("running renewed hook");
+        match std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(hook)
+            .status()
+        {
+            Ok(status) if status.success() => {}
+            Ok(status) => error!("renewed hook failed with status: {status}"),
+            Err(error) => error!("failed to run renewed hook: {error:?}"),
+        }
+        Ok(true)
     }
 
     /// Run the certbot once.


### PR DESCRIPTION
## Problem

Certbot loop retries could run without proper pacing and shutdown did not interrupt the wait/work cleanly. This caused provider request bursts and delayed process termination.

## Root cause and fix

Apply the configured interval through an interruptible wait and honor shutdown before starting another reconciliation.

## Implementation

The branch records the following focused implementation work:

- `fix(certbot): pace daemon and run once hook`
- `fix(certbot): stop daemon gracefully`

Changed paths:

- `dstack/certbot/cli/src/main.rs`
- `dstack/certbot/src/bot.rs`

## Scope

This PR addresses one logical `certbot` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-certbot-daemon-lifecycle`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
