### PR TITLE
refactor(guest): drop the unread mr-kms launch event

### DIFF
--- a/docs/tutorials/attestation-verification.md
+++ b/docs/tutorials/attestation-verification.md
@@ -526,7 +526,6 @@ These are the standard events you'll see in the log:
 | `gpu-attestation` | Verified GPU state and digest of the boot-time `nvattest` JSON | Required for an attested GPU launch; verify as described below |
 | `instance-id` | Unique instance identifier | Should match `instance_id` from response |
 | `boot-mr-done` | Boot measurements complete | Marker event |
-| `mr-kms` | KMS identity measurement | KMS public key hash |
 | `os-image-hash` | Guest OS image hash | Should match `tcb_info.os_image_hash` |
 | `key-provider` | Key provider type | e.g., `kms` |
 | `storage-fs` | Storage filesystem type | Storage configuration |

--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -95,12 +95,6 @@ async fn sign_cert_request(
 
 mod config_id_verifier;
 
-fn is_unsupported_app_info_quote(err: &anyhow::Error) -> bool {
-    let message = format!("{err:#}");
-    message.contains("Unsupported attestation quote")
-        || message.contains("unsupported attestation quote for app info decoding")
-}
-
 #[derive(clap::Parser)]
 /// Prepare full disk encryption
 pub struct SetupArgs {
@@ -1993,6 +1987,25 @@ pub async fn cmd_gateway_refresh(args: GatewayRefreshArgs) -> Result<()> {
         .await
 }
 
+/// Accept only a certificate the KMS issued for its own RPC endpoint.
+///
+/// The attestation behind this certificate is already verified by the RA-TLS
+/// layer, and the KMS identity that matters to the guest is its CA public key,
+/// pinned separately by `verify_key_provider_id`. All that is left here is
+/// refusing a certificate minted for some other purpose.
+fn validate_kms_rpc_cert(cert: Option<CertInfo>) -> Result<()> {
+    let Some(cert) = cert else {
+        bail!("Missing server cert");
+    };
+    let Some(usage) = cert.special_usage else {
+        bail!("Missing server cert usage");
+    };
+    if usage != "kms:rpc" {
+        bail!("Invalid server cert usage: {usage}");
+    }
+    Ok(())
+}
+
 struct AppIdValidator {
     allowed_app_id: String,
 }
@@ -2093,8 +2106,6 @@ impl<'a> Stage0<'a> {
         };
         let cert_pair = generate_ra_cert(tmp_ca.temp_ca_cert.clone(), tmp_ca.temp_ca_key.clone())?;
         let attestation_verifier = attestation_verifier(&self.shared.sys_config)?;
-        let verified_kms_measurement = Arc::new(std::sync::Mutex::new(None::<[u8; 32]>));
-        let captured_kms_measurement = verified_kms_measurement.clone();
         let ra_client = RaClientConfig::builder()
             .tls_no_check(false)
             .tls_built_in_root_certs(false)
@@ -2103,32 +2114,7 @@ impl<'a> Stage0<'a> {
             .tls_client_key(cert_pair.key_pem)
             .tls_ca_cert(tmp_ca.ca_cert.clone())
             .attestation_verifier(attestation_verifier)
-            .cert_validator(Box::new(move |cert| {
-                let Some(cert) = cert else {
-                    bail!("Missing server cert");
-                };
-                let Some(usage) = cert.special_usage else {
-                    bail!("Missing server cert usage");
-                };
-                if usage != "kms:rpc" {
-                    bail!("Invalid server cert usage: {usage}");
-                }
-                if let Some(att) = &cert.attestation {
-                    match att.decode_app_info(false) {
-                        Ok(kms_info) => {
-                            *captured_kms_measurement
-                                .lock()
-                                .map_err(|_| anyhow!("KMS measurement capture lock poisoned"))? =
-                                Some(kms_info.mr_aggregated);
-                        }
-                        Err(err) if is_unsupported_app_info_quote(&err) => {
-                            warn!("Skipping mr-kms runtime event for unsupported attestation quote: {err:#}");
-                        }
-                        Err(err) => return Err(err).context("Failed to decode app_info"),
-                    }
-                }
-                Ok(())
-            }))
+            .cert_validator(Box::new(validate_kms_rpc_cert))
             .build()
             .into_client()
             .context("Failed to create client")?;
@@ -2141,14 +2127,6 @@ impl<'a> Stage0<'a> {
             .await
             .context("Failed to get app key")?;
 
-        let kms_measurement = verified_kms_measurement
-            .lock()
-            .map_err(|_| anyhow!("KMS measurement capture lock poisoned"))?
-            .take();
-        if let Some(kms_measurement) = kms_measurement {
-            emit_runtime_event("mr-kms", &kms_measurement)
-                .context("failed to extend mr-kms to the launch measurement")?;
-        }
         emit_runtime_event("os-image-hash", &response.os_image_hash)
             .context("failed to extend os-image-hash to the launch measurement")?;
 

--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -1995,10 +1995,10 @@ pub async fn cmd_gateway_refresh(args: GatewayRefreshArgs) -> Result<()> {
 /// refusing a certificate minted for some other purpose.
 fn validate_kms_rpc_cert(cert: Option<CertInfo>) -> Result<()> {
     let Some(cert) = cert else {
-        bail!("Missing server cert");
+        bail!("missing server cert");
     };
     let Some(usage) = cert.special_usage else {
-        bail!("Missing server cert usage");
+        bail!("missing server cert usage");
     };
     if usage != "kms:rpc" {
         bail!("Invalid server cert usage: {usage}");

--- a/dstack/kms/kms.toml
+++ b/dstack/kms/kms.toml
@@ -34,9 +34,8 @@ enforce_self_authorization = true
 # Whether the KMS embeds an attestation in its own RPC certificate. Set false
 # only for local dev/testing where the KMS runs outside a TEE. This narrows what
 # the KMS asserts about itself and relaxes no verification: quotes presented to
-# the KMS are still fully checked, a guest that accepts an unattested
-# certificate simply does not extend mr-kms, and another KMS refuses to onboard
-# from one.
+# the KMS are still fully checked, and another KMS refuses to onboard from an
+# unattested one.
 attest_rpc_cert = true
 # AMD SEV-SNP key/cert release remains disabled unless this local KMS gate is
 # explicitly enabled. External auth policy must still allow the verified

--- a/dstack/kms/src/config.rs
+++ b/dstack/kms/src/config.rs
@@ -61,10 +61,8 @@ pub(crate) struct KmsConfig {
     ///
     /// This narrows what the KMS asserts about itself; it relaxes no
     /// verification anywhere. Quotes presented *to* the KMS are still fully
-    /// checked, so key release stays gated, and relying parties keep their own
-    /// policy: a guest accepts an unattested KMS certificate but then does not
-    /// extend `mr-kms`, so a remote verifier can still tell, and another KMS
-    /// refuses to onboard from one.
+    /// checked, so key release stays gated, and another KMS refuses to onboard
+    /// from an unattested one.
     #[serde(default = "default_true")]
     pub attest_rpc_cert: bool,
     /// Whether trusted RPCs require the KMS to first attest itself to its

--- a/dstack/kms/src/main.rs
+++ b/dstack/kms/src/main.rs
@@ -128,8 +128,8 @@ async fn main() -> Result<()> {
     if !config.attest_rpc_cert {
         warn!(
             "attest_rpc_cert = false; the KMS RPC certificate carries no attestation, so \
-             guests cannot verify which KMS they are talking to and will not extend \
-             mr-kms. Intended for local development only"
+             guests cannot verify which KMS they are talking to. Intended for local \
+             development only"
         );
     }
 


### PR DESCRIPTION
## Problem

`mr-kms` is a write-only measurement. `dstack-util` extends RTMR3 with the KMS
CVM's `mr_aggregated` after every `GetAppKey`, and nothing anywhere reads it
back. Grepping the whole repo — Rust, Solidity, TypeScript, Python, Go, the four
SDKs, test fixtures, event-log snapshots — finds no lookup by name:

```console
$ rg -n 'mr[-_]kms' --glob '!CHANGELOG.md'
dstack/dstack-util/src/system_setup.rs:2069:  warn!("Skipping mr-kms runtime event for ...")
dstack/dstack-util/src/system_setup.rs:2093:  emit_runtime_event("mr-kms", &kms_measurement)
dstack/kms/src/config.rs:66:                  /// extend `mr-kms`, so a remote verifier can still tell
dstack/kms/src/main.rs:127:                   mr-kms. Intended for local development only
docs/tutorials/attestation-verification.md:529
```

Two emitters and three sentences of prose. `dstack/verifier/` never mentions it;
the only path that could surface the name is `verification.rs:96`, which copies
`event.event` into an RTMR-mismatch diagnostic and therefore never runs on a
successful verification.

Three things follow from having no reader:

1. **The one piece of documentation is wrong.** `attestation-verification.md:529`
   describes the payload as "KMS public key hash". It is the KMS's
   `mr_aggregated`. Nobody noticed because nobody consumes it.
2. **Absence is ambiguous.** The event is emitted only when the KMS RPC
   certificate carries a decodable attestation, and skipped for
   `attest_rpc_cert = false` or an unsupported quote type. A missing `mr-kms`
   could mean an unattested KMS, an unsupported platform, or an older guest —
   indistinguishable. `kms/src/config.rs:66` claims "a remote verifier can still
   tell"; with no reader and no way to disambiguate, it cannot.
3. **It made the TLS handshake carry a side effect.** Capturing the value across
   the callback needed an `Arc<Mutex<Option<[u8; 32]>>>` cloned into the
   `cert_validator` closure, a `decode_app_info` call, and a bespoke
   `is_unsupported_app_info_quote` string-matching helper for the platforms where
   that decode is not supported — all inside what is otherwise a certificate
   check.

The intent was KMS build accountability, and that need is real: the KMS root key
survives KMS upgrades by design (onboarding replicates it), so `key-provider`,
which records the root CA public key, cannot distinguish two KMS builds sharing
one root. But the enforced answer already exists on-chain in
`DstackKms.kmsAllowedAggregatedMrs`, checked by `isKmsAllowed` when a KMS boots
and asks for that root key. `mr-kms` was an unenforced echo of it.

## Fix

Remove the event and everything that existed only to produce it.

`request_app_keys_from_kms_url` loses the mutex, the clone, the `decode_app_info`
call and the take-and-emit block. `cert_validator` captures nothing now, so it
becomes a plain function next to the file's other one, `AppIdValidator`:

```rust
.cert_validator(Box::new(validate_kms_rpc_cert))
```

Dropping `decode_app_info` from the validator removes no check.
`ra-rpc/src/client.rs:157` runs `verify_with_ra_pubkey` — report-data binding to
the certificate SubjectPublicKeyInfo, quote signature, collateral — *before*
calling the validator. `decode_app_info` only parsed identity out of the KMS's
event log to reach `mr_aggregated`, and with `mr-kms` gone nothing consumes that
log. The KMS identity the guest actually enforces is its CA public key, pinned by
`verify_key_provider_id` against `app_compose.key_provider_id`.

The stale prose in `kms/src/config.rs`, `kms/src/main.rs`, `kms/kms.toml` and the
incorrect docs row go with it.

### Alternative considered

Finishing the feature instead: have `dstack-verifier` surface `mr-kms` in
`VerificationResponse.details`, cross-check it against
`kmsAllowedAggregatedMrs`, and emit it unconditionally so absence stops being
ambiguous. Rejected for now — it is a new verification surface with an on-chain
dependency, and shipping it should be a deliberate design change rather than a
rescue of an event that has had no reader since #135. Removing it first keeps the
launch log honest about what is actually checked; the accountability question can
be reopened on its own terms.

## Compatibility

No allowlisted measurement changes. `boot-mr-done` is emitted at
`system_setup.rs:2641`, before `request_app_keys()` at `:2717`, so `mr-kms`
always landed *after* the boot-time snapshot. The on-chain KMS and app policies
read that truncated snapshot (`replay_runtime_events(.., Some("boot-mr-done"))`),
which never contained it. Registered `mrAggregated` and `deviceId` entries are
untouched.

Only the runtime RTMR3 of newly built guest images changes, and no authorization
path reads it. Event-log replay is name-agnostic, so an existing CVM whose log
contains `mr-kms` still replays to its quoted RTMR3 and verifies unchanged — no
verifier-side change is needed for either generation.

## Verification

- `rg -n 'mr[-_]kms'` over the worktree returns only `CHANGELOG.md` history.
- `cargo clippy -p dstack-util -p dstack-kms --all-targets`: no new warnings
  (the two remaining ones are pre-existing, in `amd_attest.rs` and
  `onboard_service.rs`).
- `cargo test -p dstack-util -p dstack-kms`: 102 passed, 0 failed.
- Confirmed the removed decode is redundant by reading the RA-TLS client path:
  `ra-rpc/src/client.rs:145-165` verifies the attestation and only then invokes
  the validator.
- Confirmed the emission order claim from the source: `boot-mr-done` at
  `system_setup.rs:2641` precedes `request_app_keys()` at `:2717`.
