### PR TITLE
fix(gateway): route using registered ZT domains

### DIFF
--- a/dstack/gateway/src/cert_store.rs
+++ b/dstack/gateway/src/cert_store.rs
@@ -84,11 +84,6 @@ impl CertStore {
     pub fn list_domains(&self) -> Vec<String> {
         self.cert_data.keys().cloned().collect()
     }
-
-    /// Check if a wildcard certificate exists for a domain
-    pub fn contains_wildcard(&self, base_domain: &str) -> bool {
-        self.wildcard_certs.contains_key(base_domain)
-    }
 }
 
 impl fmt::Debug for CertStore {

--- a/dstack/gateway/src/proxy.rs
+++ b/dstack/gateway/src/proxy.rs
@@ -158,7 +158,7 @@ async fn handle_connection(inbound: TcpStream, state: Proxy) -> Result<()> {
     };
 
     let (subdomain, base_domain) = sni.split_once('.').context("invalid sni")?;
-    if state.cert_resolver.get().contains_wildcard(base_domain) {
+    if state.kv_store().get_zt_domain_config(base_domain).is_some() {
         let dst = parse_dst_info(subdomain)?;
         debug!("dst: {dst:?}");
         if dst.is_tls {


### PR DESCRIPTION
## Problem

Gateway classified an SNI suffix as an application proxy domain only when a wildcard certificate was already loaded. That encouraged deployments and tests to inject the retired `PROXY_BASE_DOMAIN` app setting and a static certificate instead of using the ZT-domain control plane.

It also meant TLS-passthrough application routes were unavailable until a certificate existed, even though passthrough does not use the Gateway certificate.

## Fix

Use the registered ZT-domain configuration in WaveKV as the source of truth when classifying application SNI names. Certificate availability remains relevant only when the Gateway actually terminates TLS.

Remove the now-unused certificate-store domain-classification helper. This PR no longer introduces or consumes `PROXY_BASE_DOMAIN`.

## Related test update

PR #841 now registers `gateway-candidate.test` through `Admin.AddZtDomain` and no longer passes `PROXY_BASE_DOMAIN` to the Gateway app.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p dstack-gateway`
- `git diff --check`
