### PR TITLE
fix(vmm): avoid double-reserving reloaded VM CIDs

### DIFF
--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -884,10 +884,7 @@ impl App {
                     vm.state = old_state; // Preserve the existing state with statistics
                 }
                 None => {
-                    // This is a new VM, need to occupy its CID if it wasn't allocated
-                    if !cids_assigned.contains_key(&vm_id) {
-                        states.cid_pool.occupy(cid)?;
-                    }
+                    // Assigned CIDs were occupied above, while allocate() reserves a new CID.
                     let mut vm_state = VmState::new(vm_config);
                     vm_state.state.runtime_networks = runtime_networks;
                     states.add(vm_state);


### PR DESCRIPTION
## Problem

When VMM reloaded persisted VMs, it inserted their CIDs into the reservation set twice through overlapping restore paths. Valid subsequent allocation could report the CID as already reserved or prematurely exhaust the pool.

## Root cause and fix

Make restored CID ownership enter the allocator exactly once and avoid re-reserving the same VM during reconstruction.

## Implementation

The branch records the following focused implementation work:

- `fix(vmm): avoid double-reserving reloaded VM CIDs`

Changed paths:

- `dstack/vmm/src/app.rs`

## Scope

This PR addresses one logical `vmm` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

This PR is based directly on `master` and does not require another split product PR to merge first.

## Verification

- `git diff --check origin/master..origin/codex/fix-vmm-reloaded-cids`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
