### PR TITLE
chore: complete the master to next rename and retire dev-*

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -6,9 +6,9 @@ name: Docker Build Check
 
 on:
   push:
-    branches: [ next, dev-* ]
+    branches: [ next ]
   pull_request:
-    branches: [ next, dev-* ]
+    branches: [ next ]
 
 env:
   DSTACK_REV: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -6,9 +6,9 @@ name: Docker Build Check
 
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
 
 env:
   DSTACK_REV: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -6,9 +6,9 @@ name: Docker Build Check
 
 on:
   push:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
   pull_request:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
 
 env:
   DSTACK_REV: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/gateway-proxy-tests.yml
+++ b/.github/workflows/gateway-proxy-tests.yml
@@ -10,13 +10,13 @@ name: Gateway proxy tests
 # and asserts on what actually reaches the wire.
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'
       - '.github/workflows/gateway-proxy-tests.yml'
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'

--- a/.github/workflows/gateway-proxy-tests.yml
+++ b/.github/workflows/gateway-proxy-tests.yml
@@ -10,13 +10,13 @@ name: Gateway proxy tests
 # and asserts on what actually reaches the wire.
 on:
   push:
-    branches: [ next, dev-* ]
+    branches: [ next ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'
       - '.github/workflows/gateway-proxy-tests.yml'
   pull_request:
-    branches: [ next, dev-* ]
+    branches: [ next ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'

--- a/.github/workflows/gateway-proxy-tests.yml
+++ b/.github/workflows/gateway-proxy-tests.yml
@@ -10,13 +10,13 @@ name: Gateway proxy tests
 # and asserts on what actually reaches the wire.
 on:
   push:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'
       - '.github/workflows/gateway-proxy-tests.yml'
   pull_request:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
     paths:
       - 'dstack/gateway/**'
       - 'dstack/vendor/ktls/**'

--- a/.github/workflows/mkosi-build.yml
+++ b/.github/workflows/mkosi-build.yml
@@ -25,7 +25,7 @@ on:
   # would be silently dropped. The static job costs seconds and the image build
   # is gated by its own `if`, so an unfiltered push trigger is cheap.
   push:
-    branches: [master, next]
+    branches: [next]
     tags: ['mkosi-os-v*']
 
 concurrency:

--- a/.github/workflows/mkosi-build.yml
+++ b/.github/workflows/mkosi-build.yml
@@ -25,7 +25,7 @@ on:
   # would be silently dropped. The static job costs seconds and the image build
   # is gated by its own `if`, so an unfiltered push trigger is cheap.
   push:
-    branches: [next]
+    branches: [next, 'release/**']
     tags: ['mkosi-os-v*']
 
 concurrency:

--- a/.github/workflows/prek-check.yml
+++ b/.github/workflows/prek-check.yml
@@ -6,9 +6,9 @@ name: Prek checks
 
 on:
   push:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
   pull_request:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
 
 permissions:
   contents: read

--- a/.github/workflows/prek-check.yml
+++ b/.github/workflows/prek-check.yml
@@ -6,9 +6,9 @@ name: Prek checks
 
 on:
   push:
-    branches: [ next, dev-* ]
+    branches: [ next ]
   pull_request:
-    branches: [ next, dev-* ]
+    branches: [ next ]
 
 permissions:
   contents: read

--- a/.github/workflows/prek-check.yml
+++ b/.github/workflows/prek-check.yml
@@ -6,9 +6,9 @@ name: Prek checks
 
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,9 +6,9 @@ name: Rust checks
 
 on:
   push:
-    branches: [ next, dev-* ]
+    branches: [ next ]
   pull_request:
-    branches: [ next, dev-* ]
+    branches: [ next ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,9 +6,9 @@ name: Rust checks
 
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,9 +6,9 @@ name: Rust checks
 
 on:
   push:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
   pull_request:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [next, dev-*]
+    branches: [next]
   pull_request:
-    branches: [next, dev-*]
+    branches: [next]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [next]
+    branches: [next, 'release/**']
   pull_request:
-    branches: [next]
+    branches: [next, 'release/**']
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [master, next, dev-*]
+    branches: [next, dev-*]
   pull_request:
-    branches: [master, next, dev-*]
+    branches: [next, dev-*]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -6,9 +6,9 @@ name: SPDX License Check
 
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
 
 jobs:
   reuse-lint:

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -6,9 +6,9 @@ name: SPDX License Check
 
 on:
   push:
-    branches: [ master, next ]
+    branches: [ next ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ next ]
 
 jobs:
   reuse-lint:

--- a/.github/workflows/vmm-ui.yml
+++ b/.github/workflows/vmm-ui.yml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
   pull_request:
-    branches: [ master, next, dev-* ]
+    branches: [ next, dev-* ]
 
 jobs:
   build:

--- a/.github/workflows/vmm-ui.yml
+++ b/.github/workflows/vmm-ui.yml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
   pull_request:
-    branches: [ next ]
+    branches: [ next, 'release/**' ]
 
 jobs:
   build:

--- a/.github/workflows/vmm-ui.yml
+++ b/.github/workflows/vmm-ui.yml
@@ -9,9 +9,9 @@ permissions:
 
 on:
   push:
-    branches: [ next, dev-* ]
+    branches: [ next ]
   pull_request:
-    branches: [ next, dev-* ]
+    branches: [ next ]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ Thank you for your interest in contributing to this project!
   request against it unless a maintainer asks otherwise.
 - `release/vX.Y` carries a released line. It only takes fixes cherry-picked
   back from `next`; do not develop on it directly. Version tags are cut here.
-- `dev-*` is reserved for shared integration branches that need full CI. A
-  personal feature branch does not need to follow that pattern.
+
+Name a working branch whatever describes it. CI runs on pull requests, so a
+branch gets its checks once a PR is open rather than on every push.
 
 The default branch was renamed from `master` to `next`. Web links, raw file
 URLs, and the REST API redirect, but the old ref name is gone at the git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,9 @@ Thank you for your interest in contributing to this project!
 
 - `next` is the integration mainline and the default branch. Open every pull
   request against it unless a maintainer asks otherwise.
-- `release/vX.Y` carries a released line. It only takes fixes cherry-picked
-  back from `next`; do not develop on it directly. Version tags are cut here.
+- `release/v<major>.<minor>.x` carries a released line — `release/v0.5.x` is
+  the current one. It only takes fixes cherry-picked back from `next`; do not
+  develop on it directly. Patch tags are cut here.
 
 Name a working branch whatever describes it. CI runs on pull requests, so a
 branch gets its checks once a PR is open rather than on every push.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,27 @@
 
 Thank you for your interest in contributing to this project!
 
+## Branches
+
+- `next` is the integration mainline and the default branch. Open every pull
+  request against it unless a maintainer asks otherwise.
+- `release/vX.Y` carries a released line. It only takes fixes cherry-picked
+  back from `next`; do not develop on it directly. Version tags are cut here.
+- `dev-*` is reserved for shared integration branches that need full CI. A
+  personal feature branch does not need to follow that pattern.
+
+The default branch was renamed from `master` to `next`. Web links, raw file
+URLs, and the REST API redirect, but the old ref name is gone at the git
+level: `git fetch origin master` and `git clone -b master` now fail. Update an
+existing clone with:
+
+```bash
+git branch -m master next
+git fetch origin
+git branch -u origin/next next
+git remote set-head origin -a
+```
+
 ## Development
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### The open framework for confidential AI.
 
 [![GitHub Stars](https://img.shields.io/github/stars/dstack-tee/dstack?style=flat-square&logo=github)](https://github.com/Dstack-TEE/dstack/stargazers)
-[![License](https://img.shields.io/github/license/dstack-tee/dstack?style=flat-square)](https://github.com/Dstack-TEE/dstack/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/dstack-tee/dstack?style=flat-square)](https://github.com/Dstack-TEE/dstack/blob/next/LICENSE)
 [![REUSE status](https://api.reuse.software/badge/github.com/Dstack-TEE/dstack)](https://api.reuse.software/info/github.com/Dstack-TEE/dstack)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Dstack-TEE/dstack)
 [![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=flat-square&logo=telegram&logoColor=white)](https://t.me/+UO4bS4jflr45YmUx)
@@ -221,7 +221,7 @@ Yes. dstack runs on supported TEE-capable servers, including Intel TDX-capable h
 <details>
 <summary><strong>How do users verify my deployment?</strong></summary>
 
-Your app exposes attestation quotes via the SDK. Users verify these quotes using [dstack-verifier](https://github.com/Dstack-TEE/dstack/tree/master/dstack/verifier), [dcap-qvl](https://github.com/Phala-Network/dcap-qvl), or the [Trust Center](https://trust.phala.com). See the [verification guide](./docs/verification.md) for details.
+Your app exposes attestation quotes via the SDK. Users verify these quotes using [dstack-verifier](https://github.com/Dstack-TEE/dstack/tree/next/dstack/verifier), [dcap-qvl](https://github.com/Phala-Network/dcap-qvl), or the [Trust Center](https://trust.phala.com). See the [verification guide](./docs/verification.md) for details.
 
 </details>
 

--- a/docs/attestation-tdx.md
+++ b/docs/attestation-tdx.md
@@ -83,7 +83,7 @@ To verify dstack App data trustworthiness:
 
 - Review source code for correctness and safety.
 - Build image from source.
-- Calculate MRTD, RTMR0, RTMR1, and RTMR2 values using [dstack-mr](https://github.com/Dstack-TEE/dstack/tree/master/dstack/dstack-mr).
+- Calculate MRTD, RTMR0, RTMR1, and RTMR2 values using [dstack-mr](https://github.com/Dstack-TEE/dstack/tree/next/dstack/dstack-mr).
 - Verify quote measurements:
     - Confirm MRTD, RTMR0, RTMR1, and RTMR2 match pre-calculated values.
     - Verify RTMR3 matches the event log replay result.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -3,7 +3,7 @@
 Use this guide to get a first dstack app running on one Intel TDX host. The workflow uses `dstackup` for host setup and `dstack` for app deployment:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/master/dstack/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/next/dstack/scripts/install.sh | sh
 sudo dstackup install
 sudo dstack deploy \
   -n hello-nginx \
@@ -78,7 +78,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 Build and install the `dstackup` bootstrap command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/master/dstack/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/next/dstack/scripts/install.sh | sh
 ```
 
 The bootstrap installer builds `dstackup` from a temporary source checkout and installs it under `/usr/local/bin`. The `dstackup install` command then builds and installs `dstack`, `dstack-auth`, `dstack-vmm`, `supervisor`, static assets, and host config into the system layout.
@@ -216,7 +216,7 @@ Use `--prefix` when you want a second isolated install on the same host. A custo
 Install `dstackup` into the prefix, then use the same prefix for `dstackup` and `dstack`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/master/dstack/scripts/install.sh | sh -s -- --prefix /opt/dstack-test
+curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/next/dstack/scripts/install.sh | sh -s -- --prefix /opt/dstack-test
 
 sudo /opt/dstack-test/bin/dstackup install \
   --prefix /opt/dstack-test \

--- a/docs/tutorials/clone-build-dstack-vmm.md
+++ b/docs/tutorials/clone-build-dstack-vmm.md
@@ -56,13 +56,13 @@ All build commands should be run as the `ubuntu` user. Only the final installati
 ### Step 2: Verify dstack Repository
 
 The dstack repository should already be cloned and checked out on the current
-`master` branch from [Local Key Provider](/tutorial/gramine-key-provider):
+`next` branch from [Local Key Provider](/tutorial/gramine-key-provider):
 
 ```bash
 cd ~/dstack
 git describe --tags
 git branch --show-current
-# Should show master
+# Should show next
 ```
 
 ### Step 3: Build dstack-vmm
@@ -111,8 +111,8 @@ ls -la /usr/local/bin/dstack-supervisor
 # Check out a monorepo-era release tag when one is available
 git checkout <release-tag>
 
-# Or use the master branch for latest development
-git checkout master
+# Or use the next branch for latest development
+git checkout next
 git pull --ff-only
 ```
 

--- a/docs/tutorials/contract-deployment.md
+++ b/docs/tutorials/contract-deployment.md
@@ -49,12 +49,12 @@ These contracts use the UUPS (Universal Upgradeable Proxy Standard) pattern for 
 
 ### Step 1: Clone Repository and Navigate to auth-eth
 
-On your **local machine**, clone the dstack repository (if you haven't already) and use the current `master` branch:
+On your **local machine**, clone the dstack repository (if you haven't already) and use the current `next` branch:
 
 ```bash
 git clone https://github.com/Dstack-TEE/dstack.git ~/dstack 2>/dev/null || true
 cd ~/dstack
-git checkout master
+git checkout next
 cd dstack/kms/auth-eth
 ```
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -18,7 +18,7 @@ If any of these fail, the cryptographic proof won't verify.
 
 **Programmatic verification**: dstack provides several tools:
 
-- [dstack-verifier](https://github.com/Dstack-TEE/dstack/tree/master/dstack/verifier) - HTTP service with `/verify` endpoint, also runs as CLI
+- [dstack-verifier](https://github.com/Dstack-TEE/dstack/tree/next/dstack/verifier) - HTTP service with `/verify` endpoint, also runs as CLI
 - [dcap-qvl](https://github.com/Phala-Network/dcap-qvl) - Open source quote verification library (Rust, Python, JS/WASM, CLI)
 - [SDKs](../sdk/) - JavaScript and Python SDKs include `replayRtmrs()` for local RTMR verification
 

--- a/dstack/crates/dstackup/src/cli.rs
+++ b/dstack/crates/dstackup/src/cli.rs
@@ -11,7 +11,7 @@ pub(crate) const DEFAULT_VMM_BIN: &str = "dstack-vmm";
 pub(crate) const DEFAULT_AUTH_BIN: &str = "dstack-auth";
 pub(crate) const DEFAULT_SUPERVISOR_BIN: &str = "supervisor";
 pub(crate) const DEFAULT_SOURCE_REPO: &str = "https://github.com/Dstack-TEE/dstack";
-pub(crate) const DEFAULT_SOURCE_REF: &str = "master";
+pub(crate) const DEFAULT_SOURCE_REF: &str = "next";
 pub(crate) const DEFAULT_RELEASE_API_BASE_URL: &str = "https://api.github.com/repos";
 
 #[derive(Parser)]

--- a/dstack/kms/auth-mock/Dockerfile
+++ b/dstack/kms/auth-mock/Dockerfile
@@ -6,7 +6,7 @@ FROM oven/bun:1-alpine
 WORKDIR /app
 
 ARG DSTACK_REV
-ARG DSTACK_BRANCH=master
+ARG DSTACK_BRANCH=next
 
 RUN apk add --no-cache git
 RUN git clone --branch ${DSTACK_BRANCH} https://github.com/Dstack-TEE/dstack.git && \

--- a/dstack/scripts/install.sh
+++ b/dstack/scripts/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 DEFAULT_REPO="https://github.com/Dstack-TEE/dstack"
-DEFAULT_REF="master"
+DEFAULT_REF="next"
 DEFAULT_PREFIX="/usr/local"
 
 usage() {
@@ -15,13 +15,13 @@ Install dstackup from source.
 
 Usage:
   dstack/scripts/install.sh [options]
-  curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/master/dstack/scripts/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/Dstack-TEE/dstack/next/dstack/scripts/install.sh | sh
 
 Options:
   --repo URL       Git repository to clone when not run from a checkout.
                   Default: https://github.com/Dstack-TEE/dstack
   --ref REF        Git ref to checkout when cloning or updating DSTACK_SRC.
-                  Default: master
+                  Default: next
   --src DIR        Persistent source checkout to build from.
                   Default: a temporary checkout
   --prefix DIR     Install dstackup under DIR/bin. Use the same DIR with

--- a/dstack/verifier/README.md
+++ b/dstack/verifier/README.md
@@ -6,7 +6,7 @@ A HTTP server that provides dstack quote verification services using the same ve
 
 ### POST /verify
 
-Verifies a dstack attestation or quote with the provided data and VM configuration. The body can be grabbed via [getQuote](https://github.com/Dstack-TEE/dstack/blob/master/sdk/curl/api.md#3-get-quote) or [attest](https://github.com/Dstack-TEE/dstack/blob/master/sdk/curl/api.md#8-attest).
+Verifies a dstack attestation or quote with the provided data and VM configuration. The body can be grabbed via [getQuote](https://github.com/Dstack-TEE/dstack/blob/next/sdk/curl/api.md#3-get-quote) or [attest](https://github.com/Dstack-TEE/dstack/blob/next/sdk/curl/api.md#8-attest).
 
 **Request Body:**
 Provide either `attestation` or (`quote` + `event_log` + `vm_config`).

--- a/os/spec/artifact-manifest.schema.json
+++ b/os/spec/artifact-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Dstack-TEE/dstack/blob/master/os/spec/artifact-manifest.schema.json",
+  "$id": "https://github.com/Dstack-TEE/dstack/blob/next/os/spec/artifact-manifest.schema.json",
   "title": "dstack OS backend artifact manifest",
   "description": "Versioned handoff from an OS build backend to the common image assembler. Artifact paths are relative to the manifest.",
   "$defs": {

--- a/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/files/dstack-tee-simulator.service
+++ b/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/files/dstack-tee-simulator.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=dstack development TEE ABI simulator
-Documentation=https://github.com/Dstack-TEE/dstack/blob/master/CONTRIBUTING.md
+Documentation=https://github.com/Dstack-TEE/dstack/blob/next/CONTRIBUTING.md
 Before=dstack-prepare.service
 
 [Service]


### PR DESCRIPTION
## Problem

The default branch was renamed `master` -> `next`. GitHub redirects more than expected, but not everything, and the gap is where the breakage is.

Measured after the rename:

| layer | old ref name | result |
|---|---|---|
| `github.com/.../blob\|tree/master/...` | redirects | 302 to the `next` path |
| `raw.githubusercontent.com/.../master/...` | redirects | 200, byte-identical to `raw/next` |
| REST `repos/.../branches/master` | redirects | resolves to `next` |
| `git ls-remote refs/heads/master` | **gone** | 0 refs |
| `git fetch origin master` | **fails** | `couldn't find remote ref master` |
| `git clone -b master <url>` | **fails** | `Remote branch master not found in upstream origin` |

So documentation links were never broken, but anything that pins the ref name at the **git** layer broke the moment the rename landed. Three such places exist in this repo, and all three are on user-facing install/build paths:

1. `dstack/scripts/install.sh` — `DEFAULT_REF="master"`, consumed as `git checkout "$ref"` after cloning. This is the script behind the documented `curl -fsSL .../install.sh | sh` entrypoint. The script runs under `set -eu`, so the failed checkout aborts the install outright. Reproduced against the live repo:

   ```
   $ git clone --filter=blob:none https://github.com/Dstack-TEE/dstack.git repro
   $ cd repro && git checkout master
   error: pathspec 'master' did not match any file(s) known to git
   ```

2. `dstack/crates/dstackup/src/cli.rs` — `DEFAULT_SOURCE_REF = "master"`, the clap default for `--source-ref`, consumed by `install.rs` as `["checkout", git_ref]` on both the cached-source and fresh-clone paths. Same failure.

3. `dstack/kms/auth-mock/Dockerfile` — `ARG DSTACK_BRANCH=master` feeding `git clone --branch ${DSTACK_BRANCH}`. This is exactly the `git clone -b master` case measured above, so the image build fails at that layer.

The docs under `docs/tutorials/` also instruct readers to run `git checkout master`, which now errors.

## Fix

Three commits, each independently readable:

- `ci: drop master from workflow branch filters` — removes the now-dead `master` entry from all eight workflows. `next` was added in #1025 before the rename so CI stayed green across the cutover; this removes the other half.
- `fix: point default git refs at next` — the three functional defaults above. This preserves the existing semantics of each knob (track the development mainline); it does not change *what* they track, only the name they track it by.
- `ci: retire the dev-* branch pattern` — drops the `dev-*` glob from the six workflows that carried it. The pattern is dead config: `git ls-remote --heads origin 'refs/heads/dev-*'` returns nothing and none of the last 100 workflow runs came from such a branch. All eight workflows now filter on exactly `[next]`, so there is one rule instead of two. Working branches still get their checks through the `pull_request` trigger; only pushes to a branch with no open PR stop building, which nothing was relying on. (`dstack-dev-*` and `dstack-nvidia-dev-*` in the docs are image names, not branch patterns, and are untouched.)
- `ci: run workflows on release branches` — adds `release/**` to the eight filters. Note what this does and does not do: for both `push` and `pull_request`, GitHub runs the workflow files **as they exist on the branch being built**, so this cannot retroactively give CI to `release/v0.5.x` (cut from `v0.5.11`, whose filters predate the rename). It means any future release branch cut from `next` inherits working filters instead of needing the same fix again. Enabling CI on the existing `release/v0.5.x` is tracked separately.
- `docs: update branch references to next` — README, docs, tutorials, verifier README, the artifact-manifest `$id`, the simulator unit's `Documentation=` URL, and a new `## Branches` section in `CONTRIBUTING.md` describing `next` / `release/vX.Y` / `dev-*` plus the clone-migration one-liner.

Deliberately **not** touched:
- `CHANGELOG.md` — generated history; the old branch names are a factual record.
- `dtolnay/rust-toolchain@master`, `rwf2/Rocket branch = "master"`, `tianocore/edk2 branch=master`, the sysbox doc link — third-party refs.
- `ip link set dev <tap> master <bridge>` in `vmm/src/netd.rs` and `bus_master` in `lspci` — kernel/PCI terminology.
- `dstack/tests/docs/kms-self-authorization.md` — prose recording what a past test ran against.

## Verification

- `cargo check -p dstackup` passes.
- `sh -n dstack/scripts/install.sh` passes.
- All eight workflow files parse; resolved triggers confirmed as `push`/`pull_request` on `[next, release/**]` uniformly across all eight, with `mkosi-build`'s `mkosi-os-v*` tag trigger and `paths`-only `pull_request` filter unchanged.
- Full-tree sweep for `master` outside vendored `os/yocto/deps/**`: every remaining hit is in the deliberately-untouched list above.
- This PR is itself the first one based on `next`, so its own check run confirms `pull_request` dispatch works against the renamed branch.


## Follow-up

`release/v0.5.x` now exists at the `v0.5.11` commit, protected against deletion and force-push. It has no CI: creating it triggered zero workflow runs, and `merge-protection` targets `~DEFAULT_BRANCH` only, so a backport PR into it currently faces no required checks. Its v0.5.11-era workflows are 1918 commits old and are not expected to pass unmodified on current runners, so which of them are worth reviving on that line is a separate decision.
