### PR TITLE
chore(rpc): adopt the prpc empty-body encoding for unit responses

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -5536,9 +5536,9 @@ dependencies = [
 
 [[package]]
 name = "prpc"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd65145222d0e76bf84c71bb0e9abcf45779d032fb0933fe1cceeb11be1f06a9"
+checksum = "56168f524507cff007f4399ca18e645a18960c9c5e84fca98a24d11c56c85687"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5555,9 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "prpc-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db191928d08a5e73122ee34e0003b23c5427e40aa0057394d1009f67c3aa5eb"
+checksum = "af89d66c95988e7da1ce83bd9353e1ce7eb22ce6ba6faf5ddc6cc97aa87b3e20"
 dependencies = [
  "either",
  "fs-err",

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -261,8 +261,8 @@ x509-parser = "0.16.0"
 pkcs8 = { version = "0.10", default-features = false }
 
 # RPC/Protocol
-prpc = "0.6.0"
-prpc-build = "0.6.1"
+prpc = "0.6.2"
+prpc-build = "0.7.0"
 
 # Development/Testing
 bindgen = "0.71.1"

--- a/dstack/http-client/src/prpc.rs
+++ b/dstack/http-client/src/prpc.rs
@@ -63,7 +63,10 @@ impl RequestClient for PrpcClient {
         if status != 200 {
             anyhow::bail!("Invalid status code: {status}, path={path}");
         }
-        let response = serde_json::from_slice(&body).context("Failed to deserialize response")?;
+        // Not serde_json::from_slice: a unit response arrives as an empty body, which
+        // is not valid JSON. Every RequestClient impl has to decode through this.
+        let response =
+            prpc::codec::decode_json_from_slice(&body).context("Failed to deserialize response")?;
         Ok(response)
     }
 }

--- a/dstack/ra-rpc/src/client.rs
+++ b/dstack/ra-rpc/src/client.rs
@@ -211,6 +211,8 @@ impl RequestClient for RaClient {
             .await
             .context("Failed to read response")?
             .to_vec();
+        // Not serde_json::from_slice: a unit response arrives as an empty body, which
+        // is not valid JSON. Every RequestClient impl has to decode through this.
         let response =
             prpc::codec::decode_json_from_slice(&body).context("Failed to deserialize response")?;
         Ok(response)

--- a/dstack/ra-rpc/src/client.rs
+++ b/dstack/ra-rpc/src/client.rs
@@ -211,7 +211,8 @@ impl RequestClient for RaClient {
             .await
             .context("Failed to read response")?
             .to_vec();
-        let response = serde_json::from_slice(&body).context("Failed to deserialize response")?;
+        let response =
+            prpc::codec::decode_json_from_slice(&body).context("Failed to deserialize response")?;
         Ok(response)
     }
 }


### PR DESCRIPTION
Follow-up to #875, which dropped a transport-layer workaround that byte-matched `null` in
the Rocket responder. The problem is fixed properly upstream instead:
https://github.com/Phala-Network/prpc/pull/1.

## What changes

`prpc-build` 0.7.0 encodes a `google.protobuf.Empty` response as an **empty JSON body**
instead of the literal `null`. The decision is made in codegen from the response type, so
a method that legitimately returns a JSON `null` value is unaffected, and message fields of
type `Empty` still serialize as `null` inside the object — only the top-level body changes.
The protobuf codec is untouched; it has always encoded a unit as zero bytes.

Both `RequestClient` impls in the tree decode through `prpc::codec::decode_json_from_slice`,
which maps an empty body back to the unit type:

- `ra-rpc::RaClient`
- `http-client::PrpcClient` — missed in the first revision, caught in review. `dstack-cli-core`'s
  `stop_vm` / `remove_vm` go through it and would have reported a failure for a request that
  actually succeeded. A compile check cannot catch this: `serde_json::from_slice::<()>`
  type-checks fine and only fails on the empty input at run time.

An empty body for any other message type stays an error.

## Affected wire format

Every unit-returning **JSON** RPC now responds with an empty body rather than `null`:

- vmm: `StartVm`, `StopVm`, `RemoveVm`, `ShutdownVm`, `ResizeVm`, `SvStop`, `SvRemove`,
  `PullRegistryImage`, ...
- gateway: `Exit`, `ReloadCert`, and the admin RPCs
- kms: `Onboard.Finish`

Client audit:

| Client | Status |
| --- | --- |
| `ra-rpc::RaClient` | fixed here |
| `http-client::PrpcClient` | fixed here |
| vmm web UI — `vmmRpc` (`StartVm`/`StopVm`/`RemoveVm`/`ShutdownVm`) | unaffected: `application/octet-stream`, protobuf path |
| vmm web UI — `baseRpcCall` (`SvStop`/`SvRemove`) | unaffected: never parses the response body |
| `vmm-cli.py` | unaffected: only parses a body that looks like JSON, otherwise returns it as a string |
| JS SDK `send-rpc-request.ts` | latent: bare `JSON.parse(data)` would throw, but guest-agent exposes no unit-returning method. Should be hardened before one is added |

## Verification

- `cargo check` / `cargo clippy` for kms, vmm, gateway, guest-agent, ra-rpc, http-client and
  dstack-cli-core: clean.
- `cargo test -p ra-rpc`: pass.
- Inspected the regenerated `kms.rs` / `vmm.rs`: `dispatch_json_request` emits
  `Ok(Vec::new())` for unit methods, `dispatch_request` (protobuf) is byte-for-byte
  unchanged.