### PR TITLE
[STACKED on #931] feat(gateway): support exact SNI certificates

### DIFF
--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -264,6 +264,22 @@ impl CertStoreBuilder {
         Ok(())
     }
 
+    /// Add an exact-name certificate to the builder.
+    pub fn add_exact_cert(&mut self, domain: &str, data: &CertData) -> Result<()> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("system time is before Unix epoch")?
+            .as_secs();
+        anyhow::ensure!(data.not_after > now, "certificate is expired");
+
+        let certified_key = parse_certified_key(&data.cert_pem, &data.key_pem)
+            .with_context(|| format!("failed to parse certificate for {}", domain))?;
+        self.exact_certs
+            .insert(domain.to_string(), Arc::new(certified_key));
+        self.cert_data.insert(domain.to_string(), data.clone());
+        Ok(())
+    }
+
     /// Build the immutable CertStore
     pub fn build(self) -> CertStore {
         CertStore {

--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -538,4 +538,77 @@ mod tests {
         );
         assert!(resolver.get().has_cert_for_sni("app.example.com"));
     }
+
+    #[test]
+    fn exact_certificate_precedes_parent_wildcard() {
+        let wildcard = make_test_cert_data();
+        let exact = make_test_cert_data();
+        let mut builder = CertStoreBuilder::new();
+        builder
+            .add_cert("example.com", &wildcard)
+            .expect("failed to add wildcard certificate");
+        builder
+            .add_exact_cert("api.example.com", &exact)
+            .expect("failed to add exact certificate");
+        let store = builder.build();
+
+        let exact_selected = store
+            .resolve_cert("api.example.com")
+            .expect("exact certificate not selected");
+        let wildcard_selected = store
+            .resolve_cert("www.example.com")
+            .expect("wildcard certificate not selected");
+        assert!(Arc::ptr_eq(
+            &exact_selected,
+            store
+                .exact_certs
+                .get("api.example.com")
+                .expect("exact certificate missing")
+        ));
+        assert!(Arc::ptr_eq(
+            &wildcard_selected,
+            store
+                .wildcard_certs
+                .get("example.com")
+                .expect("wildcard certificate missing")
+        ));
+        assert!(store.resolve_cert("deep.www.example.com").is_none());
+    }
+
+    #[test]
+    fn concurrent_reads_never_observe_empty_during_reload() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let resolver = Arc::new(CertResolver::new());
+        resolver
+            .update_cert("example.com", &make_test_cert_data())
+            .expect("failed to install initial certificate");
+        let finished = Arc::new(AtomicBool::new(false));
+        let misses = Arc::new(AtomicUsize::new(0));
+        let readers = (0..4)
+            .map(|_| {
+                let resolver = resolver.clone();
+                let finished = finished.clone();
+                let misses = misses.clone();
+                std::thread::spawn(move || {
+                    while !finished.load(Ordering::Acquire) {
+                        if resolver.get().resolve_cert("app.example.com").is_none() {
+                            misses.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for _ in 0..20 {
+            resolver
+                .update_cert("example.com", &make_test_cert_data())
+                .expect("hot reload failed");
+        }
+        finished.store(true, Ordering::Release);
+        for reader in readers {
+            reader.join().expect("reader thread failed");
+        }
+        assert_eq!(misses.load(Ordering::Relaxed), 0);
+    }
 }

--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -611,4 +611,28 @@ mod tests {
         }
         assert_eq!(misses.load(Ordering::Relaxed), 0);
     }
+
+    #[test]
+    fn corrupt_update_retains_previous_certificate() {
+        let original = make_test_cert_data();
+        let mut corrupt = make_test_cert_data();
+        corrupt.cert_pem = "not a certificate".to_string();
+
+        let resolver = CertResolver::new();
+        resolver
+            .update_cert("example.com", &original)
+            .expect("failed to install original certificate");
+        resolver
+            .update_cert("example.com", &corrupt)
+            .expect_err("corrupt certificate must be rejected");
+        assert_eq!(
+            resolver
+                .get()
+                .get_cert_data("example.com")
+                .expect("original certificate was lost")
+                .not_after,
+            original.not_after
+        );
+        assert!(resolver.get().has_cert_for_sni("app.example.com"));
+    }
 }


### PR DESCRIPTION
> **STACKED PR — merge #931 first.**

## Problem

Gateway selected certificates only through wildcard/general domain matching. A certificate issued for one exact SNI name could not be selected reliably and clients received the wrong/default identity.

## Root cause and fix

Index and resolve exact SNI certificate names before fallback matching.

## Implementation

The branch records the following focused implementation work:

- `feat(gateway): support exact SNI certificates`
- `test(gateway): cover SNI precedence and atomic reload`
- `test(gateway): retain cert on corrupt hot reload`

Changed paths:

- `dstack/gateway/src/cert_store.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #931
- GitHub base branch: `codex/fix-gateway-expired-cert-reload`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-gateway-expired-cert-reload..origin/codex/feat-gateway-exact-sni-certificates`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
