### PR TITLE
[STACKED on #940] fix(verifier): separate service and Rocket configuration

### DIFF
--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -409,7 +409,7 @@ image_download_timeout_secs = 7
             ),
             (
                 "invalid-scheme",
-                valid_config("").replace("http://", "file://"),
+                valid_config("").replace("http://127.0.0.1:18081", "file:///tmp"),
                 "must use http or https",
             ),
             (

--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -77,7 +77,14 @@ impl Config {
     }
 }
 
-fn config_figment(config_path: &Path) -> Figment {
+fn verifier_config_figment(config_path: &Path) -> Figment {
+    Figment::new()
+        .merge(Toml::string(include_str!("../dstack-verifier.toml")))
+        .merge(Toml::file(config_path))
+        .merge(Env::prefixed("DSTACK_VERIFIER_").split("__"))
+}
+
+fn rocket_figment(config_path: &Path) -> Figment {
     Figment::from(rocket::Config::default())
         .merge(Toml::string(include_str!("../dstack-verifier.toml")))
         .merge(Toml::file(config_path))
@@ -85,7 +92,7 @@ fn config_figment(config_path: &Path) -> Figment {
 }
 
 fn load_config(config_path: &Path) -> Result<Config> {
-    let config: Config = config_figment(config_path)
+    let config: Config = verifier_config_figment(config_path)
         .extract()
         .context("Failed to load configuration")?;
     config.validate()?;
@@ -314,7 +321,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let config_path = Path::new(&cli.config);
-    let figment = config_figment(config_path);
+    let figment = rocket_figment(config_path);
     let config = load_config(config_path)?;
     // Check for oneshot modes
     if let Some(file_path) = cli.verify {


### PR DESCRIPTION
> **STACKED PR — merge #940 first.**

## Problem

Verifier service settings and Rocket framework settings shared overlapping configuration names/namespaces. Rocket environment values could override verifier options, or verifier fields could be consumed by the wrong parser.

## Root cause and fix

Separate the service configuration from Rocket configuration and pass each parser only its own namespace.

## Implementation

The branch records the following focused implementation work:

- `fix(verifier): separate service and Rocket config`
- `fix(test): use valid unsupported image URL`

Changed paths:

- `dstack/verifier/src/main.rs`

## Scope

This PR addresses one logical `verifier` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #940
- GitHub base branch: `codex/fix-verifier-config-precedence`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-verifier-config-precedence..origin/codex/fix-verifier-service-config`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
