### PR TITLE
[STACKED on #932] fix(gateway): accept app-info peer identities

### DIFF
--- a/dstack/gateway/src/web_routes/wavekv_sync.rs
+++ b/dstack/gateway/src/web_routes/wavekv_sync.rs
@@ -10,13 +10,14 @@ use crate::{
     kv::{decode, encode},
     main_service::Proxy,
 };
-use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use ra_tls::traits::CertExt;
 use rocket::{
+    State,
     data::{Data, ToByteUnit},
     http::{ContentType, Status},
-    mtls::{oid::Oid, Certificate},
-    post, State,
+    mtls::{Certificate, oid::Oid},
+    post,
 };
 use std::io::{Read, Write};
 use tracing::warn;
@@ -82,13 +83,27 @@ fn verify_gateway_peer(state: &Proxy, cert: Option<Certificate<'_>>) -> Result<(
         return Err(Status::Unauthorized);
     };
 
-    let remote_app_id = RocketCert(&cert).get_app_id().map_err(|e| {
-        warn!("WaveKV sync: failed to extract app_id from certificate: {e}");
-        Status::Unauthorized
-    })?;
+    let cert = RocketCert(&cert);
+    let remote_app_id = cert
+        .get_app_id()
+        .map_err(|e| {
+            warn!("WaveKV sync: failed to extract app_id from certificate: {e}");
+            Status::Unauthorized
+        })?
+        .or_else(|| {
+            cert.get_app_info()
+                .map_err(|e| {
+                    warn!("WaveKV sync: failed to extract app_info from certificate: {e}");
+                    Status::Unauthorized
+                })
+                .transpose()
+                .ok()
+                .flatten()
+                .map(|info| info.app_id)
+        });
 
     let Some(remote_app_id) = remote_app_id else {
-        warn!("WaveKV sync: certificate does not contain app_id");
+        warn!("WaveKV sync: certificate does not contain app identity");
         return Err(Status::Unauthorized);
     };
 

--- a/dstack/gateway/src/web_routes/wavekv_sync.rs
+++ b/dstack/gateway/src/web_routes/wavekv_sync.rs
@@ -10,14 +10,13 @@ use crate::{
     kv::{decode, encode},
     main_service::Proxy,
 };
-use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use ra_tls::traits::CertExt;
 use rocket::{
-    State,
     data::{Data, ToByteUnit},
     http::{ContentType, Status},
-    mtls::{Certificate, oid::Oid},
-    post,
+    mtls::{oid::Oid, Certificate},
+    post, State,
 };
 use std::io::{Read, Write};
 use tracing::warn;
@@ -84,23 +83,19 @@ fn verify_gateway_peer(state: &Proxy, cert: Option<Certificate<'_>>) -> Result<(
     };
 
     let cert = RocketCert(&cert);
-    let remote_app_id = cert
-        .get_app_id()
-        .map_err(|e| {
-            warn!("WaveKV sync: failed to extract app_id from certificate: {e}");
-            Status::Unauthorized
-        })?
-        .or_else(|| {
-            cert.get_app_info()
-                .map_err(|e| {
-                    warn!("WaveKV sync: failed to extract app_info from certificate: {e}");
-                    Status::Unauthorized
-                })
-                .transpose()
-                .ok()
-                .flatten()
-                .map(|info| info.app_id)
-        });
+    let remote_app_id = match cert.get_app_id().map_err(|e| {
+        warn!("WaveKV sync: failed to extract app_id from certificate: {e}");
+        Status::Unauthorized
+    })? {
+        Some(app_id) => Some(app_id),
+        None => cert
+            .get_app_info()
+            .map_err(|e| {
+                warn!("WaveKV sync: failed to extract app_info from certificate: {e}");
+                Status::Unauthorized
+            })?
+            .map(|info| info.app_id),
+    };
 
     let Some(remote_app_id) = remote_app_id else {
         warn!("WaveKV sync: certificate does not contain app identity");


### PR DESCRIPTION
> **STACKED PR — merge #932 first.**

## Problem

Peer synchronization required a legacy identity form and rejected valid peers that identify themselves using app-info records. Healthy peers therefore failed authentication during mixed-version synchronization.

## Root cause and fix

Accept and verify the supported app-info peer identity representation while retaining the existing trust checks.

## Implementation

The branch records the following focused implementation work:

- `fix(gateway): accept app-info peer identities`
- `fix(gateway): decode app-info peer identity`

Changed paths:

- `dstack/gateway/src/web_routes/wavekv_sync.rs`

## Scope

This PR addresses one logical `gateway` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #932
- GitHub base branch: `codex/fix-gateway-peer-sync-urls`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-gateway-peer-sync-urls..origin/codex/fix-gateway-app-info-peer-identity`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
