### PR TITLE
fix(mkosi): install the Sysbox rsync dependency

### DIFF
--- a/os/mkosi/mkosi.conf
+++ b/os/mkosi/mkosi.conf
@@ -57,6 +57,7 @@ Packages=
         jq
         fuse3
         pigz
+        rsync
         xfsprogs
         e2fsprogs
         gdisk


### PR DESCRIPTION
## Problem

The mkosi Sysbox installation path uses rsync to stage its filesystem, but rsync was absent from the build environment/image dependency set. The component failed with `rsync: command not found` during image preparation.

## Root cause and fix

Install rsync in the mkosi build/component dependency set before the Sysbox staging step.

## Implementation

The branch records the following focused implementation work:

- `fix(mkosi): install Sysbox rsync dependency`

Changed paths:

- `os/mkosi/mkosi.conf`

## Scope

This PR addresses one logical `mkosi` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-mkosi-sysbox-rsync`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
