### PR TITLE
fix(guest): force refresh after a missing handshake

### DIFF
--- a/os/common/rootfs/wg-checker.sh
+++ b/os/common/rootfs/wg-checker.sh
@@ -49,13 +49,9 @@ check_and_refresh() {
 
     now=$(date +%s)
 
-    # Periodic refresh every REFRESH_INTERVAL seconds (not forced)
-    if [ "$LAST_REFRESH" -eq 0 ] || [ $((now - LAST_REFRESH)) -ge $REFRESH_INTERVAL ]; then
-        do_refresh "$now" "Periodic refresh" 0
-        return
-    fi
-
-    # Check handshake staleness (forced refresh)
+    # Check handshake staleness before the periodic refresh. Otherwise equal
+    # handshake and refresh intervals continually reset STALE_SINCE and a peer
+    # with no handshake can never reach the forced-refresh branch.
     latest=$(get_latest_handshake)
     if [ -z "$latest" ]; then
         latest=0
@@ -64,14 +60,22 @@ check_and_refresh() {
     if [ "$latest" -gt 0 ]; then
         if [ $((now - latest)) -ge $HANDSHAKE_TIMEOUT ]; then
             do_refresh "$now" "WireGuard handshake stale" 1 >&2
+            return
         fi
+        STALE_SINCE=0
     else
         if [ "$STALE_SINCE" -eq 0 ]; then
             STALE_SINCE=$now
         fi
         if [ $((now - STALE_SINCE)) -ge $HANDSHAKE_TIMEOUT ]; then
             do_refresh "$now" "WireGuard handshake stale" 1 >&2
+            return
         fi
+    fi
+
+    # Periodic refresh every REFRESH_INTERVAL seconds (not forced).
+    if [ "$LAST_REFRESH" -eq 0 ] || [ $((now - LAST_REFRESH)) -ge $REFRESH_INTERVAL ]; then
+        do_refresh "$now" "Periodic refresh" 0
     fi
 }
 

--- a/os/common/rootfs/wg-checker.sh
+++ b/os/common/rootfs/wg-checker.sh
@@ -7,6 +7,7 @@
 HANDSHAKE_TIMEOUT=180
 REFRESH_INTERVAL=180
 LAST_REFRESH=0
+LAST_FORCE=0
 STALE_SINCE=0
 DSTACK_WORK_DIR=${DSTACK_WORK_DIR:-/dstack}
 IFNAME=dstack-wg0
@@ -39,7 +40,6 @@ do_refresh() {
     fi
 
     LAST_REFRESH=$now
-    STALE_SINCE=0
 }
 
 check_and_refresh() {
@@ -49,28 +49,36 @@ check_and_refresh() {
 
     now=$(date +%s)
 
-    # Check handshake staleness before the periodic refresh. Otherwise equal
-    # handshake and refresh intervals continually reset STALE_SINCE and a peer
-    # with no handshake can never reach the forced-refresh branch.
     latest=$(get_latest_handshake)
     if [ -z "$latest" ]; then
         latest=0
     fi
 
+    # A peer that never completed a handshake reports 0, so there is no
+    # timestamp to age against; fall back to when we first observed that state.
+    # STALE_SINCE is cleared only by an actual handshake, never by a refresh:
+    # since HANDSHAKE_TIMEOUT equals REFRESH_INTERVAL, clearing it on every
+    # periodic refresh re-arms the timer one tick before it can expire, leaving
+    # the forced branch unreachable for a peer that never handshakes.
     if [ "$latest" -gt 0 ]; then
-        if [ $((now - latest)) -ge $HANDSHAKE_TIMEOUT ]; then
-            do_refresh "$now" "WireGuard handshake stale" 1 >&2
-            return
-        fi
         STALE_SINCE=0
+        stale_for=$((now - latest))
     else
         if [ "$STALE_SINCE" -eq 0 ]; then
             STALE_SINCE=$now
         fi
-        if [ $((now - STALE_SINCE)) -ge $HANDSHAKE_TIMEOUT ]; then
+        stale_for=$((now - STALE_SINCE))
+    fi
+
+    # Forced refresh bounces the interface and re-requests certificates, so cap
+    # it at one attempt per HANDSHAKE_TIMEOUT. Without this, a gateway that
+    # stays unreachable would be retried on every 10s tick.
+    if [ "$stale_for" -ge $HANDSHAKE_TIMEOUT ]; then
+        if [ $((now - LAST_FORCE)) -ge $HANDSHAKE_TIMEOUT ]; then
             do_refresh "$now" "WireGuard handshake stale" 1 >&2
-            return
+            LAST_FORCE=$now
         fi
+        return
     fi
 
     # Periodic refresh every REFRESH_INTERVAL seconds (not forced).


### PR DESCRIPTION
## Problem

A CVM whose WireGuard tunnel never completed a handshake stayed unreachable
indefinitely, even after dstack-gateway came back.

`wg-checker.service` watches the tunnel that gateway uses to reach the CVM. It
has two recovery paths, and only the forced one can help here:

| | trigger | effect |
| --- | --- | --- |
| periodic, `force=0` | every `REFRESH_INTERVAL` | `register_cvm`, then **return early if the config is unchanged** |
| stale handshake, `force=1` | handshake older than `HANDSHAKE_TIMEOUT` | skip the comparison, `wg-quick down` + `up` |

When gateway recovers it usually hands back the same peer key, endpoint and
client IP, so the periodic refresh hits the `config unchanged, skipping
reconfiguration` short-circuit in `GatewayContext::setup()` and never touches
the interface. Only a forced refresh rebuilds a tunnel whose config is correct
but whose state is dead.

## Root cause

`wg show latest-handshakes` reports `0` for a peer that never handshook, so
there is no timestamp to age against. The checker substitutes `STALE_SINCE` —
the time it first saw that state — and forces a refresh once that reaches
`HANDSHAKE_TIMEOUT`.

That timer could never expire, because `do_refresh()` cleared `STALE_SINCE` on
every call, including the non-forced periodic path. With `HANDSHAKE_TIMEOUT ==
REFRESH_INTERVAL == 180` and a 10s loop:

- `t=T` — periodic refresh runs, clearing `STALE_SINCE`
- `t=T+10` — `STALE_SINCE=T+10`
- forced refresh needs `now >= T+190`
- `t=T+180` — periodic fires first (`now - STALE_SINCE` is only 170) and clears the timer again

The staleness timer was re-armed one tick before it could expire, on every
cycle, forever.

## Fix

Give `STALE_SINCE` a single meaning: when we first observed a peer with no
handshake. It is cleared by an actual handshake and by nothing else, so the
periodic refresh no longer interferes with it.

Making the forced branch reachable exposes a second defect. Nothing rate limits
it, so while gateway stays unreachable the checker would bounce the interface
and re-request certificates on every 10s tick — a self-inflicted flood aimed at
a gateway that is already down. This is not a separate concern: fixing the
timer is what activates the flood, so both have to land together. `LAST_FORCE`
caps forced refreshes at one per `HANDSHAKE_TIMEOUT`.

Note the flood is already reachable on `master` through the other path — a peer
that handshook once and then went dead keeps a frozen, permanently stale
timestamp. See the `frozen` row below.

Changed paths:

- `os/common/rootfs/wg-checker.sh`

## Verification

`check_and_refresh` was replayed against a mocked clock with `dstack-util` and
`wg` stubbed on `PATH`, leaving `do_refresh()` itself untouched so each version
runs its own real logic. 900s of simulated time, 10s ticks:

| scenario | master | this PR |
| --- | --- | --- |
| healthy handshakes | 0 forced | 0 forced |
| never handshakes | 0 forced | 4 forced |
| never handshakes, gateway recovers midway | 0 forced | 2 forced, then back to periodic |
| handshook once, then peer removed | 0 forced | 3 forced |
| handshake frozen, gateway down | 62 forced | 4 forced |

No change on the healthy path; both stuck paths now recover; the retry storm
drops from 62 attempts to 4.

Also checked:

- `shellcheck -s sh os/common/rootfs/wg-checker.sh`: clean
- `dash -n os/common/rootfs/wg-checker.sh`: clean
- `git diff --check origin/master..HEAD`: clean

## Scope

One logical `guest` finding. It intentionally excludes the acceptance-test
infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

Based directly on `master`; does not require another split product PR to merge
first.
