### PR TITLE
[STACKED on #868] fix(gateway): normalize ZT domain CRUD keys

### DIFF
--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -468,8 +468,9 @@ impl AdminRpc for AdminRpcHandler {
         let kv_store = self.state.kv_store();
         let cert_resolver = &self.state.cert_resolver;
 
+        let domain = normalize_zt_domain(&request.domain)?;
         let config = kv_store
-            .get_zt_domain_config(&request.domain)
+            .get_zt_domain_config(&domain)
             .context("ZT-Domain config not found")?;
 
         Ok(zt_domain_to_proto(config, kv_store, cert_resolver))
@@ -479,12 +480,13 @@ impl AdminRpc for AdminRpcHandler {
         let kv_store = self.state.kv_store();
         let cert_resolver = &self.state.cert_resolver;
 
-        // Check if domain already exists
-        if kv_store.get_zt_domain_config(&request.domain).is_some() {
-            bail!("ZT-Domain config already exists: {}", request.domain);
-        }
-
         let config = proto_to_zt_domain_config(&request, kv_store)?;
+
+        // Uniqueness is checked after normalization so wildcard, case, and a
+        // trailing root dot cannot silently overwrite the same DNS name.
+        if kv_store.get_zt_domain_config(&config.domain).is_some() {
+            bail!("ZT-Domain config already exists: {}", config.domain);
+        }
 
         kv_store.save_zt_domain_config(&config)?;
         info!("Added ZT-Domain config: {}", config.domain);
@@ -496,12 +498,12 @@ impl AdminRpc for AdminRpcHandler {
         let kv_store = self.state.kv_store();
         let cert_resolver = &self.state.cert_resolver;
 
-        // Check if config exists
-        kv_store
-            .get_zt_domain_config(&request.domain)
-            .context("ZT-Domain config not found")?;
-
         let config = proto_to_zt_domain_config(&request, kv_store)?;
+
+        // Check the normalized key rather than the caller's presentation.
+        kv_store
+            .get_zt_domain_config(&config.domain)
+            .context("ZT-Domain config not found")?;
 
         kv_store.save_zt_domain_config(&config)?;
         info!("Updated ZT-Domain config: {}", config.domain);
@@ -512,14 +514,14 @@ impl AdminRpc for AdminRpcHandler {
     async fn delete_zt_domain(self, request: DeleteZtDomainRequest) -> Result<()> {
         let kv_store = self.state.kv_store();
 
-        // Check if config exists
+        let domain = normalize_zt_domain(&request.domain)?;
         kv_store
-            .get_zt_domain_config(&request.domain)
+            .get_zt_domain_config(&domain)
             .context("ZT-Domain config not found")?;
 
         // Delete config (cert data, acme, attestations are kept for historical purposes)
-        kv_store.delete_zt_domain_config(&request.domain)?;
-        info!("Deleted ZT-Domain config: {}", request.domain);
+        kv_store.delete_zt_domain_config(&domain)?;
+        info!("Deleted ZT-Domain config: {domain}");
         Ok(())
     }
 
@@ -792,6 +794,16 @@ fn redact_token(token: &str) -> String {
     }
 }
 
+fn normalize_zt_domain(domain: &str) -> Result<String> {
+    let domain = domain.trim().trim_end_matches('.');
+    let domain = domain
+        .strip_prefix("*.")
+        .unwrap_or(domain)
+        .to_ascii_lowercase();
+    validate_zt_domain(&domain)?;
+    Ok(domain)
+}
+
 fn validate_zt_domain(domain: &str) -> Result<()> {
     if domain.is_empty() || domain.len() > 253 || !domain.is_ascii() {
         bail!("domain must be a non-empty ASCII DNS name of at most 253 bytes");
@@ -830,13 +842,7 @@ fn proto_to_zt_domain_config(
             .context("specified dns credential not found")?;
     }
 
-    // Strip wildcard prefix if user entered it
-    let domain = proto
-        .domain
-        .strip_prefix("*.")
-        .unwrap_or(&proto.domain)
-        .to_string();
-    validate_zt_domain(&domain)?;
+    let domain = normalize_zt_domain(&proto.domain)?;
     if proto.port == 0 {
         bail!("port must be between 1 and 65535");
     }


### PR DESCRIPTION
> **STACKED PR — merge #868 first.**

## Problem

ZT domain create, read, update, and delete paths normalized keys differently. The same domain with case/trailing-dot variation could be created under one key but not found or deleted through another.

## Root cause and fix

Canonicalize the domain once and use that identical canonical key for every CRUD operation.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): normalize ZT domain CRUD keys`

Changed paths:

- `dstack/gateway/src/admin_service.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #868
- GitHub base branch: `codex/fix-gateway-zt-domain-inputs`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-gateway-zt-domain-inputs..origin/codex/fix-gateway-zt-domain-crud`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
