### PR TITLE
fix(simulator): provide TDX configfs without a kernel provider

### DIFF
--- a/dstack/tee-simulator/Cargo.toml
+++ b/dstack/tee-simulator/Cargo.toml
@@ -22,7 +22,7 @@ dstack-types.workspace = true
 dstack-mr.workspace = true
 fuser.workspace = true
 libc.workspace = true
-nix = { workspace = true, features = ["fs", "mount"] }
+nix = { workspace = true, features = ["fs", "mount", "user"] }
 sd-notify.workspace = true
 sha2.workspace = true
 tpm2.workspace = true

--- a/dstack/tee-simulator/src/tdx.rs
+++ b/dstack/tee-simulator/src/tdx.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::{CString, OsStr};
+use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -207,8 +207,8 @@ impl TdxSimulatorFs {
     fn new(generator: Arc<TdxGenerator>) -> Result<Self> {
         Ok(Self {
             state: SimulatorState::new(generator, CCEL_FIXTURE, None)?,
-            uid: unsafe { libc::geteuid() },
-            gid: unsafe { libc::getegid() },
+            uid: nix::unistd::geteuid().as_raw(),
+            gid: nix::unistd::getegid().as_raw(),
         })
     }
 
@@ -448,24 +448,43 @@ pub(crate) fn ensure_configfs_mount(mountpoint: &Path) -> Result<()> {
     }
 
     if !mountpoint.is_dir() {
-        let source = CString::new("configfs")?;
-        let target = CString::new("/sys/kernel/config")?;
-        let fstype = CString::new("configfs")?;
-        let rc = unsafe {
-            libc::mount(
-                source.as_ptr(),
-                target.as_ptr(),
-                fstype.as_ptr(),
-                libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC,
-                std::ptr::null(),
-            )
-        };
-        if rc != 0 {
-            let error = std::io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::EBUSY) {
+        let flags = nix::mount::MsFlags::MS_NOSUID
+            | nix::mount::MsFlags::MS_NODEV
+            | nix::mount::MsFlags::MS_NOEXEC;
+        if let Err(error) = nix::mount::mount(
+            Some("configfs"),
+            "/sys/kernel/config",
+            Some("configfs"),
+            flags,
+            None::<&str>,
+        ) {
+            if error != nix::errno::Errno::EBUSY {
                 return Err(error).context("failed to mount configfs");
             }
         }
+    }
+    // configfs rejects arbitrary directories when no kernel TSM provider has
+    // registered the `tsm` subsystem. In a no-TEE development guest the
+    // simulator is that provider, so shadow the otherwise-empty configfs with
+    // a private tmpfs and create the userspace ABI hierarchy there.
+    if let Err(error) = std::fs::create_dir_all(mountpoint) {
+        if !matches!(error.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) {
+            return Err(error)
+                .with_context(|| format!("failed to create {}", mountpoint.display()));
+        }
+        let flags = nix::mount::MsFlags::MS_NOSUID
+            | nix::mount::MsFlags::MS_NODEV
+            | nix::mount::MsFlags::MS_NOEXEC;
+        nix::mount::mount(
+            Some("dstack-tee-simulator"),
+            "/sys/kernel/config",
+            Some("tmpfs"),
+            flags,
+            Some("mode=0755"),
+        )
+        .context("failed to mount simulator configfs shadow")?;
+        std::fs::create_dir_all(mountpoint)
+            .with_context(|| format!("failed to create {}", mountpoint.display()))?;
     }
     if !mountpoint.is_dir() {
         bail!(


### PR DESCRIPTION
## Problem

In a development guest without a hardware TDX/TSM provider, mounting `configfs` succeeds but the kernel does not register `/sys/kernel/config/tsm`. Because configfs rejects arbitrary userspace directories, creating `/sys/kernel/config/tsm/report` returns `EPERM` or `EACCES`.

The TDX simulator then exits before mounting its FUSE implementation, so software expecting the standard TSM report ABI cannot request a simulated TDX quote.

## Fix

When creation of the standard TSM path fails specifically with `EPERM`/`EACCES`, mount a `tmpfs` shadow at `/sys/kernel/config`, create the expected `/sys/kernel/config/tsm/report` hierarchy there, and let the simulator mount its userspace TDX ABI at the standard location.

Other filesystem errors still fail startup. Custom simulator mountpoints are unchanged.

## Unsafe removal

The implementation does not add raw mount or identity FFI:

- Existing and new `libc::mount` calls are replaced with safe `nix::mount::mount`.
- `libc::geteuid/getegid` are replaced with safe `nix::unistd` wrappers.
- `tdx.rs` contains no `unsafe` block after this change.

The `nix` `mount` and `user` features are recorded in `Cargo.toml` and `Cargo.lock`.

## Diff

- `dstack/tee-simulator/src/tdx.rs`
- `dstack/tee-simulator/Cargo.toml`
- `dstack/Cargo.lock`

This PR contains no Nitro NSM SONAME change; that remains isolated in #844.

## Dependency

Directly based on `master`; it can be reviewed and merged independently of #844.

## Verification

- `cargo check -p dstack-tee-simulator --all-targets`: passed.
- `git diff --check origin/master...HEAD`: passed.
- `grep unsafe dstack/tee-simulator/src/tdx.rs`: no matches.
