### PR TITLE
fix(http-client): accept empty JSON unit responses

### DIFF
--- a/dstack/http-client/src/prpc.rs
+++ b/dstack/http-client/src/prpc.rs
@@ -43,6 +43,34 @@ impl PrpcClient {
     }
 }
 
+fn normalize_json_response_body(body: &[u8]) -> &[u8] {
+    if body.is_empty() {
+        b"null"
+    } else {
+        body
+    }
+}
+
+#[cfg(test)]
+mod response_tests {
+    use super::{normalize_json_response_body, serde_json};
+
+    #[test]
+    fn empty_json_response_decodes_as_unit() {
+        let value: () = serde_json::from_slice(normalize_json_response_body(b""))
+            .expect("empty response should decode as unit");
+        assert_eq!(value, ());
+    }
+
+    #[test]
+    fn non_empty_json_response_is_unchanged() {
+        assert_eq!(
+            normalize_json_response_body(br#"{"value":1}"#),
+            br#"{"value":1}"#
+        );
+    }
+}
+
 impl RequestClient for PrpcClient {
     async fn request<T, R>(&self, path: &str, body: T) -> Result<R, Error>
     where
@@ -63,7 +91,8 @@ impl RequestClient for PrpcClient {
         if status != 200 {
             anyhow::bail!("Invalid status code: {status}, path={path}");
         }
-        let response = serde_json::from_slice(&body).context("Failed to deserialize response")?;
+        let response = serde_json::from_slice(normalize_json_response_body(&body))
+            .context("Failed to deserialize response")?;
         Ok(response)
     }
 }


### PR DESCRIPTION
## Problem

The shared HTTP client similarly attempted JSON deserialization for an empty successful unit response and returned an EOF parse error.

## Root cause and fix

Recognize empty success bodies for unit-returning calls and preserve strict decoding for typed payloads.

## Implementation

The branch records the following focused implementation work:

- `fix(http-client): accept empty JSON unit responses`

Changed paths:

- `dstack/http-client/src/prpc.rs`

## Scope

This PR addresses one logical `http-client` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-http-client-empty-json`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
