### PR TITLE
fix(guest): disable the ZFS pool root mountpoint

### DIFF
--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -2387,7 +2387,7 @@ impl<'a> Stage0<'a> {
                 FsType::Zfs => {
                     info!("Creating ZFS filesystem");
                     cmd! {
-                        zpool create -o autoexpand=on dstack $fs_dev;
+                        zpool create -o autoexpand=on -m none dstack $fs_dev;
                         zfs create -o mountpoint=$mount_point -o atime=off -o checksum=blake3 dstack/data;
                     }
                     .context("Failed to create zpool")?;


### PR DESCRIPTION
## Problem

A newly created ZFS pool inherits the default root-dataset mountpoint. This can mount the `dstack` pool root separately from the explicitly managed `dstack/data` dataset, creating an unintended mount in the guest filesystem.

## Fix

Create the pool with `-m none`, leaving the pool root unmounted. Only `dstack/data`, whose mountpoint is explicitly configured by the guest setup code, is mounted.

## Implementation

- `fix(guest): disable the ZFS pool root mountpoint`

Changed path:

- `dstack/dstack-util/src/system_setup.rs`

## Scope

This PR is based directly on `master` and contains only the ZFS root-mountpoint change.

## Verification

- `cargo test -p dstack-util --no-run`: passed
- `git diff --check origin/master...HEAD`: passed
