### PR TITLE
fix(ra-rpc): accept empty JSON unit responses

### DIFF
--- a/dstack/ra-rpc/src/client.rs
+++ b/dstack/ra-rpc/src/client.rs
@@ -173,6 +173,34 @@ impl RaClient {
     }
 }
 
+fn normalize_json_response_body(body: &[u8]) -> &[u8] {
+    if body.is_empty() {
+        b"null"
+    } else {
+        body
+    }
+}
+
+#[cfg(test)]
+mod response_tests {
+    use super::normalize_json_response_body;
+
+    #[test]
+    fn empty_json_response_decodes_as_unit() {
+        let value: () = serde_json::from_slice(normalize_json_response_body(b""))
+            .expect("empty response should decode as unit");
+        assert_eq!(value, ());
+    }
+
+    #[test]
+    fn non_empty_json_response_is_unchanged() {
+        assert_eq!(
+            normalize_json_response_body(br#"{"value":1}"#),
+            br#"{"value":1}"#
+        );
+    }
+}
+
 impl RequestClient for RaClient {
     async fn request<T, R>(&self, path: &str, body: T) -> Result<R, Error>
     where
@@ -211,7 +239,8 @@ impl RequestClient for RaClient {
             .await
             .context("Failed to read response")?
             .to_vec();
-        let response = serde_json::from_slice(&body).context("Failed to deserialize response")?;
+        let response = serde_json::from_slice(normalize_json_response_body(&body))
+            .context("Failed to deserialize response")?;
         Ok(response)
     }
 }


### PR DESCRIPTION
## Problem

RA-RPC decoded every successful response as JSON containing a value. Servers legitimately encode Rust/unit success as an empty JSON response, which the client rejected at EOF.

## Root cause and fix

Treat an empty successful body as the unit value while retaining normal JSON decoding for non-unit responses.

## Implementation

The branch records the following focused implementation work:

- `fix(ra-rpc): accept empty JSON unit responses`

Changed paths:

- `dstack/ra-rpc/src/client.rs`

## Scope

This PR addresses one logical `ra-rpc` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-ra-rpc-empty-json`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
