### PR TITLE
fix(kms): reject repeated onboarding

### DIFF
--- a/dstack/kms/src/onboard_service.rs
+++ b/dstack/kms/src/onboard_service.rs
@@ -136,6 +136,11 @@ impl OnboardRpc for OnboardHandler {
 
     async fn onboard(self, request: OnboardRequest) -> Result<OnboardResponse> {
         validate_onboarding_domain(&request.domain)?;
+        let _bootstrap_guard = self.state.bootstrap_lock.lock().await;
+        let cfg = &self.state.config;
+        if cfg.root_ca_key().exists() || cfg.k256_key().exists() {
+            bail!("KMS has already been onboarded");
+        }
         let source_url = request.source_url.trim_end_matches('/').to_string();
         let source_url = if source_url.ends_with("/prpc") {
             source_url
@@ -143,7 +148,7 @@ impl OnboardRpc for OnboardHandler {
             format!("{source_url}/prpc")
         };
         let keys = Keys::onboard(
-            &self.state.config,
+            cfg,
             &source_url,
             &request.domain,
             self.state.attestation_verifier.clone(),
@@ -151,8 +156,7 @@ impl OnboardRpc for OnboardHandler {
         .await
         .context("Failed to onboard")?;
         let k256_pubkey = keys.k256_key.verifying_key().to_sec1_bytes().to_vec();
-        keys.store(&self.state.config)
-            .context("Failed to store keys")?;
+        keys.store(cfg).context("Failed to store keys")?;
         Ok(OnboardResponse { k256_pubkey })
     }
 


### PR DESCRIPTION
## Problem

After successful KMS onboarding, the onboarding RPC remained usable. A repeated or concurrent request could replace identity state that must remain stable after initialization.

## Fix

Serialize onboarding with the existing bootstrap lock and reject onboarding when either persisted KMS identity key already exists.

The branch is rebuilt on current `master`. The graceful `Finish` shutdown behavior is already provided by #875 and is no longer part of this PR's delta. The unrelated global `ra-rpc` JSON response normalization has been removed.

## Verification

- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `cargo check --manifest-path dstack/Cargo.toml -p dstack-kms`
- `cargo test --manifest-path dstack/Cargo.toml -p dstack-kms --no-run`
- `git diff --check`
