### PR TITLE
fix(gateway): validate peer synchronization URLs

### DIFF
--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -682,6 +682,8 @@ impl KvStore {
     /// This stores the URL in KvStore (for address lookup) and also adds the node
     /// to the wavekv peer list (so SyncManager knows to sync with it).
     pub fn register_peer_url(&self, node_id: NodeId, url: &str) -> Result<()> {
+        validate_peer_url(url)?;
+
         // Store URL in persistent KvStore
         self.persistent
             .write()
@@ -1031,5 +1033,41 @@ impl KvStore {
     /// Watch for certificate data changes (any domain)
     pub fn watch_all_certs(&self) -> watch::Receiver<()> {
         self.persistent.watch_prefix(keys::CERT_PREFIX)
+    }
+}
+
+fn validate_peer_url(url: &str) -> Result<()> {
+    let parsed = reqwest::Url::parse(url).context("invalid peer URL")?;
+    anyhow::ensure!(
+        matches!(parsed.scheme(), "http" | "https"),
+        "peer URL scheme must be http or https"
+    );
+    anyhow::ensure!(parsed.host_str().is_some(), "peer URL must include a host");
+    anyhow::ensure!(
+        parsed.username().is_empty() && parsed.password().is_none(),
+        "peer URL must not contain credentials"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod peer_url_tests {
+    use super::validate_peer_url;
+
+    #[test]
+    fn accepts_http_sync_urls() {
+        assert!(validate_peer_url("https://gateway.example:8011/sync").is_ok());
+        assert!(validate_peer_url("http://127.0.0.1:8011").is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_or_unsafe_sync_urls() {
+        for url in [
+            "not-a-sync-url",
+            "ftp://gateway.example/sync",
+            "https://user:secret@gateway.example/sync",
+        ] {
+            assert!(validate_peer_url(url).is_err(), "accepted {url}");
+        }
     }
 }


### PR DESCRIPTION
## Problem

Peer synchronization URLs from persisted/configured gateway state were accepted without restricting scheme, credentials, or malformed host data. Synchronization could target an invalid or unintended endpoint and fail after state was committed.

## Root cause and fix

Parse and validate peer URLs at the boundary, allowing only the supported secure form before storing or connecting.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): validate peer synchronization URLs`

Changed paths:

- `dstack/gateway/src/kv/mod.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and has no parent dependency.

## Verification

- `git diff --check origin/master..origin/codex/fix-gateway-peer-sync-urls`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.

