### PR TITLE
fix(supervisor): keep client JSON output clean

### DIFF
--- a/dstack/supervisor/client/src/main.rs
+++ b/dstack/supervisor/client/src/main.rs
@@ -50,7 +50,11 @@ async fn main() -> Result<()> {
     {
         use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        fmt().with_env_filter(filter).with_ansi(false).init();
+        fmt()
+            .with_env_filter(filter)
+            .with_ansi(false)
+            .with_writer(std::io::stderr)
+            .init();
     }
 
     let cli = Cli::parse();


### PR DESCRIPTION
## Summary

Send Supervisor client tracing output to stderr so stdout remains valid machine-readable JSON.

## Verification

- `cargo test --manifest-path dstack/Cargo.toml -p supervisor-client`
- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `git diff --check`