### PR TITLE
[STACKED on #958] feat(kms): emit authorization policy audit events

### DIFF
--- a/dstack/kms/auth-eth/contracts/DstackApp.sol
+++ b/dstack/kms/auth-eth/contracts/DstackApp.sol
@@ -40,6 +40,8 @@ contract DstackApp is
     event UpgradesDisabled();
     event AllowAnyDeviceSet(bool allowAny);
     event RequireTcbUpToDateSet(bool requireUpToDate);
+    /// @notice Additive audit event for reconstructing authorization policy.
+    event PolicyChanged(address indexed actor, bytes32 indexed policy, bytes32 indexed value, bool enabled);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -94,12 +96,14 @@ contract DstackApp is
         if (initialDeviceId != bytes32(0)) {
             allowedDeviceIds[initialDeviceId] = true;
             emit DeviceAdded(initialDeviceId);
+            _emitPolicy("device", initialDeviceId, true);
         }
 
         // Add initial compose hash if provided
         if (initialComposeHash != bytes32(0)) {
             allowedComposeHashes[initialComposeHash] = true;
             emit ComposeHashAdded(initialComposeHash);
+            _emitPolicy("compose-hash", initialComposeHash, true);
         }
 
         __Ownable_init(initialOwner);
@@ -130,44 +134,55 @@ contract DstackApp is
     }
 
     // Function to authorize upgrades (required by UUPSUpgradeable)
-    function _authorizeUpgrade(address) internal view override onlyOwner {
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
         require(!_upgradesDisabled, "Upgrades are permanently disabled");
+        _emitPolicy("implementation-upgrade", bytes32(uint256(uint160(newImplementation))), true);
+    }
+
+    function _emitPolicy(string memory policy, bytes32 value, bool enabled) internal {
+        emit PolicyChanged(msg.sender, keccak256(bytes(policy)), value, enabled);
     }
 
     // Add a compose hash to allowed list
     function addComposeHash(bytes32 composeHash) external onlyOwner {
         allowedComposeHashes[composeHash] = true;
         emit ComposeHashAdded(composeHash);
+        _emitPolicy("compose-hash", composeHash, true);
     }
 
     // Remove a compose hash from allowed list
     function removeComposeHash(bytes32 composeHash) external onlyOwner {
         allowedComposeHashes[composeHash] = false;
         emit ComposeHashRemoved(composeHash);
+        _emitPolicy("compose-hash", composeHash, false);
     }
 
     // Set whether any device is allowed to boot this app
     function setAllowAnyDevice(bool _allowAnyDevice) external onlyOwner {
         allowAnyDevice = _allowAnyDevice;
         emit AllowAnyDeviceSet(_allowAnyDevice);
+        _emitPolicy("allow-any-device", bytes32(0), _allowAnyDevice);
     }
 
     // Set whether TCB status must be UpToDate to boot this app
     function setRequireTcbUpToDate(bool _requireUpToDate) external onlyOwner {
         requireTcbUpToDate = _requireUpToDate;
         emit RequireTcbUpToDateSet(_requireUpToDate);
+        _emitPolicy("require-tcb-up-to-date", bytes32(0), _requireUpToDate);
     }
 
     // Add a device ID to allowed list
     function addDevice(bytes32 deviceId) external onlyOwner {
         allowedDeviceIds[deviceId] = true;
         emit DeviceAdded(deviceId);
+        _emitPolicy("device", deviceId, true);
     }
 
     // Remove a device ID from allowed list
     function removeDevice(bytes32 deviceId) external onlyOwner {
         allowedDeviceIds[deviceId] = false;
         emit DeviceRemoved(deviceId);
+        _emitPolicy("device", deviceId, false);
     }
 
     // Check if an app is allowed to boot
@@ -202,6 +217,7 @@ contract DstackApp is
     function disableUpgrades() external onlyOwner {
         _upgradesDisabled = true;
         emit UpgradesDisabled();
+        _emitPolicy("upgrades-disabled", bytes32(0), true);
     }
 
     // Add storage gap for upgradeable contracts

--- a/dstack/kms/auth-eth/contracts/DstackKms.sol
+++ b/dstack/kms/auth-eth/contracts/DstackKms.sol
@@ -59,6 +59,9 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
     // slither-disable-next-line unindexed-event-address
     event AppImplementationSet(address implementation);
     event AppDeployedViaFactory(address indexed appId, address indexed deployer);
+    /// @notice Additive audit event for reconstructing authorization policy.
+    /// @dev `value` is the affected bytes32 value, address, or hash of dynamic public data.
+    event PolicyChanged(address indexed actor, bytes32 indexed policy, bytes32 indexed value, bool enabled);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -75,6 +78,7 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
         if (_appImplementation != address(0)) {
             appImplementation = _appImplementation;
             emit AppImplementationSet(_appImplementation);
+            _emitPolicy("app-implementation", bytes32(uint256(uint160(_appImplementation))), true);
         }
     }
 
@@ -96,12 +100,19 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
     }
 
     // Function to authorize upgrades (required by UUPSUpgradeable)
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner { }
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {
+        _emitPolicy("implementation-upgrade", bytes32(uint256(uint160(newImplementation))), true);
+    }
+
+    function _emitPolicy(string memory policy, bytes32 value, bool enabled) internal {
+        emit PolicyChanged(msg.sender, keccak256(bytes(policy)), value, enabled);
+    }
 
     // Function to set KMS information
     function setKmsInfo(KmsInfo memory info) external onlyOwner {
         kmsInfo = info;
         emit KmsInfoSet(info.k256Pubkey);
+        _emitPolicy("kms-info", keccak256(info.k256Pubkey), true);
     }
 
     // Function to set KMS quote
@@ -118,6 +129,7 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
     function setGatewayAppId(string memory appId) external onlyOwner {
         gatewayAppId = appId;
         emit GatewayAppIdSet(appId);
+        _emitPolicy("gateway-app-id", keccak256(bytes(appId)), true);
     }
 
     /// @notice Register an app address as known to this KMS.
@@ -133,6 +145,7 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
         require(appId != address(0), "Invalid app ID");
         registeredApps[appId] = true;
         emit AppRegistered(appId);
+        _emitPolicy("registered-app", bytes32(uint256(uint160(appId))), true);
     }
 
     // Function to set DstackApp implementation contract address
@@ -140,6 +153,7 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
         require(_implementation != address(0), "Invalid implementation address");
         appImplementation = _implementation;
         emit AppImplementationSet(_implementation);
+        _emitPolicy("app-implementation", bytes32(uint256(uint160(_implementation))), true);
     }
 
     // Factory method: Deploy and register DstackApp in single transaction
@@ -200,36 +214,42 @@ contract DstackKms is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, E
     function addKmsAggregatedMr(bytes32 mrAggregated) external onlyOwner {
         kmsAllowedAggregatedMrs[mrAggregated] = true;
         emit KmsAggregatedMrAdded(mrAggregated);
+        _emitPolicy("kms-aggregated-mr", mrAggregated, true);
     }
 
     // Function to deregister an aggregated MR measurement
     function removeKmsAggregatedMr(bytes32 mrAggregated) external onlyOwner {
         kmsAllowedAggregatedMrs[mrAggregated] = false;
         emit KmsAggregatedMrRemoved(mrAggregated);
+        _emitPolicy("kms-aggregated-mr", mrAggregated, false);
     }
 
     // Function to register a KMS device ID
     function addKmsDevice(bytes32 deviceId) external onlyOwner {
         kmsAllowedDeviceIds[deviceId] = true;
         emit KmsDeviceAdded(deviceId);
+        _emitPolicy("kms-device", deviceId, true);
     }
 
     // Function to deregister a KMS device ID
     function removeKmsDevice(bytes32 deviceId) external onlyOwner {
         kmsAllowedDeviceIds[deviceId] = false;
         emit KmsDeviceRemoved(deviceId);
+        _emitPolicy("kms-device", deviceId, false);
     }
 
     // Function to register an image measurement
     function addOsImageHash(bytes32 osImageHash) external onlyOwner {
         allowedOsImages[osImageHash] = true;
         emit OsImageHashAdded(osImageHash);
+        _emitPolicy("os-image", osImageHash, true);
     }
 
     // Function to deregister an image measurement
     function removeOsImageHash(bytes32 osImageHash) external onlyOwner {
         allowedOsImages[osImageHash] = false;
         emit OsImageHashRemoved(osImageHash);
+        _emitPolicy("os-image", osImageHash, false);
     }
 
     // Function to check if KMS is allowed to boot

--- a/dstack/kms/auth-eth/test/EventAudit.t.sol
+++ b/dstack/kms/auth-eth/test/EventAudit.t.sol
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "openzeppelin-foundry-upgrades/Upgrades.sol";
+import "../contracts/DstackKms.sol";
+import "../contracts/DstackApp.sol";
+
+contract EventAuditTest is Test {
+    bytes32 private constant AUDIT_TOPIC = keccak256("PolicyChanged(address,bytes32,bytes32,bool)");
+
+    address private owner;
+    address private outsider;
+    DstackKms private kms;
+    DstackApp private app;
+
+    function setUp() public {
+        owner = makeAddr("audit-owner");
+        outsider = makeAddr("audit-outsider");
+        vm.startPrank(owner);
+        DstackApp appImplementation = new DstackApp();
+        kms = DstackKms(
+            Upgrades.deployUUPSProxy(
+                "DstackKms.sol", abi.encodeCall(DstackKms.initialize, (owner, address(appImplementation)))
+            )
+        );
+        app = DstackApp(
+            Upgrades.deployUUPSProxy(
+                "DstackApp.sol",
+                abi.encodeWithSignature(
+                    "initialize(address,bool,bool,bool,bytes32,bytes32)",
+                    owner,
+                    false,
+                    false,
+                    false,
+                    bytes32(0),
+                    bytes32(0)
+                )
+            )
+        );
+        vm.stopPrank();
+    }
+
+    function test_KmsPolicyEventsReconstructQueriedState() public {
+        bytes32 mr = keccak256("audit-mr");
+        bytes32 device = keccak256("audit-device");
+        bytes32 image = keccak256("audit-image");
+        string memory gateway = "audit-gateway";
+
+        vm.recordLogs();
+        vm.startPrank(owner);
+        kms.addKmsAggregatedMr(mr);
+        kms.addKmsDevice(device);
+        kms.addOsImageHash(image);
+        kms.setGatewayAppId(gateway);
+        kms.registerApp(address(app));
+        kms.removeKmsAggregatedMr(mr);
+        vm.stopPrank();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        _assertAudit(logs, owner, "kms-aggregated-mr", mr, true);
+        _assertAudit(logs, owner, "kms-device", device, true);
+        _assertAudit(logs, owner, "os-image", image, true);
+        _assertAudit(logs, owner, "gateway-app-id", keccak256(bytes(gateway)), true);
+        _assertAudit(logs, owner, "registered-app", bytes32(uint256(uint160(address(app)))), true);
+        _assertAudit(logs, owner, "kms-aggregated-mr", mr, false);
+
+        assertFalse(kms.kmsAllowedAggregatedMrs(mr));
+        assertTrue(kms.kmsAllowedDeviceIds(device));
+        assertTrue(kms.allowedOsImages(image));
+        assertEq(kms.gatewayAppId(), gateway);
+        assertTrue(kms.registeredApps(address(app)));
+    }
+
+    function test_AppPolicyEventsReconstructQueriedState() public {
+        bytes32 composeHash = keccak256("audit-compose");
+        bytes32 device = keccak256("audit-app-device");
+
+        vm.recordLogs();
+        vm.startPrank(owner);
+        app.addComposeHash(composeHash);
+        app.addDevice(device);
+        app.setAllowAnyDevice(true);
+        app.setRequireTcbUpToDate(true);
+        app.removeDevice(device);
+        app.disableUpgrades();
+        vm.stopPrank();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        _assertAudit(logs, owner, "compose-hash", composeHash, true);
+        _assertAudit(logs, owner, "device", device, true);
+        _assertAudit(logs, owner, "allow-any-device", bytes32(0), true);
+        _assertAudit(logs, owner, "require-tcb-up-to-date", bytes32(0), true);
+        _assertAudit(logs, owner, "device", device, false);
+        _assertAudit(logs, owner, "upgrades-disabled", bytes32(0), true);
+
+        assertTrue(app.allowedComposeHashes(composeHash));
+        assertFalse(app.allowedDeviceIds(device));
+        assertTrue(app.allowAnyDevice());
+        assertTrue(app.requireTcbUpToDate());
+    }
+
+    function test_InvalidMutationEmitsNoAuditAndLeavesNoPartialState() public {
+        bytes32 image = keccak256("unauthorized-image");
+        vm.recordLogs();
+        vm.prank(outsider);
+        vm.expectRevert();
+        kms.addOsImageHash(image);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_auditCount(logs), 0);
+        assertFalse(kms.allowedOsImages(image));
+    }
+
+    function test_ReorgDropsOrphanEventAndCanonicalEventRebuildsState() public {
+        bytes32 orphaned = keccak256("orphaned-compose");
+        bytes32 canonical = keccak256("canonical-compose");
+        uint256 snapshot = vm.snapshotState();
+
+        vm.recordLogs();
+        vm.prank(owner);
+        app.addComposeHash(orphaned);
+        Vm.Log[] memory orphanLogs = vm.getRecordedLogs();
+        _assertAudit(orphanLogs, owner, "compose-hash", orphaned, true);
+        assertTrue(app.allowedComposeHashes(orphaned));
+
+        assertTrue(vm.revertToState(snapshot));
+        assertFalse(app.allowedComposeHashes(orphaned));
+
+        vm.recordLogs();
+        vm.prank(owner);
+        app.addComposeHash(canonical);
+        Vm.Log[] memory canonicalLogs = vm.getRecordedLogs();
+        _assertAudit(canonicalLogs, owner, "compose-hash", canonical, true);
+        assertEq(_auditCount(canonicalLogs), 1);
+        assertTrue(app.allowedComposeHashes(canonical));
+        assertFalse(app.allowedComposeHashes(orphaned));
+    }
+
+    function test_UpgradeAuditIncludesActorAndImplementation() public {
+        vm.startPrank(owner);
+        DstackApp replacement = new DstackApp();
+        vm.recordLogs();
+        app.upgradeToAndCall(address(replacement), "");
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.stopPrank();
+
+        _assertAudit(
+            logs,
+            owner,
+            "implementation-upgrade",
+            bytes32(uint256(uint160(address(replacement)))),
+            true
+        );
+        assertEq(Upgrades.getImplementationAddress(address(app)), address(replacement));
+    }
+
+    function _assertAudit(
+        Vm.Log[] memory logs,
+        address actor,
+        string memory policy,
+        bytes32 value,
+        bool enabled
+    )
+        private
+        pure
+    {
+        bytes32 actorTopic = bytes32(uint256(uint160(actor)));
+        bytes32 policyTopic = keccak256(bytes(policy));
+        for (uint256 i = 0; i < logs.length; ++i) {
+            Vm.Log memory entry = logs[i];
+            if (
+                entry.topics.length == 4 && entry.topics[0] == AUDIT_TOPIC && entry.topics[1] == actorTopic
+                    && entry.topics[2] == policyTopic && entry.topics[3] == value && abi.decode(entry.data, (bool)) == enabled
+            ) {
+                return;
+            }
+        }
+        revert("expected policy audit event not found");
+    }
+
+    function _auditCount(Vm.Log[] memory logs) private pure returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length == 4 && logs[i].topics[0] == AUDIT_TOPIC) ++count;
+        }
+    }
+}

--- a/dstack/kms/auth-eth/test/EventAudit.t.sol
+++ b/dstack/kms/auth-eth/test/EventAudit.t.sol
@@ -149,13 +149,7 @@ contract EventAuditTest is Test {
         Vm.Log[] memory logs = vm.getRecordedLogs();
         vm.stopPrank();
 
-        _assertAudit(
-            logs,
-            owner,
-            "implementation-upgrade",
-            bytes32(uint256(uint160(address(replacement)))),
-            true
-        );
+        _assertAudit(logs, owner, "implementation-upgrade", bytes32(uint256(uint160(address(replacement)))), true);
         assertEq(Upgrades.getImplementationAddress(address(app)), address(replacement));
     }
 
@@ -175,7 +169,8 @@ contract EventAuditTest is Test {
             Vm.Log memory entry = logs[i];
             if (
                 entry.topics.length == 4 && entry.topics[0] == AUDIT_TOPIC && entry.topics[1] == actorTopic
-                    && entry.topics[2] == policyTopic && entry.topics[3] == value && abi.decode(entry.data, (bool)) == enabled
+                    && entry.topics[2] == policyTopic && entry.topics[3] == value
+                    && abi.decode(entry.data, (bool)) == enabled
             ) {
                 return;
             }

--- a/dstack/kms/src/main_service/upgrade_authority.rs
+++ b/dstack/kms/src/main_service/upgrade_authority.rs
@@ -245,6 +245,92 @@ pub(crate) async fn ensure_kms_allowed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Webhook;
+    use ra_tls::attestation::TeeVariant;
+    use serde_json::Value;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn boot_info(identity: u8) -> BootInfo {
+        BootInfo {
+            tee_variant: TeeVariant::DstackTdx,
+            mr_aggregated: vec![identity; 32],
+            os_image_hash: vec![identity.wrapping_add(1); 32],
+            mr_system: vec![identity.wrapping_add(2); 32],
+            app_id: vec![identity.wrapping_add(3); 20],
+            compose_hash: vec![identity.wrapping_add(4); 32],
+            instance_id: vec![identity.wrapping_add(5); 20],
+            device_id: vec![identity.wrapping_add(6); 32],
+            key_provider_info: vec![identity.wrapping_add(7); 32],
+            tcb_status: "UpToDate".into(),
+            advisory_ids: vec![],
+        }
+    }
+
+    fn serve(responses: Vec<&'static str>) -> (String, thread::JoinHandle<Vec<(String, Value)>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request = Vec::new();
+                let mut chunk = [0u8; 4096];
+                let header_end = loop {
+                    let read = stream.read(&mut chunk).unwrap();
+                    assert_ne!(read, 0, "request ended before headers");
+                    request.extend_from_slice(&chunk[..read]);
+                    if let Some(position) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                    {
+                        break position + 4;
+                    }
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.split_once(':').and_then(|(name, value)| {
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().unwrap())
+                        })
+                    })
+                    .unwrap_or(0);
+                while request.len() < header_end + content_length {
+                    let read = stream.read(&mut chunk).unwrap();
+                    assert_ne!(read, 0, "request ended before body");
+                    request.extend_from_slice(&chunk[..read]);
+                }
+                let path = headers
+                    .lines()
+                    .next()
+                    .unwrap()
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap()
+                    .to_string();
+                let body =
+                    serde_json::from_slice(&request[header_end..header_end + content_length])
+                        .unwrap();
+                requests.push((path, body));
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response.len(),
+                    response
+                )
+                .unwrap();
+            }
+            requests
+        });
+        (format!("http://{address}"), handle)
+    }
+
+    fn webhook(url: String) -> AuthApi {
+        AuthApi::Webhook {
+            webhook: Webhook { url },
+        }
+    }
 
     #[test]
     fn app_id_len_must_be_20_bytes() {
@@ -254,5 +340,68 @@ mod tests {
             Ok(()) => panic!("19-byte app_id must reject"),
             Err(err) => assert!(err.to_string().contains("app_id must be 20 bytes")),
         }
+    }
+
+    #[rocket::async_test]
+    async fn repeated_authorization_is_never_served_from_a_decision_cache() {
+        let (url, server) = serve(vec![
+            r#"{"isAllowed":true,"gatewayAppId":"gateway","reason":"initial allow"}"#,
+            r#"{"isAllowed":false,"gatewayAppId":"gateway","reason":"revoked"}"#,
+        ]);
+        let auth = webhook(url);
+        let info = boot_info(1);
+
+        let first = auth.is_app_allowed(&info, false).await.unwrap();
+        let repeated = auth.is_app_allowed(&info, false).await.unwrap();
+        assert!(first.is_allowed);
+        assert!(!repeated.is_allowed);
+        assert_eq!(repeated.reason, "revoked");
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].0, "/bootAuth/app");
+        assert_eq!(requests[1].0, "/bootAuth/app");
+        assert_eq!(requests[0].1, requests[1].1);
+    }
+
+    #[rocket::async_test]
+    async fn authorization_scope_preserves_route_and_every_identity_field() {
+        let (url, server) = serve(vec![
+            r#"{"isAllowed":true,"gatewayAppId":"gateway","reason":"app"}"#,
+            r#"{"isAllowed":true,"gatewayAppId":"gateway","reason":"kms"}"#,
+        ]);
+        let auth = webhook(url);
+        let app = boot_info(10);
+        let kms = boot_info(20);
+
+        assert!(auth.is_app_allowed(&app, false).await.unwrap().is_allowed);
+        assert!(auth.is_app_allowed(&kms, true).await.unwrap().is_allowed);
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests[0].0, "/bootAuth/app");
+        assert_eq!(requests[1].0, "/bootAuth/kms");
+        assert_ne!(requests[0].1["appId"], requests[1].1["appId"]);
+        assert_ne!(requests[0].1["deviceId"], requests[1].1["deviceId"]);
+        assert_ne!(requests[0].1["osImageHash"], requests[1].1["osImageHash"]);
+        assert_ne!(requests[0].1["composeHash"], requests[1].1["composeHash"]);
+        assert_ne!(requests[0].1["instanceId"], requests[1].1["instanceId"]);
+        assert_ne!(requests[0].1["mrAggregated"], requests[1].1["mrAggregated"]);
+    }
+
+    #[rocket::async_test]
+    async fn malformed_backend_response_fails_closed_and_next_request_recovers() {
+        let (url, server) = serve(vec![
+            "not-json",
+            r#"{"isAllowed":true,"gatewayAppId":"gateway","reason":"recovered"}"#,
+        ]);
+        let auth = webhook(url);
+        let info = boot_info(30);
+
+        let error = auth.is_app_allowed(&info, false).await.unwrap_err();
+        assert!(error.to_string().contains("failed to decode response"));
+        let recovered = auth.is_app_allowed(&info, false).await.unwrap();
+        assert!(recovered.is_allowed);
+        assert_eq!(recovered.reason, "recovered");
+        assert_eq!(server.join().unwrap().len(), 2);
     }
 }

--- a/dstack/kms/src/main_service/upgrade_authority.rs
+++ b/dstack/kms/src/main_service/upgrade_authority.rs
@@ -286,7 +286,7 @@ mod tests {
                         break position + 4;
                     }
                 };
-                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
                 let content_length = headers
                     .lines()
                     .find_map(|line| {


### PR DESCRIPTION
> **STACKED PR — merge #958 first.**

## Problem

Authorization policy changes and decisions had no complete on-chain/event audit trail. Operators could not reconstruct which policy state produced a grant or prove that decisions were evaluated without stale caching.

## Root cause and fix

Emit policy and decision audit events with the identifiers/state needed to reconstruct authorization history.

## Implementation

The branch records the following focused implementation work:

- `feat(kms): emit authorization policy audit events`
- `test(kms): reconstruct policy from audit events`
- `test(kms): prove authorization decisions are uncached`
- `fix(test): own captured authorization headers`

Changed paths:

- `dstack/kms/auth-eth/contracts/DstackApp.sol`
- `dstack/kms/auth-eth/contracts/DstackKms.sol`
- `dstack/kms/auth-eth/test/EventAudit.t.sol`
- `dstack/kms/src/main_service/upgrade_authority.rs`

## Scope

This PR addresses one logical `kms` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #958
- GitHub base branch: `codex/feat-kms-finalized-ethereum-auth`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/feat-kms-finalized-ethereum-auth..origin/codex/feat-kms-auth-policy-audit`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
