### PR TITLE
[STACKED on #941] fix(kms): bound the authorization boot schema

### DIFF
--- a/dstack/kms/auth-eth-bun/index.test.ts
+++ b/dstack/kms/auth-eth-bun/index.test.ts
@@ -197,7 +197,21 @@ describe('API Compatibility Tests', () => {
 
       expect(response.status).toBe(400);
     });
-  });
+
+
+    it('should reject oversized and non-hex measurements before backend use', async () => {
+      for (const mrAggregated of ['0x' + 'ab'.repeat(33), 'not-hex']) {
+        const response = await appFetch(new Request('http://localhost:3001/bootAuth/app', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...validBootInfo, mrAggregated }),
+        }));
+
+        expect(response.status).toBe(400);
+      }
+      expect(mockReadContract).not.toHaveBeenCalled();
+    });
+});
 
   describe('POST /bootAuth/kms', () => {
     const validBootInfo = {

--- a/dstack/kms/auth-eth-bun/index.ts
+++ b/dstack/kms/auth-eth-bun/index.ts
@@ -8,18 +8,23 @@ import { z } from 'zod';
 import { createPublicClient, http, type Address, type Hex } from 'viem';
 
 // zod schemas for validation - compatible with original fastify implementation
+const boundedHex = (bytes: number, description: string) =>
+  z.string()
+    .regex(/^0x[0-9a-fA-F]*$/, `${description} must be hexadecimal`)
+    .max(2 + bytes * 2, `${description} exceeds ${bytes} bytes`);
+
 const BootInfoSchema = z.object({
-  // required fields (matching original fastify schema)
-  mrAggregated: z.string().describe('aggregated MR measurement'),
-  osImageHash: z.string().describe('OS Image hash'),
-  appId: z.string().describe('application ID'),
-  composeHash: z.string().describe('compose hash'),
-  instanceId: z.string().describe('instance ID'),
-  deviceId: z.string().describe('device ID'),
-  // optional fields (for full compatibility with BootInfo interface)
-  tcbStatus: z.string().optional().default(''),
-  advisoryIds: z.array(z.string()).optional().default([]),
-  mrSystem: z.string().optional().default('')
+  // Short hexadecimal values remain compatible with the original backend,
+  // which left-pads them before making the contract call.
+  mrAggregated: boundedHex(32, 'aggregated MR measurement'),
+  osImageHash: boundedHex(32, 'OS Image hash'),
+  appId: boundedHex(20, 'application ID'),
+  composeHash: boundedHex(32, 'compose hash'),
+  instanceId: boundedHex(20, 'instance ID'),
+  deviceId: boundedHex(32, 'device ID'),
+  tcbStatus: z.string().max(128).optional().default(''),
+  advisoryIds: z.array(z.string().max(256)).max(128).optional().default([]),
+  mrSystem: boundedHex(32, 'system MR measurement').optional().default('')
 });
 
 const BootResponseSchema = z.object({

--- a/dstack/kms/auth-eth-bun/index.ts
+++ b/dstack/kms/auth-eth-bun/index.ts
@@ -10,8 +10,11 @@ import { createPublicClient, http, type Address, type Hex } from 'viem';
 // zod schemas for validation - compatible with original fastify implementation
 const boundedHex = (bytes: number, description: string) =>
   z.string()
-    .regex(/^0x[0-9a-fA-F]*$/, `${description} must be hexadecimal`)
-    .max(2 + bytes * 2, `${description} exceeds ${bytes} bytes`);
+    .regex(/^(?:0x)?[0-9a-fA-F]*$/, `${description} must be hexadecimal`)
+    .refine(
+      (value) => value.replace(/^0x/, '').length <= bytes * 2,
+      `${description} exceeds ${bytes} bytes`,
+    );
 
 const BootInfoSchema = z.object({
   // Short hexadecimal values remain compatible with the original backend,


### PR DESCRIPTION
> **STACKED PR — merge #941 first.**

## Problem

The authorization boot payload/schema accepted unbounded or structurally unconstrained data. A malformed backend response could consume excessive resources or introduce unsupported fields/state during KMS startup.

## Root cause and fix

Define and enforce the supported boot schema, including size/count bounds, before installing authorization state.

## Implementation

The branch records the following focused implementation work:

- `fix(kms): bound authorization boot schema`
- `fix(kms): preserve unprefixed auth measurements`

Changed paths:

- `dstack/kms/auth-eth-bun/index.test.ts`
- `dstack/kms/auth-eth-bun/index.ts`

## Scope

This PR addresses one logical `kms` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #941
- GitHub base branch: `codex/fix-kms-auth-locks`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-kms-auth-locks..origin/codex/fix-kms-auth-boot-schema`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
