### PR TITLE
ci: add next to workflow branch filters

### DIFF
--- a/.github/workflows/mkosi-build.yml
+++ b/.github/workflows/mkosi-build.yml
@@ -25,7 +25,7 @@ on:
   # would be silently dropped. The static job costs seconds and the image build
   # is gated by its own `if`, so an unfiltered push trigger is cheap.
   push:
-    branches: [master]
+    branches: [master, next]
     tags: ['mkosi-os-v*']
 
 concurrency:

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -6,9 +6,9 @@ name: SPDX License Check
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, next ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master, next ]
 
 jobs:
   reuse-lint:


### PR DESCRIPTION
## Problem

We are about to rename the default branch `master` -> `next`. Six of the eight workflows that filter on branch names already list `next` (`branches: [ master, next, dev-* ]`), so they keep working across the rename. Two do not:

- `.github/workflows/spdx-check.yml` — `branches: [ master, main ]`
- `.github/workflows/mkosi-build.yml` — `push.branches: [master]`

`spdx-check.yml` is the blocking one. It produces `reuse-lint`, which is one of the three required status checks in the `merge-protection` ruleset (alongside `rust-checks` and `sdk-tests`). GitHub retargets open PRs to the new default branch on rename, and `pull_request.branches` filters on the **base** branch — so the moment `master` becomes `next`, every one of the 18 currently-open PRs would stop matching this filter, `reuse-lint` would never be dispatched, and the required check would sit pending forever with no error surfaced anywhere. All 18 PRs become unmergeable.

Note the existing `dev-*` glob does not cover this: it requires the hyphen and does not match `next`, so `next` has to be listed explicitly.

`mkosi-build.yml` is not a required check and its `pull_request` trigger is filtered by `paths` only (no branch filter), so PR runs are unaffected. Only the post-merge `push` build on the mainline would silently stop firing.

## Fix

Add `next` alongside `master` in both files. Keeping `master` means CI is correct both before and after the rename, so this can merge independently and the rename is not time-coupled to it. A follow-up PR drops `master` from all eight workflows once the rename has landed.

Also drop `main` from `spdx-check.yml`. This repo has no `main` branch — `git ls-remote --heads origin main` is empty and `main` appears in no other workflow — so the entry has never matched anything and only adds noise to the filter.

## Verification

- Both files parse and resolve to the intended triggers:
  - `spdx-check.yml` -> `push.branches` and `pull_request.branches` both `[master, next]`
  - `mkosi-build.yml` -> `push.branches` `[master, next]`, `tags` `[mkosi-os-v*]` unchanged, `pull_request` still `paths`-only
- Diff is 3 lines across 2 files; no job, step, or trigger type was added or removed.
- Confirmed `main` does not exist on origin and is referenced by no other workflow.
- Confirmed against the live ruleset that the required contexts are exactly `sdk-tests`, `rust-checks`, `reuse-lint`, and that all three rulesets target `~DEFAULT_BRANCH` (so they follow the rename without manual edits).