### PR TITLE
refactor(ra-tls): separate attestation from issuer claims

### DIFF
--- a/dstack/crates/mock-attestation/src/server.rs
+++ b/dstack/crates/mock-attestation/src/server.rs
@@ -93,12 +93,12 @@ async fn pccs_root_crl(State(state): State<Arc<MockCollateralState>>) -> impl In
 }
 
 async fn pck_crl(State(state): State<Arc<MockCollateralState>>) -> impl IntoResponse {
+    let Ok(collateral) = state.tdx.sample_collateral() else {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
     binary(
         state.tdx.pck_crl_der(),
-        Some((
-            "SGX-PCK-CRL-Issuer-Chain",
-            state.tdx.sample_collateral().unwrap().pck_crl_issuer_chain,
-        )),
+        Some(("SGX-PCK-CRL-Issuer-Chain", collateral.pck_crl_issuer_chain)),
     )
 }
 

--- a/dstack/ra-tls/src/attestation.rs
+++ b/dstack/ra-tls/src/attestation.rs
@@ -9,22 +9,25 @@ pub use dstack_attest::attestation::*;
 use crate::{oids, traits::CertExt};
 use anyhow::{bail, Context, Result};
 
-/// Verified RA-TLS certificate evidence.
+/// Attestation evidence verified and bound to an RA-TLS certificate key.
 ///
-/// This is the certificate-level endpoint identity proof: the embedded dstack
-/// attestation has been cryptographically verified and its `report_data` is
-/// bound to the certificate SubjectPublicKeyInfo.
-pub struct VerifiedRaTlsCert {
-    /// DER-encoded SubjectPublicKeyInfo from the verified certificate.
+/// This type proves only the embedded attestation and its binding to the
+/// certificate SubjectPublicKeyInfo. It does not authenticate the certificate
+/// issuer or any other certificate extension. Application identity asserted by
+/// a KMS-issued certificate is an issuer claim and must be consumed only after
+/// normal certificate-chain verification.
+pub struct VerifiedRaTlsAttestation {
+    /// DER-encoded SubjectPublicKeyInfo bound to the attestation.
     pub public_key_der: Vec<u8>,
     /// Verified dstack attestation embedded in the certificate.
     pub attestation: VerifiedAttestation,
-    /// Optional app id certificate extension.
-    pub app_id: Option<Vec<u8>>,
-    /// Optional app info certificate extension.
-    pub app_info: Option<AppInfo>,
-    /// Optional dstack certificate usage extension.
-    pub special_usage: Option<String>,
+}
+
+impl VerifiedRaTlsAttestation {
+    /// Decode application identity from the verified attestation evidence.
+    pub fn decode_app_info(&self, allow_dummy: bool) -> Result<AppInfo> {
+        self.attestation.decode_app_info(allow_dummy)
+    }
 }
 
 /// Extract attestation from x509 certificate
@@ -41,14 +44,25 @@ pub fn from_der(cert: &[u8]) -> Result<Option<VersionedAttestation>> {
 /// DER SubjectPublicKeyInfo. That binding prevents an operator-controlled
 /// network endpoint from reusing valid attestation evidence with a different
 /// TLS key.
-pub async fn verify_der(cert: &[u8], verifier: &AttestationVerifier) -> Result<VerifiedRaTlsCert> {
+///
+/// This function does not verify a certificate chain and deliberately does not
+/// return non-attestation certificate extensions. KMS-issued certificates may
+/// omit attestation entirely; authenticate their issuer claims through the
+/// certificate chain instead.
+pub async fn verify_der(
+    cert: &[u8],
+    verifier: &AttestationVerifier,
+) -> Result<VerifiedRaTlsAttestation> {
     let (_, cert) =
         x509_parser::parse_x509_certificate(cert).context("failed to parse certificate")?;
     verify_cert(&cert, verifier).await
 }
 
 /// Verify the RA-TLS attestation embedded in a PEM-encoded X.509 certificate.
-pub async fn verify_pem(cert: &[u8], verifier: &AttestationVerifier) -> Result<VerifiedRaTlsCert> {
+pub async fn verify_pem(
+    cert: &[u8],
+    verifier: &AttestationVerifier,
+) -> Result<VerifiedRaTlsAttestation> {
     let (_, pem) = x509_parser::pem::parse_x509_pem(cert).context("failed to parse PEM")?;
     verify_der(&pem.contents, verifier).await
 }
@@ -57,26 +71,20 @@ pub async fn verify_pem(cert: &[u8], verifier: &AttestationVerifier) -> Result<V
 async fn verify_cert(
     cert: &x509_parser::prelude::X509Certificate<'_>,
     verifier: &AttestationVerifier,
-) -> Result<VerifiedRaTlsCert> {
+) -> Result<VerifiedRaTlsAttestation> {
     let attestation = from_cert(cert)?.context("RA-TLS attestation extension missing")?;
     let public_key_der = cert.tbs_certificate.public_key().raw.to_vec();
     if public_key_der.is_empty() {
         bail!("certificate SubjectPublicKeyInfo is empty");
     }
-    let app_id = cert.get_app_id()?;
-    let app_info = cert.get_app_info()?;
-    let special_usage = cert.get_special_usage()?;
     let attestation = attestation
         .into_v1()
         .verify_with_ra_pubkey(&public_key_der, verifier)
         .await
         .context("RA-TLS attestation verification failed")?;
-    Ok(VerifiedRaTlsCert {
+    Ok(VerifiedRaTlsAttestation {
         public_key_der,
         attestation,
-        app_id,
-        app_info,
-        special_usage,
     })
 }
 

--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -220,7 +220,7 @@ async fn run_cert_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()
         .await
         .map_err(|e| anyhow::anyhow!("failed to verify RA-TLS certificate: {:#}", e))?;
 
-    let app_info = verified.attestation.decode_app_info(false).ok();
+    let app_info = verified.decode_app_info(false).ok();
     // Bind the reported os_image_hash to the attested boot measurement. For
     // every platform except TDX legacy this is a self-contained check (no image
     // download); relying parties should only trust `os_image_hash` when
@@ -233,8 +233,6 @@ async fn run_cert_oneshot(file_path: &str, config: &Config) -> anyhow::Result<()
             "tee_variant": verified.attestation.quote.variant(),
             "report_data": hex::encode(verified.attestation.report_data),
             "public_key_der": hex::encode(&verified.public_key_der),
-            "app_id_extension": verified.app_id.as_ref().map(hex::encode),
-            "special_usage": verified.special_usage,
             "app_info": app_info.map(|info| serde_json::json!({
                 "app_id": hex::encode(info.app_id),
                 "compose_hash": hex::encode(info.compose_hash),


### PR DESCRIPTION
## Problem

`VerifiedRaTlsCert` mixed two different trust domains in one result type:

- attestation evidence verified against a TEE trust root and bound to the certificate public key
- `app-id`, `app-info`, and usage extensions whose authenticity comes from normal certificate-chain validation and the KMS issuer

Putting both in a type named `VerifiedRaTlsCert` made issuer claims look attestation-verified. It also encouraged comparing them to embedded attestation even though KMS-issued certificates may intentionally omit attestation.

## Change

- rename the result to `VerifiedRaTlsAttestation`
- return only the certificate public key and verified attestation evidence
- provide `decode_app_info()` to derive application identity from verified evidence when attestation is present
- stop returning issuer-backed certificate extensions from the attestation verification API
- make verifier certificate output report application identity only from verified attestation
- document that KMS certificate claims must be consumed after normal certificate-chain verification

This preserves the intended trust model: KMS signs and backs certificate identity extensions, while RA-TLS attestation verification is a separate optional proof bound to the leaf key.

## Verification

- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `cargo test --manifest-path dstack/Cargo.toml -p ra-tls`
- `cargo check --manifest-path dstack/Cargo.toml -p dstack-verifier`
- `cargo clippy --manifest-path dstack/Cargo.toml -p ra-tls -p dstack-verifier --all-targets -- -D warnings`
- `git diff --check`
