### PR TITLE
fix(dstackup): pick a random free CID window, and keep it across re-runs

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2400,6 +2400,7 @@ dependencies = [
  "clap",
  "dstack-cli-core",
  "hex",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",

--- a/dstack/crates/dstackup/Cargo.toml
+++ b/dstack/crates/dstackup/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 clap.workspace = true
 dstack-cli-core.workspace = true
 hex = { workspace = true, features = ["alloc"] }
+rand.workspace = true
 # reqwest (+ rustls/hyper) is already linked via dstack-cli-core's prpc client,
 # so using it for http here adds ~no binary cost and drops the curl dependency.
 reqwest = { workspace = true }

--- a/dstack/crates/dstackup/src/cid.rs
+++ b/dstack/crates/dstackup/src/cid.rs
@@ -65,13 +65,18 @@ fn first_free(candidates: impl Iterator<Item = u32>, occupied: &[(u32, u32)]) ->
 /// choose a CID window that won't collide with a VMM already on this host.
 ///
 /// Precedence: an explicit `--cid-start` is honored but refused on overlap; then
-/// a random free block.
-pub(crate) fn pick_cid_start(explicit: Option<u32>, occupied: &[(u32, u32)]) -> Result<u32> {
-    pick_cid_start_from(explicit, occupied, random_starts())
+/// the start a previous install recorded; then a random free block.
+pub(crate) fn pick_cid_start(
+    explicit: Option<u32>,
+    recorded: Option<u32>,
+    occupied: &[(u32, u32)],
+) -> Result<u32> {
+    pick_cid_start_from(explicit, recorded, occupied, random_starts())
 }
 
 fn pick_cid_start_from(
     explicit: Option<u32>,
+    recorded: Option<u32>,
     occupied: &[(u32, u32)],
     candidates: impl Iterator<Item = u32>,
 ) -> Result<u32> {
@@ -94,6 +99,14 @@ fn pick_cid_start_from(
         return Ok(start);
     }
 
+    // A recorded start already belongs to this install, so a re-run reuses it
+    // verbatim and never moves a live instance's pool out from under its running
+    // CVMs. It is deliberately not re-checked: `occupied` includes this install's
+    // own VMM, so the check could only ever fail against itself.
+    if let Some(start) = recorded {
+        return Ok(start);
+    }
+
     match first_free(candidates, occupied) {
         Some(start) => {
             println!("  [ok] cid-start {start} (avoids CIDs already reserved on this host)");
@@ -112,7 +125,7 @@ mod tests {
 
     #[test]
     fn takes_the_first_candidate_when_the_host_is_empty() {
-        let picked = pick_cid_start_from(None, &[], [40_000, 50_000].into_iter()).unwrap();
+        let picked = pick_cid_start_from(None, None, &[], [40_000, 50_000].into_iter()).unwrap();
         assert_eq!(picked, 40_000);
     }
 
@@ -120,7 +133,8 @@ mod tests {
     fn skips_candidates_whose_stride_is_taken() {
         let occupied = [(40_000, 41_000), (50_000, 50_001)];
         let picked =
-            pick_cid_start_from(None, &occupied, [40_000, 50_000, 60_000].into_iter()).unwrap();
+            pick_cid_start_from(None, None, &occupied, [40_000, 50_000, 60_000].into_iter())
+                .unwrap();
         assert_eq!(picked, 60_000);
     }
 
@@ -131,14 +145,15 @@ mod tests {
         let occupied = [(45_000, 45_001)];
         assert!(window_overlaps(40_000, CID_BLOCK_STRIDE, &occupied));
         assert!(!window_overlaps(40_000, CID_POOL_SIZE, &occupied));
-        let picked = pick_cid_start_from(None, &occupied, [40_000, 60_000].into_iter()).unwrap();
+        let picked =
+            pick_cid_start_from(None, None, &occupied, [40_000, 60_000].into_iter()).unwrap();
         assert_eq!(picked, 60_000);
     }
 
     #[test]
     fn gives_up_after_the_attempt_budget() {
         let occupied = [(40_000, 50_000)];
-        let err = pick_cid_start_from(None, &occupied, std::iter::repeat(40_000))
+        let err = pick_cid_start_from(None, None, &occupied, std::iter::repeat(40_000))
             .unwrap_err()
             .to_string();
         assert!(err.contains("could not find a free CID window"), "{err}");
@@ -149,18 +164,36 @@ mod tests {
         // Overlaps the *stride* of an occupied block but not its pool, which an
         // explicit choice is allowed to do.
         let occupied = [(40_000, 41_000)];
-        let picked = pick_cid_start_from(Some(45_000), &occupied, [60_000].into_iter()).unwrap();
+        let picked =
+            pick_cid_start_from(Some(45_000), None, &occupied, [60_000].into_iter()).unwrap();
         assert_eq!(picked, 45_000);
     }
 
     #[test]
     fn explicit_is_refused_on_overlap_and_suggests_a_free_start() {
         let occupied = [(40_000, 41_000)];
-        let err = pick_cid_start_from(Some(40_500), &occupied, [60_000].into_iter())
+        let err = pick_cid_start_from(Some(40_500), None, &occupied, [60_000].into_iter())
             .unwrap_err()
             .to_string();
         assert!(err.contains("--cid-start 40500 overlaps"), "{err}");
         assert!(err.contains("e.g. --cid-start 60000"), "{err}");
+    }
+
+    #[test]
+    fn explicit_wins_over_a_recorded_start() {
+        let picked =
+            pick_cid_start_from(Some(45_000), Some(70_000), &[], [60_000].into_iter()).unwrap();
+        assert_eq!(picked, 45_000);
+    }
+
+    #[test]
+    fn a_recorded_start_is_reused_verbatim() {
+        // The install's own VMM shows up in `occupied`; reusing must not treat
+        // that as a conflict, otherwise every re-run would move the pool.
+        let occupied = [(70_000, 71_000)];
+        let picked =
+            pick_cid_start_from(None, Some(70_000), &occupied, [60_000].into_iter()).unwrap();
+        assert_eq!(picked, 70_000);
     }
 
     #[test]

--- a/dstack/crates/dstackup/src/cid.rs
+++ b/dstack/crates/dstackup/src/cid.rs
@@ -81,6 +81,15 @@ fn pick_cid_start_from(
     candidates: impl Iterator<Item = u32>,
 ) -> Result<u32> {
     if let Some(start) = explicit {
+        // A start so high that its pool runs off the end of the CID space. The
+        // VMM rejects this too (`Config::validate`), but preflight is where it
+        // belongs: nothing has been written to the host yet.
+        if start.checked_add(CID_POOL_SIZE).is_none() {
+            bail!(
+                "--cid-start {start} leaves no room for a {CID_POOL_SIZE}-wide pool \
+                 (it overflows u32)"
+            );
+        }
         // An explicit choice is checked against the pool it actually asks for,
         // not the stride: the operator picked the number, so don't demand
         // growth headroom they didn't ask for.
@@ -177,6 +186,14 @@ mod tests {
             .to_string();
         assert!(err.contains("--cid-start 40500 overlaps"), "{err}");
         assert!(err.contains("e.g. --cid-start 60000"), "{err}");
+    }
+
+    #[test]
+    fn explicit_is_refused_when_its_pool_runs_off_the_end_of_the_cid_space() {
+        let err = pick_cid_start_from(Some(u32::MAX - 10), None, &[], [60_000].into_iter())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("leaves no room for a 1000-wide pool"), "{err}");
     }
 
     #[test]

--- a/dstack/crates/dstackup/src/cid.rs
+++ b/dstack/crates/dstackup/src/cid.rs
@@ -5,52 +5,104 @@
 //! pick a vsock CID window that doesn't collide with a VMM already on the host.
 
 use anyhow::{bail, Result};
+use rand::Rng;
 
-/// size of a VMM's CID pool (matches `config::VmmRender` default).
+/// size of a VMM's CID pool (matches `config::VmmRender` default). This is what
+/// ends up in `cvm.cid_pool_size`.
 const CID_POOL_SIZE: u32 = 1000;
-/// default CID pool start when nothing else is using that range.
-const DEFAULT_CID_START: u32 = 1000;
 
-/// whether `[start, start+CID_POOL_SIZE)` intersects any occupied range.
-fn cid_window_overlaps(start: u32, occupied: &[(u32, u32)]) -> bool {
-    let end = start.saturating_add(CID_POOL_SIZE);
+/// spacing between candidate pool starts, and the width we require to be free
+/// before taking one.
+///
+/// This is an installer-side heuristic only: it is never written to vmm.toml and
+/// the VMM knows nothing about it. Requiring a whole stride to be free leaves an
+/// instance room to raise `cvm.cid_pool_size` later without walking into a
+/// neighbour, and striding the candidate space keeps a random pick cheap to
+/// verify.
+const CID_BLOCK_STRIDE: u32 = 10_000;
+
+/// lowest candidate start. The first stride is skipped because CIDs 0-2 are
+/// reserved (hypervisor, local, host).
+const CID_MIN: u32 = CID_BLOCK_STRIDE;
+
+/// highest candidate start, chosen so `start + CID_BLOCK_STRIDE` stays in u32.
+const CID_MAX: u32 = u32::MAX - CID_BLOCK_STRIDE;
+
+/// how many candidates to try before giving up.
+const CID_PICK_ATTEMPTS: usize = 8;
+
+/// whether `[start, start + width)` intersects any occupied range. Both sides
+/// are half-open.
+fn window_overlaps(start: u32, width: u32, occupied: &[(u32, u32)]) -> bool {
+    let end = start.saturating_add(width);
     occupied.iter().any(|&(s, e)| start < e && s < end)
 }
 
-/// the lowest pool-aligned CID block at or above every occupied range. We jump
-/// above the highest reservation rather than packing into a free gap below it —
-/// simpler, and the result is always collision-free.
-fn next_free_cid_block(occupied: &[(u32, u32)]) -> u32 {
-    let max_end = occupied
-        .iter()
-        .map(|&(_, e)| e)
-        .max()
-        .unwrap_or(DEFAULT_CID_START);
-    (max_end.div_ceil(CID_POOL_SIZE) * CID_POOL_SIZE).max(DEFAULT_CID_START)
+/// number of stride-aligned candidate blocks in `[CID_MIN, CID_MAX]`.
+fn candidate_blocks() -> u32 {
+    (CID_MAX - CID_MIN) / CID_BLOCK_STRIDE + 1
 }
 
-/// choose a CID window `[start, start+CID_POOL_SIZE)` that won't collide with a
-/// VMM already running on this host. With an explicit `--cid-start`, honor it
-/// but refuse on overlap; without one, use the default unless it's taken, then
-/// move to the next free block.
+/// an endless stream of stride-aligned starts drawn uniformly from the CID space.
+///
+/// Random rather than "the next free block above everything in use": two installs
+/// racing on the same host would compute the same next block from the same
+/// observation and collide deterministically, and a single stray high CID from an
+/// unrelated QEMU would drag every later install up with it.
+fn random_starts() -> impl Iterator<Item = u32> {
+    let mut rng = rand::thread_rng();
+    let blocks = candidate_blocks();
+    std::iter::repeat_with(move || CID_MIN + rng.gen_range(0..blocks) * CID_BLOCK_STRIDE)
+}
+
+/// first candidate whose whole stride is free, within the attempt budget.
+fn first_free(candidates: impl Iterator<Item = u32>, occupied: &[(u32, u32)]) -> Option<u32> {
+    candidates
+        .take(CID_PICK_ATTEMPTS)
+        .find(|&start| !window_overlaps(start, CID_BLOCK_STRIDE, occupied))
+}
+
+/// choose a CID window that won't collide with a VMM already on this host.
+///
+/// Precedence: an explicit `--cid-start` is honored but refused on overlap; then
+/// a random free block.
 pub(crate) fn pick_cid_start(explicit: Option<u32>, occupied: &[(u32, u32)]) -> Result<u32> {
-    match explicit {
-        Some(n) => {
-            if cid_window_overlaps(n, occupied) {
-                bail!(
-                    "--cid-start {n} overlaps a CID range already reserved on this host; \
-                     pick a free start, e.g. --cid-start {}",
-                    next_free_cid_block(occupied)
-                );
+    pick_cid_start_from(explicit, occupied, random_starts())
+}
+
+fn pick_cid_start_from(
+    explicit: Option<u32>,
+    occupied: &[(u32, u32)],
+    candidates: impl Iterator<Item = u32>,
+) -> Result<u32> {
+    if let Some(start) = explicit {
+        // An explicit choice is checked against the pool it actually asks for,
+        // not the stride: the operator picked the number, so don't demand
+        // growth headroom they didn't ask for.
+        if window_overlaps(start, CID_POOL_SIZE, occupied) {
+            match first_free(candidates, occupied) {
+                Some(free) => bail!(
+                    "--cid-start {start} overlaps a CID range already reserved on this host; \
+                     pick a free start, e.g. --cid-start {free}"
+                ),
+                None => bail!(
+                    "--cid-start {start} overlaps a CID range already reserved on this host; \
+                     pick a free start"
+                ),
             }
-            Ok(n)
         }
-        None if !cid_window_overlaps(DEFAULT_CID_START, occupied) => Ok(DEFAULT_CID_START),
-        None => {
-            let start = next_free_cid_block(occupied);
-            println!("  [ok] cid-start {start} (avoids CIDs already reserved by another VMM)");
+        return Ok(start);
+    }
+
+    match first_free(candidates, occupied) {
+        Some(start) => {
+            println!("  [ok] cid-start {start} (avoids CIDs already reserved on this host)");
             Ok(start)
         }
+        None => bail!(
+            "could not find a free CID window in {CID_PICK_ATTEMPTS} attempts; \
+             pass --cid-start <start> explicitly"
+        ),
     }
 }
 
@@ -59,26 +111,64 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cid_default_when_range_free() {
-        assert_eq!(pick_cid_start(None, &[]).unwrap(), 1000);
-        // a pool entirely above the default window leaves it free.
-        assert_eq!(pick_cid_start(None, &[(2000, 3000)]).unwrap(), 1000);
+    fn takes_the_first_candidate_when_the_host_is_empty() {
+        let picked = pick_cid_start_from(None, &[], [40_000, 50_000].into_iter()).unwrap();
+        assert_eq!(picked, 40_000);
     }
 
     #[test]
-    fn cid_auto_offsets_past_an_existing_vmm() {
-        // another VMM reserving [1000,2000) -> jump to 2000.
-        assert_eq!(pick_cid_start(None, &[(1000, 2000)]).unwrap(), 2000);
-        // its reserved pool plus a stray live CVM at 2500 -> jump past it.
-        assert_eq!(
-            pick_cid_start(None, &[(1000, 2000), (2500, 2501)]).unwrap(),
-            3000
-        );
+    fn skips_candidates_whose_stride_is_taken() {
+        let occupied = [(40_000, 41_000), (50_000, 50_001)];
+        let picked =
+            pick_cid_start_from(None, &occupied, [40_000, 50_000, 60_000].into_iter()).unwrap();
+        assert_eq!(picked, 60_000);
     }
 
     #[test]
-    fn cid_explicit_honored_or_refused() {
-        assert_eq!(pick_cid_start(Some(2000), &[(1000, 2000)]).unwrap(), 2000);
-        assert!(pick_cid_start(Some(1000), &[(1000, 2000)]).is_err());
+    fn a_candidate_needs_its_whole_stride_free_not_just_its_pool() {
+        // 45_000 is clear of [40_000, 41_000) as a 1000-wide pool, but it sits
+        // inside that candidate's stride, so the block is rejected.
+        let occupied = [(45_000, 45_001)];
+        assert!(window_overlaps(40_000, CID_BLOCK_STRIDE, &occupied));
+        assert!(!window_overlaps(40_000, CID_POOL_SIZE, &occupied));
+        let picked = pick_cid_start_from(None, &occupied, [40_000, 60_000].into_iter()).unwrap();
+        assert_eq!(picked, 60_000);
+    }
+
+    #[test]
+    fn gives_up_after_the_attempt_budget() {
+        let occupied = [(40_000, 50_000)];
+        let err = pick_cid_start_from(None, &occupied, std::iter::repeat(40_000))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not find a free CID window"), "{err}");
+    }
+
+    #[test]
+    fn explicit_is_honored_when_its_pool_is_free() {
+        // Overlaps the *stride* of an occupied block but not its pool, which an
+        // explicit choice is allowed to do.
+        let occupied = [(40_000, 41_000)];
+        let picked = pick_cid_start_from(Some(45_000), &occupied, [60_000].into_iter()).unwrap();
+        assert_eq!(picked, 45_000);
+    }
+
+    #[test]
+    fn explicit_is_refused_on_overlap_and_suggests_a_free_start() {
+        let occupied = [(40_000, 41_000)];
+        let err = pick_cid_start_from(Some(40_500), &occupied, [60_000].into_iter())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--cid-start 40500 overlaps"), "{err}");
+        assert!(err.contains("e.g. --cid-start 60000"), "{err}");
+    }
+
+    #[test]
+    fn random_starts_are_aligned_and_leave_room_for_a_stride() {
+        for start in random_starts().take(64) {
+            assert!((CID_MIN..=CID_MAX).contains(&start), "{start} out of range");
+            assert_eq!(start % CID_BLOCK_STRIDE, 0, "{start} is not stride-aligned");
+            assert!(start.checked_add(CID_BLOCK_STRIDE).is_some(), "{start}");
+        }
     }
 }

--- a/dstack/crates/dstackup/src/install.rs
+++ b/dstack/crates/dstackup/src/install.rs
@@ -90,7 +90,7 @@ pub(crate) async fn cmd_install(mut o: InstallOpts, release_api_base_url: &str) 
 
     // 4. preflight - fail BEFORE any side effect (image download, key provider,
     //    dirs, units), so a CID/port clash can't half-install the host.
-    let cid_start = pick_cid_start(o.cid_start, &host::occupied_cid_ranges())?;
+    let cid_start = pick_cid_start(o.cid_start, st.cid_start, &host::occupied_cid_ranges())?;
     let kms_owned = kms_port_owned(
         &st,
         &client_url,
@@ -219,6 +219,7 @@ pub(crate) async fn cmd_install(mut o: InstallOpts, release_api_base_url: &str) 
     st.client_url = client_url.clone();
     st.client_token_path = token_path.display().to_string();
     st.auth_port = o.auth_port;
+    st.cid_start = Some(cid_start);
     st.platform = platform.vmm_str().to_string();
     st.image = o.image.clone();
     let instance = effective_instance(&o, &layout, explicit_prefix);

--- a/dstack/crates/dstackup/src/state.rs
+++ b/dstack/crates/dstackup/src/state.rs
@@ -35,6 +35,11 @@ pub(crate) struct State {
     #[serde(default)]
     pub(crate) client_token_path: String,
     pub(crate) auth_port: u16,
+    /// vsock CID pool start this install chose, so a re-run reuses it instead of
+    /// picking a fresh window and moving a live instance's pool. Absent in state
+    /// files written before this was recorded.
+    #[serde(default)]
+    pub(crate) cid_start: Option<u32>,
     /// systemd unit names (without the `.service` suffix).
     #[serde(default)]
     pub(crate) vmm_unit: String,
@@ -70,4 +75,27 @@ pub(crate) fn write_state(prefix: &Path, st: &State) -> Result<()> {
 pub(crate) fn write(path: &Path, body: &str) -> Result<()> {
     dstack_cli_core::fsutil::write_atomic(path, body)
         .with_context(|| format!("writing {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `read_state` swallows a parse error into `None`, which an install reads as
+    /// "nothing here" — it would then re-pick the CID window and ports of a live
+    /// install. So a state file written before a field existed must still load.
+    #[test]
+    fn a_state_file_without_cid_start_still_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = r#"{
+            "prefix": "/var/lib/dstack",
+            "client_url": "http://127.0.0.1:9080",
+            "auth_port": 8090
+        }"#;
+        fs::write(state_path(dir.path()), body).unwrap();
+
+        let st = read_state(dir.path()).expect("legacy state file must still parse");
+        assert_eq!(st.cid_start, None);
+        assert_eq!(st.auth_port, 8090);
+    }
 }


### PR DESCRIPTION
## Problem

`dstackup install` picks the vsock CID window for a new host install with `pick_cid_start`,
which reserves the lowest pool-aligned block **at or above every occupied range**:

```rust
let max_end = occupied.iter().map(|&(_, e)| e).max().unwrap_or(DEFAULT_CID_START);
(max_end.div_ceil(CID_POOL_SIZE) * CID_POOL_SIZE).max(DEFAULT_CID_START)
```

Three problems follow from "observe, then stack on top":

1. **Two concurrent installs collide deterministically.** Both read the same `max_end` from
   the same host, both compute the same next block, and both write it into their `vmm.toml`.
   The clash then surfaces much later, as `vhost-vsock: unable to set guest cid: Address
   already in use` when the second install's first CVM boots.
2. **One stray high CID drags every later install up with it.** Any unrelated QEMU on the
   host contributes a 1-wide occupied range (`occupied_cid_ranges` scans for `guest-cid=`),
   and every subsequent install is pushed above it permanently.
3. **`max_end.div_ceil(SIZE) * SIZE` overflows `u32`.** A `guest-cid=` above
   `u32::MAX - CID_POOL_SIZE` — reachable by any VM on the host, since the field is a bare
   `u32` — wraps in release builds and silently yields a *low* start that may already be
   taken. This is the failure mode the function exists to prevent.

Separately, `pick_cid_start` never consulted the install state, so **re-running
`dstackup install` re-picked the window** and rewrote `cvm.cid_start` underneath a running
instance. `app.rs` only warns about CIDs outside the configured pool ("not tracking cid
{cid} in the pool"), so this degrades into drifting VMs rather than a clean error.

## Fix

**Commit 1 — random free block instead of stacking.** Draw stride-aligned candidates
uniformly from the CID space and take the first one whose window is free, up to an attempt
budget. Randomness removes the shared observation that made concurrent installs collide,
and makes the choice independent of where other CIDs happen to sit. `next_free_cid_block`
is deleted, which removes the overflow with it; the candidate range is bounded so
`start + stride` always stays in `u32`.

The stride is deliberately wider than the pool:

```rust
const CID_POOL_SIZE: u32 = 1000;      // what ends up in cvm.cid_pool_size
const CID_BLOCK_STRIDE: u32 = 10_000; // candidate alignment + required free width
```

A candidate must have its **whole stride** free, so an operator can raise
`cvm.cid_pool_size` later without walking into a neighbour. The stride is an installer-side
heuristic only — it is never written to `vmm.toml` and the VMM knows nothing about it, so
this adds no new config surface and nothing to keep in sync. The headroom is therefore
best-effort, not a guarantee; a `cid_pool_size` raised past it is a config conflict for the
VMM to reject, not something the installer can enforce after the fact.

An explicit `--cid-start` keeps its current semantics — honored, refused on overlap, with a
free start suggested in the error — and is still checked against the pool it actually asks
for rather than the stride, so operators are not held to headroom they did not request.

**Commit 2 — reuse the recorded window on a re-run.** `State` gains `cid_start`, and
`pick_cid_start` takes it as the middle precedence step: explicit `--cid-start` > recorded >
random. This mirrors the existing `resolve_kms_port` precedence. The recorded value is
reused verbatim and deliberately not re-checked: `occupied_cid_ranges()` includes this
install's own running VMM, so the only thing a re-check could ever fail against is itself.

The new field is `Option<u32>` behind `#[serde(default)]`. That matters more than usual
here because `read_state` swallows a parse error into `None`, which an install reads as
"nothing here" — a compat break would silently re-pick the CID window *and* the ports of a
live install, so there is a regression test pinning that a pre-`cid_start` state file still
loads.

**Commit 3 — reject an explicit start whose pool runs off the end of the CID space.**
A `--cid-start` above `u32::MAX - CID_POOL_SIZE` would render a `vmm.toml` the VMM then
refuses (`Config::validate` checks the same `cid_start + cid_pool_size` overflow), so it is
caught in preflight instead, before anything is written to the host. Originated as a
Copilot Autofix suggestion on this PR; kept, reformatted to rustfmt, and pinned with a test.

## Scope

This is the installer's avoidance path only — it lowers the odds of a mistake, it does not
close the hole. `dstackup` only sees the moment of install: hand-edited `vmm.toml`s,
hand-started VMMs, and instances that come up *after* an install all bypass it entirely.
The enforcing counterpart is a startup-time conflict check in `dstack-vmm` itself, which is
not in this PR.

## Verification

`cargo test -p dstackup` — 29 passed (10 in `cid`, 1 new compat test in `state`).
`cargo clippy -p dstackup --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean.

The `cid` tests drive `pick_cid_start_from` with an explicit candidate iterator, so every
selection rule is deterministic; a separate test asserts the real `random_starts()` stream
stays stride-aligned, within range, and never overflows. Coverage: first free candidate
taken, occupied strides skipped, whole-stride-not-just-pool requirement, attempt budget
exhausted, explicit honored, explicit refused with a suggestion, explicit refused when its
pool overflows, explicit beats recorded, recorded reused verbatim against an `occupied` set
that contains it.

Numbers behind the attempt budget of 8, over the 429,494 stride-aligned candidate blocks:

| existing instances | first-try collision | after 8 attempts |
|---|---|---|
| 10 | 0.0023% | 8.6e-36 % |
| 100 | 0.023% | 8.6e-28 % |
| 1000 | 0.23% | 8.6e-20 % |

## Trade-off

Chosen CIDs are no longer small and sequential (`10000`, `20000`, …) but arbitrary
stride-aligned values, which costs some readability when eyeballing `ps aux | grep
guest-cid` — currently the documented way to chase a CID clash in `docs/deployment.md`.
That workflow only exists because there is no authoritative place to ask who owns a CID;
the right fix is a registry lookup rather than hand-comparable numbers, and it belongs with
the VMM-side work above. The install prints the chosen start, and it is recorded in
`dstackup-state.json`.
