### PR TITLE
fix(supervisor): reply before graceful shutdown

### DIFF
--- a/dstack/supervisor/src/web_api.rs
+++ b/dstack/supervisor/src/web_api.rs
@@ -81,10 +81,10 @@ fn clear(supervisor: &State<Supervisor>) -> Json<Response<()>> {
 }
 
 #[post("/shutdown")]
-async fn shutdown(supervisor: &State<Supervisor>, shutdown: Shutdown) -> Json<Response<()>> {
+async fn shutdown(supervisor: &State<Supervisor>, rocket_shutdown: Shutdown) -> Json<Response<()>> {
     let result = supervisor.shutdown().await;
     if result.is_ok() {
-        shutdown.notify();
+        rocket_shutdown.notify();
     }
     to_json(result)
 }

--- a/dstack/supervisor/src/web_api.rs
+++ b/dstack/supervisor/src/web_api.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use or_panic::ResultOrPanic;
 use rocket::figment::Figment;
 use rocket::serde::json::Json;
-use rocket::{delete, get, post, routes, Build, Rocket, State};
+use rocket::{delete, get, post, routes, Build, Rocket, Shutdown, State};
 use serde::{Deserialize, Serialize};
 use tokio::signal;
 use tracing::info;
@@ -81,8 +81,12 @@ fn clear(supervisor: &State<Supervisor>) -> Json<Response<()>> {
 }
 
 #[post("/shutdown")]
-async fn shutdown(supervisor: &State<Supervisor>) -> Json<Response<()>> {
-    to_json(perform_shutdown(supervisor, false).await)
+async fn shutdown(supervisor: &State<Supervisor>, shutdown: Shutdown) -> Json<Response<()>> {
+    let result = supervisor.shutdown().await;
+    if result.is_ok() {
+        shutdown.notify();
+    }
+    to_json(result)
 }
 
 async fn perform_shutdown(supervisor: &Supervisor, force: bool) -> Result<()> {


### PR DESCRIPTION
## Summary

Return the Supervisor shutdown response before notifying Rocket to stop, so clients receive the result instead of losing the connection to an immediate process exit. Signal-triggered shutdown retains the existing forced-exit behavior.

## Verification

- `cargo test --manifest-path dstack/Cargo.toml -p supervisor`
- `cargo fmt --manifest-path dstack/Cargo.toml --all`
- `git diff --check`