### PR TITLE
fix(simulator): make vTPM device publication deterministic

### DIFF
--- a/dstack/tee-simulator/src/tdx.rs
+++ b/dstack/tee-simulator/src/tdx.rs
@@ -82,11 +82,13 @@ impl SimulatorState {
         let report_data: [u8; 64] = report_data
             .try_into()
             .map_err(|_| anyhow::anyhow!("inblob must be exactly 64 bytes"))?;
-        self.outblob = self.make_quote(report_data)?;
-        self.generation = self
+        let generation = self
             .generation
             .checked_add(1)
             .context("tsm generation overflow")?;
+        let outblob = self.make_quote(report_data)?;
+        self.outblob = outblob;
+        self.generation = generation;
         Ok(())
     }
 
@@ -592,7 +594,7 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_boundaries_are_failure_atomic() {
+    fn state_updates_are_failure_atomic() {
         let mut state = SimulatorState::new(
             Arc::new(TdxGenerator::from_seed([0x71; 32]).unwrap()),
             CCEL_FIXTURE,
@@ -610,6 +612,12 @@ mod tests {
         assert_eq!(state.rtmrs[3], original_rtmr3);
         assert!(state.extend_rtmr(1, &[0x22; 48]).is_err());
         assert_eq!(state.rtmrs[1], replay_boot_rtmrs(CCEL_FIXTURE).unwrap()[1]);
+
+        state.generation = i64::MAX;
+        assert!(state.request_quote(&[0x33; 64]).is_err());
+        assert_eq!(state.generation, i64::MAX);
+        assert_eq!(state.outblob, original_quote);
+        state.generation = 0;
 
         state.request_quote(&[0x33; 64]).unwrap();
         assert_eq!(state.generation, 1);

--- a/dstack/tee-simulator/src/tdx.rs
+++ b/dstack/tee-simulator/src/tdx.rs
@@ -592,6 +592,33 @@ mod tests {
     }
 
     #[test]
+    fn filesystem_boundaries_are_failure_atomic() {
+        let mut state = SimulatorState::new(
+            Arc::new(TdxGenerator::from_seed([0x71; 32]).unwrap()),
+            CCEL_FIXTURE,
+            None,
+        )
+        .unwrap();
+        let original_quote = state.outblob.clone();
+        let original_rtmr3 = state.rtmrs[3];
+
+        assert!(state.request_quote(&[0x11; 63]).is_err());
+        assert_eq!(state.generation, 0);
+        assert_eq!(state.outblob, original_quote);
+
+        assert!(state.extend_rtmr(3, &[0x22; 47]).is_err());
+        assert_eq!(state.rtmrs[3], original_rtmr3);
+        assert!(state.extend_rtmr(1, &[0x22; 48]).is_err());
+        assert_eq!(state.rtmrs[1], replay_boot_rtmrs(CCEL_FIXTURE).unwrap()[1]);
+
+        state.request_quote(&[0x33; 64]).unwrap();
+        assert_eq!(state.generation, 1);
+        assert_ne!(state.outblob, original_quote);
+        state.extend_rtmr(3, &[0x44; 48]).unwrap();
+        assert_ne!(state.rtmrs[3], original_rtmr3);
+    }
+
+    #[test]
     fn boot_rtmrs_replay_the_bundled_ccel() {
         let rtmrs = replay_boot_rtmrs(CCEL_FIXTURE).unwrap();
         assert!(rtmrs[..2].iter().all(|rtmr| *rtmr != [0u8; 48]));

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -87,6 +87,21 @@ fn ensure_device_node(path: &Path, major: &str, minor: &str) -> Result<()> {
     if device_node_matches(path, expected_major, expected_minor)? {
         return Ok(());
     }
+    match fs_err::symlink_metadata(path) {
+        Ok(_) => {
+            // Recheck in case udev published the expected node between the two
+            // metadata calls above.
+            if device_node_matches(path, expected_major, expected_minor)? {
+                return Ok(());
+            }
+            bail!(
+                "{} exists but is not character device {expected_major}:{expected_minor}",
+                path.display()
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
     let path_text = path.to_str().context("device path is not UTF-8")?;
     if let Err(error) = command("mknod", &[path_text, "c", major, minor]) {
         // udev can publish the node after the existence check but before

--- a/dstack/tee-simulator/src/tpm.rs
+++ b/dstack/tee-simulator/src/tpm.rs
@@ -9,6 +9,7 @@ use std::{
     io::{Read, Write},
     os::{
         fd::{AsRawFd, FromRawFd},
+        unix::fs::{FileTypeExt as _, MetadataExt as _},
         unix::net::UnixStream,
     },
     path::Path,
@@ -65,6 +66,35 @@ fn command(program: &str, args: &[&str]) -> Result<()> {
         .with_context(|| format!("failed to execute {program}"))?;
     if !status.success() {
         bail!("{program} failed with status {status}");
+    }
+    Ok(())
+}
+
+fn device_node_matches(path: &Path, major: u64, minor: u64) -> Result<bool> {
+    let metadata = match fs_err::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(metadata.file_type().is_char_device()
+        && nix::sys::stat::major(metadata.rdev()) == major
+        && nix::sys::stat::minor(metadata.rdev()) == minor)
+}
+
+fn ensure_device_node(path: &Path, major: &str, minor: &str) -> Result<()> {
+    let expected_major = major.parse().context("invalid device major")?;
+    let expected_minor = minor.parse().context("invalid device minor")?;
+    if device_node_matches(path, expected_major, expected_minor)? {
+        return Ok(());
+    }
+    let path_text = path.to_str().context("device path is not UTF-8")?;
+    if let Err(error) = command("mknod", &[path_text, "c", major, minor]) {
+        // udev can publish the node after the existence check but before
+        // mknod. Accept only the exact character device registered by sysfs.
+        if device_node_matches(path, expected_major, expected_minor)? {
+            return Ok(());
+        }
+        return Err(error);
     }
     Ok(())
 }
@@ -288,9 +318,6 @@ fn install_gcp_event_log(bytes: &[u8]) -> Result<()> {
     fs_err::write(event_log, bytes).context("failed to install simulated TPM event log")
 }
 fn create_tpm_device_node() -> Result<()> {
-    if Path::new("/dev/tpm0").exists() {
-        return Ok(());
-    }
     let sys_dev = Path::new("/sys/class/tpm/tpm0/dev");
     if !sys_dev.exists() {
         return Ok(());
@@ -300,7 +327,7 @@ fn create_tpm_device_node() -> Result<()> {
         .trim()
         .split_once(':')
         .context("invalid /sys/class/tpm/tpm0/dev")?;
-    command("mknod", &["/dev/tpm0", "c", major, minor])
+    ensure_device_node(Path::new("/dev/tpm0"), major, minor)
 }
 
 fn provision_nv(index: &str, contents: &Path) -> Result<()> {
@@ -397,7 +424,7 @@ pub fn run_nitro_vtpm(runtime_dir: &Path, config: &TeeSimulatorConfig) -> Result
         .trim()
         .split_once(':')
         .context("invalid vTPM device number")?;
-    command("mknod", &["/dev/tpm0", "c", major, minor])?;
+    ensure_device_node(Path::new("/dev/tpm0"), major, minor)?;
     sd_notify::notify(true, &[sd_notify::NotifyState::Ready])?;
     let result = proxy_thread
         .join()


### PR DESCRIPTION
## Summary

- validate that an existing `/dev/tpm0` is the expected character device
- tolerate the udev-versus-`mknod` publication race only when the resulting device number matches
- add failure-atomic coverage for invalid TDX quote and RTMR operations

## Context

The simulator previously treated any existing `/dev/tpm0` as ready and failed if udev created the node between the existence check and `mknod`. This made GCP vTPM and NitroTPM startup timing-dependent and could accept a stale or mismatched node.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p dstack-tee-simulator`
- `cargo clippy -p dstack-tee-simulator -- -D warnings`
- `git diff --check origin/next...HEAD`