### PR TITLE
fix(verifier): never verify a legacy TDX boot on the lite path

### DIFF
--- a/dstack/dstack-types/src/lib.rs
+++ b/dstack/dstack-types/src/lib.rs
@@ -1098,10 +1098,13 @@ pub struct VmConfig {
     #[serde(default, skip_serializing_if = "TdxAttestationVariant::is_legacy")]
     pub tdx_attestation_variant: TdxAttestationVariant,
     /// TDX-only no-image-download measurement material. Attached whenever
-    /// the OS image provides it, regardless of `tdx_attestation_variant`, so
-    /// a verifier can choose lite verification even for a boot that resolved
-    /// to `Legacy`. Omitted only when the image predates this measurement
-    /// material.
+    /// the OS image provides it, regardless of `tdx_attestation_variant`, and
+    /// omitted only when the image predates this measurement material.
+    ///
+    /// Its presence does not select lite verification: `tdx_attestation_variant`
+    /// alone does. A `Legacy` boot is verified through the image download even
+    /// when this document is attached, because only that path verifies the ACPI
+    /// tables.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tdx_measurement: Option<TdxOsImageMeasurementDocument>,
     /// GCP TDX no-image-download measurement material. Present for GCP

--- a/dstack/verifier/src/verification.rs
+++ b/dstack/verifier/src/verification.rs
@@ -1330,6 +1330,108 @@ mod tests {
     }
 
     #[test]
+    fn gcp_and_nitro_enclave_measurement_bindings_matrix() {
+        let verifier = test_verifier();
+
+        let nitro_pcrs = NitroPcrs {
+            pcr0: vec![0x10; 48],
+            pcr1: vec![0x11; 48],
+            pcr2: vec![0x12; 48],
+        };
+        let nitro_config: VmConfig = serde_json::from_value(serde_json::json!({
+            "os_image_hash": hex::encode(nitro_pcrs.image_hash()),
+        }))
+        .unwrap();
+        verifier
+            .verify_os_image_hash_for_nitro_enclave(&nitro_config, &nitro_pcrs)
+            .unwrap();
+        let mut changed_nitro = nitro_pcrs.clone();
+        changed_nitro.pcr2[0] ^= 1;
+        assert!(verifier
+            .verify_os_image_hash_for_nitro_enclave(&nitro_config, &changed_nitro)
+            .is_err());
+        let debug_nitro = NitroPcrs {
+            pcr0: vec![0; 48],
+            pcr1: vec![0; 48],
+            pcr2: vec![0; 48],
+        };
+        assert!(verifier
+            .verify_os_image_hash_for_nitro_enclave(&nitro_config, &debug_nitro)
+            .is_err());
+
+        let uki_hash = vec![0x24; 32];
+        let measurement = dstack_types::GcpOsImageMeasurement::new(uki_hash.clone()).unwrap();
+        let measurement_bytes = measurement.to_cbor_vec();
+        let checksum_file = format!(
+            "{}  measurement.gcp.cbor\n",
+            hex::encode(Sha256::digest(&measurement_bytes))
+        )
+        .into_bytes();
+        let os_image_hash = dstack_types::image_hash_from_sha256sum(&checksum_file);
+        let gcp_config: VmConfig = serde_json::from_value(serde_json::json!({
+            "os_image_hash": hex::encode(os_image_hash),
+            "gcp_measurement": dstack_types::GcpOsImageMeasurementDocument::new(
+                checksum_file,
+                measurement_bytes,
+            ),
+        }))
+        .unwrap();
+        let expected_pcr0 =
+            hex!("0cca9ec161b09288802e5a112255d21340ed5b797f5fe29cecccfd8f67b9f802");
+        let gcp_quote = |pcr0: Vec<u8>, event_28: Vec<u8>| TpmQuote {
+            message: Vec::new(),
+            signature: Vec::new(),
+            pcr_values: vec![tpm_types::PcrValue {
+                index: 0,
+                algorithm: "sha256".into(),
+                value: pcr0,
+            }],
+            ak_cert: Vec::new(),
+            platform: dstack_types::Platform::Gcp,
+            event_log: vec![
+                tpm_types::TpmEvent {
+                    pcr_index: 2,
+                    digest: vec![1; 32],
+                },
+                tpm_types::TpmEvent {
+                    pcr_index: 2,
+                    digest: vec![2; 32],
+                },
+                tpm_types::TpmEvent {
+                    pcr_index: 2,
+                    digest: event_28,
+                },
+            ],
+        };
+        verifier
+            .verify_os_image_hash_for_gcp_tdx(
+                &gcp_config,
+                &gcp_quote(expected_pcr0.to_vec(), uki_hash.clone()),
+            )
+            .unwrap();
+        assert!(verifier
+            .verify_os_image_hash_for_gcp_tdx(
+                &gcp_config,
+                &gcp_quote(vec![0; 32], uki_hash.clone()),
+            )
+            .is_err());
+        assert!(verifier
+            .verify_os_image_hash_for_gcp_tdx(
+                &gcp_config,
+                &gcp_quote(expected_pcr0.to_vec(), vec![0; 32]),
+            )
+            .is_err());
+        let mut missing_document = gcp_config;
+        missing_document.gcp_measurement = None;
+        assert!(verifier
+            .verify_os_image_hash_for_gcp_tdx(
+                &missing_document,
+                &gcp_quote(expected_pcr0.to_vec(), uki_hash),
+            )
+            .is_err());
+    }
+
+    #[test]
     fn aws_os_image_check_requires_measurement() {
         let pcrs = aws_boot_pcrs(0x04);
         let mut vm_config = aws_vm_config(&pcrs);

--- a/dstack/verifier/src/verification.rs
+++ b/dstack/verifier/src/verification.rs
@@ -20,7 +20,7 @@ use cc_eventlog::{
 use dstack_mr::{
     tdx::TdxRtmr0AcpiHashes, RtmrLog, RtmrLogs, TdxMeasurementDetails, TdxMeasurements,
 };
-use dstack_types::VmConfig;
+use dstack_types::{TdxAttestationVariant, VmConfig};
 use hex_literal::hex;
 use ra_tls::attestation::{
     AppInfo, Attestation, AttestationQuote, AttestationVerifier, DstackVerifiedReport, NitroPcrs,
@@ -680,22 +680,25 @@ impl CvmVerifier {
             AttestationQuote::DstackGcpTdx(quote) => {
                 self.verify_os_image_hash_for_gcp_tdx(&vm_config, &quote.tpm_quote)?;
             }
-            AttestationQuote::DstackTdx(_) => {
-                // New images carry a self-contained measurement document even
-                // when the boot kept the legacy attestation selector. Prefer
-                // that signed-MR-bound material; retain image download only
-                // for old legacy images which do not provide it.
-                if vm_config.tdx_attestation_variant.is_lite()
-                    || vm_config.tdx_measurement.is_some()
-                {
-                    self.verify_os_image_hash_for_dstack_tdx_lite(
-                        &vm_config,
-                        attestation,
-                        debug,
-                        details,
-                    )
-                    .await?;
-                } else {
+            // The declared scheme alone selects the path, matched exhaustively
+            // so a new variant fails the build here instead of taking one.
+            //
+            // A `tdx_measurement` document must not pull a `Legacy` boot onto
+            // the lite path. The paths are not interchangeable: the legacy path
+            // recomputes the ACPI tables from `vm_config` and reports
+            // `acpi_tables_verified`, while the lite path takes the RTMR0 ACPI
+            // digests from the event log as given (see
+            // `tdx_acpi_hashes_from_event_log`) and never checks the table
+            // contents. Images attach the document whenever they have it,
+            // independent of the scheme, so honoring it here would drop ACPI
+            // table verification for a boot that resolved to `Legacy` precisely
+            // because the app asked for it (`requirements.tdx_measure_acpi_tables`,
+            // enforced guest-side in `dstack-util`'s system_setup).
+            //
+            // `Lite` without a document is rejected by the lite path itself,
+            // rather than degraded to a download.
+            AttestationQuote::DstackTdx(_) => match vm_config.tdx_attestation_variant {
+                TdxAttestationVariant::Legacy => {
                     self.verify_os_image_hash_for_dstack_tdx(
                         &vm_config,
                         attestation,
@@ -704,7 +707,16 @@ impl CvmVerifier {
                     )
                     .await?;
                 }
-            }
+                TdxAttestationVariant::Lite => {
+                    self.verify_os_image_hash_for_dstack_tdx_lite(
+                        &vm_config,
+                        attestation,
+                        debug,
+                        details,
+                    )
+                    .await?;
+                }
+            },
             AttestationQuote::DstackNitroEnclave(_) => {
                 let DstackVerifiedReport::DstackNitroEnclave(report) = &attestation.report else {
                     bail!("internal error: nitro quote without a verified nitro report");

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -1413,12 +1413,12 @@ fn make_vm_config(
         .and_then(|d| hex::decode(d).ok())
         .unwrap_or_default();
     // Attach the lite measurement material whenever the image provides it,
-    // regardless of the resolved attestation variant: the guest's exposed
-    // event log always retains the RTMR0 ACPI digest events (see
-    // cc_eventlog::tdx::label_tdx_acpi_data_events), so a verifier can freely
-    // choose lite verification for a legacy-resolved boot too.
-    // `tdx_attestation_variant` keeps its original meaning of "the scheme the
-    // VMM/KMS resolved for this boot" and is unaffected by this.
+    // regardless of the resolved attestation variant, so the config shape stays
+    // uniform across images. It does not widen how the boot is verified:
+    // verifiers select the path from `tdx_attestation_variant` alone, and a
+    // legacy-resolved boot is verified through the image download even with the
+    // document attached. `tdx_attestation_variant` keeps its original meaning of
+    // "the scheme the VMM/KMS resolved for this boot".
     let tdx_measurement = if is_tdx {
         if tdx_attestation_variant.is_lite() {
             Some(image.tdx_measurement.clone().context(


### PR DESCRIPTION
## Problem

The TDX branch of `verify_os_image_hash` picked its verification path with a
boolean predicate:

```rust
if vm_config.tdx_attestation_variant.is_lite() || vm_config.tdx_measurement.is_some()
```

So a `Legacy` boot carrying a `tdx_measurement` document was verified on the
lite path. That is not a rare combination: the VMM attaches the document
whenever the image provides it, independent of the resolved scheme, so it fires
on ordinary legacy boots off any recent image.

The two paths are not interchangeable:

- The legacy path recomputes the ACPI tables from `vm_config` and reports
  `acpi_tables_verified`.
- The lite path takes the RTMR0 ACPI digests from the event log as given
  (`tdx_acpi_hashes_from_event_log`) and never checks the table contents. RTMR0
  then matches by construction, so ACPI content the host chose is accepted
  rather than verified.

A boot resolves to `Legacy` precisely when the app asked for that check, via
`requirements.tdx_measure_acpi_tables` (enforced guest-side in `dstack-util`'s
system_setup). The fallback therefore dropped the guarantee the app had
requested, silently.

Secondary problem: `TdxAttestationVariant` is an enum, but testing it through
`is_lite()` meant a third variant would compile cleanly and fall through to a
path rather than fail the build.

## Fix

Select the path from `tdx_attestation_variant` alone, matched exhaustively at
the dispatch site:

- `Legacy` always downloads the image.
- `Lite` always uses the measurement document.

`Lite` without a document already fails in
`verify_os_image_hash_for_dstack_tdx_lite` with
"tdx lite attestation requires vm_config.tdx_measurement", so it is rejected
rather than degraded to a download; routing keeps it there deliberately.

This also settles a disagreement between two decision sites: the verifier CLI's
`needs_image_download` already keyed on `is_legacy()` alone, and so refused to
verify certs that this path would have accepted as lite.

The dispatch on `AttestationQuote` is left as a direct match. It was already
exhaustive — all five variants listed, no catch-all arm, not
`#[non_exhaustive]` — so a new platform already fails to compile there, and the
direct match keeps each arm's pattern binding.

## Behavior change

Legacy TDX boots on images that ship `tdx_measurement` now download the image
instead of verifying from the document. That is the point of the fix, but it
does mean those verifications gain a network fetch. Deployments that want the
no-download path should resolve to `Lite`, which is what that scheme is for.

The VMM still attaches `tdx_measurement` on legacy boots to keep the config
shape uniform; it no longer widens how the boot is verified.

## Commits

- `fix(verifier): never verify a legacy TDX boot on the lite path`
- `test(verifier): cover GCP and Nitro image bindings`

Changed paths:

- `dstack/verifier/src/verification.rs`
- `dstack/dstack-types/src/lib.rs` (comment)
- `dstack/vmm/src/app.rs` (comment)

## Tests

`gcp_and_nitro_enclave_measurement_bindings_matrix` covers two platform
bindings that had no negative tests: GCP PCR0 replay against the UKI hash
(rejecting a wrong PCR0, a wrong event digest, and a missing measurement
document), and the Nitro enclave PCR-to-image-hash binding (rejecting a flipped
PCR bit and all-zero debug PCRs).

The TDX path selection is not unit-tested. It is now a two-arm match on the
scheme, so a test would restate the match arms; and it cannot be driven from a
fixture, because a request carrying an `attestation` ignores the top-level
`vm_config`, so the scheme cannot be flipped without forging a new attestation
blob. `verifies_tdx_lite_fixture_without_acpi_table_verification` continues to
pin the lite path end to end.

## Follow-up, not in this PR

Strictness on `Legacy` only helps to the extent `tdx_attestation_variant` is
itself trustworthy. `vm_config` is host-supplied and only indirectly constrained
(the recomputed MRs must match the hardware report), so a host can still declare
`lite` and reach the lite path. This PR fixes an accidental downgrade, not a
malicious one. Consumers that need ACPI table verification should gate on the
reported `acpi_tables_verified` rather than assume it.

## Verification

- `cargo test -p dstack-verifier --all-features`: 15 passed.
- `cargo test -p dstack-vmm -p dstack-types -p dstack-util`: passed.
- `cargo clippy -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow unused_variables`
  (the CI command, whole workspace): passed.
- `cargo fmt --check`: passed.
- Both commits build and lint independently, so the branch stays bisectable.