### PR TITLE
fix(gateway): persist the WireGuard config owner-only

### DIFF
--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -25,7 +25,7 @@ use ra_rpc::{CallContext, RpcCall, VerifiedAttestation};
 use ra_tls::attestation::AppInfo;
 use rand::seq::IteratorRandom;
 use rinja::Template as _;
-use safe_write::safe_write;
+use safe_write::safe_write_with_mode;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use tokio::sync::{
@@ -1132,7 +1132,9 @@ impl ProxyState {
 
     pub(crate) fn reconfigure(&mut self) -> Result<()> {
         let wg_config = self.generate_wg_config()?;
-        safe_write(&self.config.wg.config_path, wg_config).context("Failed to write wg config")?;
+        // the rendered config carries the interface's WireGuard private key.
+        safe_write_with_mode(&self.config.wg.config_path, wg_config, 0o600)
+            .context("Failed to write wg config")?;
         // wg setconf <interface_name> <config_path>
         let ifname = &self.config.wg.interface;
         let config_path = &self.config.wg.config_path;

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1134,7 +1134,7 @@ impl ProxyState {
         let wg_config = self.generate_wg_config()?;
         // the rendered config carries the interface's WireGuard private key.
         safe_write_with_mode(&self.config.wg.config_path, wg_config, 0o600)
-            .context("Failed to write wg config")?;
+            .context("failed to write wg config")?;
         // wg setconf <interface_name> <config_path>
         let ifname = &self.config.wg.interface;
         let config_path = &self.config.wg.config_path;

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -25,6 +25,13 @@ async fn create_test_state() -> TestState {
     let mut config = figment.focus("core").extract::<Config>().unwrap();
     let temp_dir = TempDir::new().expect("failed to create temp dir");
     config.sync.data_dir = temp_dir.path().to_string_lossy().to_string();
+    // the default points at /etc/wireguard/wg0.conf, so anything that calls
+    // `reconfigure` would write to the host's real WireGuard config.
+    config.wg.config_path = temp_dir
+        .path()
+        .join("wg.conf")
+        .to_string_lossy()
+        .into_owned();
     let options = ProxyOptions {
         config,
         my_app_id: None,
@@ -50,6 +57,35 @@ async fn test_empty_config() {
     let state = create_test_state().await;
     let wg_config = state.lock().generate_wg_config().unwrap();
     insta::assert_snapshot!(wg_config);
+}
+
+/// The rendered config contains the interface's WireGuard private key, so the
+/// file must not be readable by anyone else. It used to be written with the
+/// default mode, landing at `0o666 & !umask`.
+#[cfg(unix)]
+#[tokio::test]
+async fn wg_config_is_written_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let state = create_test_state().await;
+    let path = state.lock().config.wg.config_path.clone();
+
+    // `reconfigure` also runs `wg syncconf`, which fails without a real
+    // interface — that failure is logged rather than propagated, so the write
+    // is still exercised here.
+    state.lock().reconfigure().expect("reconfigure failed");
+
+    let rendered = std::fs::read_to_string(&path).expect("wg config was not written");
+    assert!(
+        rendered.contains("PrivateKey"),
+        "test would be vacuous: the config carries no key"
+    );
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "wg config holds a private key, got mode {mode:o}"
+    );
 }
 
 fn policy(restrict: bool, ports: &[u16]) -> PortPolicy {


### PR DESCRIPTION
## Problem

`ProxyState::reconfigure` renders `gateway/templates/wg.conf`:

```
[Interface]
PrivateKey = {{ private_key }}
ListenPort = {{ listen_port }}
```

and wrote it with plain `safe_write`, which creates the file with the default `0o666 & !umask`. The interface's WireGuard private key therefore landed at **0644 or 0664 — readable by every local user**. Nothing chmods it afterwards; a `grep -rn "set_permissions\|chmod" gateway/src/` comes back empty.

Measured against the current code:

```
assertion `left == right` failed: wg config holds a private key, got mode 664
```

## Fix

```rust
// the rendered config carries the interface's WireGuard private key.
safe_write_with_mode(&self.config.wg.config_path, wg_config, 0o600)
```

The mode is applied when the file is created, so the key is never briefly exposed under wider bits — not even between the write and a follow-up `chmod`. This mirrors what `kms::onboard_service::store_keys` already does for the CA and RPC private keys.

## Test-scaffolding change

`create_test_state` now points `config.wg.config_path` into the test's temp directory. It defaults to `/etc/wireguard/wg0.conf`, so until now any test that called `reconfigure` would have written to the **host's real WireGuard config**. No test did yet, which is why this had not bitten; the new test needs it.

## Verification

`wg_config_is_written_owner_only` fails against the current code (`got mode 664`) and passes after. It asserts the rendered config actually contains `PrivateKey` before checking the mode, so it cannot pass vacuously if the template ever changes.

54 tests pass in `dstack-gateway`, `cargo fmt --check` is clean. The one clippy warning in the crate is pre-existing in `gateway/src/pp.rs` and untouched here.

## Scope

Only the WireGuard config. The other `safe_write` call sites in `gateway/` and `kms/` write certificates, domains and bootstrap info, which are public. Existing deployments keep their current mode until the next `reconfigure`, which happens on any instance registration.
