### PR TITLE
[STACKED on #883] fix(util): write TPM quotes atomically

### DIFF
--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -1170,7 +1170,8 @@ fn cmd_tpm_quote(args: TpmQuoteArgs) -> Result<()> {
         serde_json::to_string_pretty(&tpm_quote).context("Failed to serialize TPM quote")?;
 
     if let Some(output_path) = args.output {
-        fs::write(&output_path, quote_json).context("Failed to write quote to file")?;
+        safe_write_with_mode(&output_path, &quote_json, 0o600)
+            .context("Failed to write quote to file")?;
         eprintln!("TPM quote written to: {:?}", output_path);
     } else {
         println!("{}", quote_json);


### PR DESCRIPTION
> **STACKED PR — merge #883 first.**

## Problem

TPM quote output was overwritten in place. A concurrent reader or interrupted write could consume a truncated quote and report an attestation parse/signature failure.

## Root cause and fix

Write the complete quote to a temporary file and atomically rename it to the requested output.

## Implementation

The branch records the following focused implementation work:

- `fix(util): write TPM quotes atomically`

Changed paths:

- `dstack/dstack-util/src/main.rs`

## Scope

This PR addresses one logical `util` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #883
- GitHub base branch: `codex/fix-guest-atomic-credentials`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/fix-guest-atomic-credentials..origin/codex/fix-util-atomic-tpm-quotes`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
