### PR TITLE
fix(mock-attestation): handle PCK collateral errors

### DIFF
--- a/dstack/crates/mock-attestation/src/server.rs
+++ b/dstack/crates/mock-attestation/src/server.rs
@@ -93,12 +93,12 @@ async fn pccs_root_crl(State(state): State<Arc<MockCollateralState>>) -> impl In
 }
 
 async fn pck_crl(State(state): State<Arc<MockCollateralState>>) -> impl IntoResponse {
+    let Ok(collateral) = state.tdx.sample_collateral() else {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
     binary(
         state.tdx.pck_crl_der(),
-        Some((
-            "SGX-PCK-CRL-Issuer-Chain",
-            state.tdx.sample_collateral().unwrap().pck_crl_issuer_chain,
-        )),
+        Some(("SGX-PCK-CRL-Issuer-Chain", collateral.pck_crl_issuer_chain)),
     )
 }
 


### PR DESCRIPTION
## Problem

The `Rust checks` workflow on `master` fails Clippy because the mock PCCS PCK CRL handler calls `unwrap()` while the workspace denies `clippy::unwrap_used`.

The panic is also inappropriate for an HTTP handler because collateral generation can fail.

## Change

- handle `sample_collateral()` failures explicitly
- return HTTP 500 instead of panicking
- reuse the successfully generated collateral when setting the issuer-chain header

## Verification

- `cargo fmt --manifest-path dstack/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path dstack/Cargo.toml -p mock-attestation -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow unused_variables`
- `git diff --check`
