### PR TITLE
[STACKED on #964] fix(mock-attestation): model complete DCAP collateral

### DIFF
--- a/dstack/crates/mock-attestation/src/server.rs
+++ b/dstack/crates/mock-attestation/src/server.rs
@@ -60,6 +60,10 @@ pub fn router(state: Arc<MockCollateralState>) -> Router {
     Router::new()
         .route("/sgx/certification/v4/pckcrl", get(pck_crl))
         .route("/sgx/certification/v4/rootcacrl", get(pccs_root_crl))
+        // Older guest images use the SGX PCS prefix for shared DCAP collateral.
+        // Serve both spellings so simulated TDX evidence remains compatible.
+        .route("/sgx/certification/v4/tcb", get(tcb_info))
+        .route("/sgx/certification/v4/qe/identity", get(qe_identity))
         .route("/tdx/certification/v4/tcb", get(tcb_info))
         .route("/tdx/certification/v4/qe/identity", get(qe_identity))
         .route("/vcek/v1/Milan/cert_chain", get(sev_ca_chain))

--- a/dstack/crates/mock-attestation/src/server.rs
+++ b/dstack/crates/mock-attestation/src/server.rs
@@ -94,8 +94,11 @@ async fn pccs_root_crl(State(state): State<Arc<MockCollateralState>>) -> impl In
 
 async fn pck_crl(State(state): State<Arc<MockCollateralState>>) -> impl IntoResponse {
     binary(
-        state.tdx.root_crl_der(),
-        Some(("SGX-PCK-CRL-Issuer-Chain", state.tdx.root_ca_pem())),
+        state.tdx.pck_crl_der(),
+        Some((
+            "SGX-PCK-CRL-Issuer-Chain",
+            state.tdx.sample_collateral().unwrap().pck_crl_issuer_chain,
+        )),
     )
 }
 

--- a/dstack/crates/mock-attestation/src/tdx.rs
+++ b/dstack/crates/mock-attestation/src/tdx.rs
@@ -179,6 +179,10 @@ impl TdxGenerator {
         self.root_crl.clone()
     }
 
+    pub fn pck_crl_der(&self) -> Vec<u8> {
+        self.pck_crl.clone()
+    }
+
     pub fn attest(&self, report_data: [u8; 64]) -> Result<TdxEvidence> {
         self.attest_with_rtmrs(
             report_data,

--- a/dstack/crates/mock-attestation/src/tdx.rs
+++ b/dstack/crates/mock-attestation/src/tdx.rs
@@ -3,17 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use dcap_qvl::QuoteCollateralV3;
 use dcap_qvl::quote::{
     AuthData, AuthDataV4, CertificationData, Data, EnclaveReport, Header,
     QEReportCertificationData, Quote, Report, TDReport10,
 };
-use p256::ecdsa::{Signature, SigningKey, signature::Signer};
+use dcap_qvl::QuoteCollateralV3;
+use p256::ecdsa::{signature::Signer, Signature, SigningKey};
 use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, CertificateRevocationListParams,
     CertifiedKey, CustomExtension, DnType, ExtendedKeyUsagePurpose, IsCa, KeyIdMethod, KeyPair,
-    KeyUsagePurpose, PKCS_ECDSA_P256_SHA256, RemoteKeyPair, SerialNumber, SignatureAlgorithm,
+    KeyUsagePurpose, RemoteKeyPair, SerialNumber, SignatureAlgorithm, PKCS_ECDSA_P256_SHA256,
 };
 use scale::Encode;
 use serde_json::json;
@@ -30,8 +30,10 @@ const INTEL_QE_VENDOR_ID: [u8; 16] = [
 pub struct TdxGenerator {
     root: Certificate,
     root_signing_key: SigningKey,
+    pck_ca: Certificate,
     pck: Certificate,
     pck_key: SigningKey,
+    pck_crl: Vec<u8>,
     tcb_signer: Certificate,
     tcb_signer_key: SigningKey,
     qe_signer: Certificate,
@@ -88,12 +90,19 @@ impl TdxGenerator {
             },
             root_signing_key,
         ) = make_root(&seed)?;
+        let (pck_ca, pck_ca_key) = make_ca(
+            "Mock Intel SGX PCK Platform CA",
+            "tdx-pck-ca",
+            &seed,
+            &root,
+            &root_key,
+        )?;
         let (pck, pck_key) = make_leaf(
             "Mock Intel SGX PCK Certificate",
             "tdx-pck",
             &seed,
-            &root,
-            &root_key,
+            &pck_ca,
+            &pck_ca_key,
             true,
         )?;
         let (tcb_signer, tcb_signer_key) = make_leaf(
@@ -112,6 +121,17 @@ impl TdxGenerator {
             &root_key,
             false,
         )?;
+        let pck_crl = CertificateRevocationListParams {
+            this_update: fixed_time(MOCK_PKI_NOT_BEFORE)?,
+            next_update: fixed_time(MOCK_PKI_NOT_AFTER)?,
+            crl_number: SerialNumber::from(1u64),
+            issuing_distribution_point: None,
+            revoked_certs: Vec::new(),
+            key_identifier_method: KeyIdMethod::Sha256,
+        }
+        .signed_by(&pck_ca, &pck_ca_key)?
+        .der()
+        .to_vec();
         let root_crl = CertificateRevocationListParams {
             this_update: fixed_time(MOCK_PKI_NOT_BEFORE)?,
             next_update: fixed_time(MOCK_PKI_NOT_AFTER)?,
@@ -126,8 +146,10 @@ impl TdxGenerator {
         Ok(Self {
             root,
             root_signing_key,
+            pck_ca,
             pck,
             pck_key,
+            pck_crl,
             tcb_signer,
             tcb_signer_key,
             qe_signer,
@@ -207,7 +229,8 @@ impl TdxGenerator {
             .map_err(|bytes: Vec<u8>| anyhow::anyhow!("invalid QE report size {}", bytes.len()))?;
         let qe_sig: Signature = self.pck_key.sign(&qe_report_bytes);
 
-        let pck_chain = format!("{}{}", self.pck.pem(), self.root.pem()).into_bytes();
+        let pck_chain =
+            format!("{}{}{}", self.pck.pem(), self.pck_ca.pem(), self.root.pem()).into_bytes();
         let qe_certification = QEReportCertificationData {
             qe_report: qe_report_bytes,
             qe_report_signature: qe_sig.to_bytes().into(),
@@ -287,9 +310,9 @@ impl TdxGenerator {
             "isvprodid":1, "tcbLevels":[{"tcb":{"isvsvn":1},"tcbDate":issue,"tcbStatus":"UpToDate"}]
         }).to_string();
         Ok(QuoteCollateralV3 {
-            pck_crl_issuer_chain: self.root.pem(),
+            pck_crl_issuer_chain: format!("{}{}", self.pck_ca.pem(), self.root.pem()),
             root_ca_crl: self.root_crl.clone(),
-            pck_crl: self.root_crl.clone(),
+            pck_crl: self.pck_crl.clone(),
             tcb_info_issuer_chain: format!("{}{}", self.tcb_signer.pem(), self.root.pem()),
             tcb_info_signature: sign_raw(&self.tcb_signer_key, tcb_info.as_bytes())?,
             tcb_info,
@@ -320,6 +343,25 @@ fn make_root(seed: &[u8; 32]) -> Result<(CertifiedKey, SigningKey)> {
     ]);
     let cert = params.self_signed(&key_pair)?;
     Ok((CertifiedKey { cert, key_pair }, signing_key))
+}
+
+fn make_ca(
+    name: &str,
+    label: &str,
+    seed: &[u8; 32],
+    issuer: &Certificate,
+    issuer_key: &KeyPair,
+) -> Result<(Certificate, KeyPair)> {
+    let (key, _) = deterministic_key_pair(seed, label)?;
+    let mut params = cert_params(name)?;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages.extend([
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ]);
+    let cert = params.signed_by(&key, issuer, issuer_key)?;
+    Ok((cert, key))
 }
 
 fn make_leaf(
@@ -446,14 +488,13 @@ mod tests {
         );
         let mut tampered = evidence.quote.clone();
         tampered[100] ^= 1;
-        assert!(
-            verifier
-                .verify(&tampered, &evidence.collateral, now)
-                .is_err()
-        );
-        assert!(
-            crate::ensure_report_data(&verified.report.as_td10().unwrap().report_data, &[0x24; 64])
-                .is_err()
-        );
+        assert!(verifier
+            .verify(&tampered, &evidence.collateral, now)
+            .is_err());
+        assert!(crate::ensure_report_data(
+            &verified.report.as_td10().unwrap().report_data,
+            &[0x24; 64]
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
> **STACKED PR — merge #964 first.**

## Problem

Mock DCAP collateral omitted parts of the certificate/CRL/TCB structure expected by the production quote verifier. Simulator quotes could not exercise the complete verification path and failed for missing collateral rather than quote content.

## Root cause and fix

Generate a complete internally consistent DCAP collateral set from the seeded mock PKI.

## Implementation

The branch records the following focused implementation work:

- `fix(mock-attestation): serve legacy DCAP paths`
- `fix(mock-attestation): model the PCK CA chain`
- `fix(mock-attestation): serve the PCK issuer CRL`

Changed paths:

- `dstack/crates/mock-attestation/src/server.rs`
- `dstack/crates/mock-attestation/src/tdx.rs`

## Scope

This PR addresses one logical `mock-attestation` finding. It intentionally excludes the acceptance-test infrastructure from #841 and unrelated product fixes from #840.

## Dependency and merge order

- Parent PR: #964
- GitHub base branch: `codex/feat-simulator-seeded-attestation`
- Merge the parent first; this PR contains only the additional delta above that parent.

## Verification

- `git diff --check origin/codex/feat-simulator-seeded-attestation..origin/codex/fix-mock-attestation-dcap-collateral`: passed.
- The declared base was verified as an ancestor of the PR head.
- Focused compile/check verification was run for the changed component where applicable; non-Rust packaging or configuration changes were reviewed against their exact branch delta.
