### PR TITLE
fix(os): make the SELinux assertion real and match it across both backends

### DIFF
--- a/os/mkosi/components/kernel/kernel.config
+++ b/os/mkosi/components/kernel/kernel.config
@@ -207,7 +207,16 @@ CONFIG_NFT_LIMIT=m
 CONFIG_NFT_REJECT=m
 CONFIG_NFT_REJECT_INET=m
 CONFIG_NFT_HASH=m
+# SELinux, matching dstack-docker.cfg symbol for symbol. CONFIG_SECURITY comes
+# from x86_64_defconfig here, but the rest of the chain is asserted because two
+# separate steps fail silently: SELINUX needs SECURITY_NETWORK && AUDIT, and an
+# LSM only registers if CONFIG_LSM names it, which depends on which
+# DEFAULT_SECURITY_* is chosen.
+CONFIG_SECURITY_NETWORK=y
+CONFIG_AUDIT=y
 CONFIG_SECURITY_SELINUX=y
+CONFIG_DEFAULT_SECURITY_SELINUX=y
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,selinux,smack,tomoyo,apparmor,ipe,bpf"
 CONFIG_BRIDGE_VLAN_FILTERING=y
 CONFIG_XFRM=y
 CONFIG_XFRM_USER=y

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
@@ -20,7 +20,28 @@ CONFIG_BPF_SYSCALL=y
 CONFIG_IP_VS=m
 CONFIG_SECCOMP=y
 CONFIG_SECCOMP_FILTER=y
+# SELinux. This line alone never took effect: the kernel is built from the
+# linux-yocto "tiny" type, which leaves CONFIG_SECURITY off, and SELINUX is
+# "depends on SECURITY_NETWORK && AUDIT && NET && INET" with SECURITY_NETWORK in
+# turn depending on SECURITY. So every image this fragment produced ran without
+# SELinux while claiming otherwise, and os/mkosi -- which starts from
+# x86_64_defconfig -- had it.
+CONFIG_SECURITY=y
+CONFIG_SECURITY_NETWORK=y
+CONFIG_AUDIT=y
 CONFIG_SECURITY_SELINUX=y
+# Compiling it in is still not enough, and the second failure is silent too: an
+# LSM only registers if CONFIG_LSM names it, and that string's default is picked
+# by DEFAULT_SECURITY_*. Enabling SECURITY without naming a default lands on
+# DEFAULT_SECURITY_DAC, whose list is
+# "landlock,lockdown,yama,loadpin,safesetid,ipe,bpf" -- no selinux -- so the
+# hooks would build and never initialize.
+CONFIG_DEFAULT_SECURITY_SELINUX=y
+# The resulting order is asserted rather than left to a default, in both
+# backends, so neither a defconfig change nor a new DEFAULT_SECURITY_* branch
+# can drop selinux without failing the build. Entries for LSMs that are not
+# compiled in are ignored by the kernel.
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,selinux,smack,tomoyo,apparmor,ipe,bpf"
 CONFIG_VLAN_8021Q=y
 CONFIG_BRIDGE_VLAN_FILTERING=y
 CONFIG_XFRM=y


### PR DESCRIPTION
## Problem

`CONFIG_SECURITY_SELINUX=y` has been in `dstack-docker.cfg` for a long time and has never done anything.

The kernel is built from the linux-yocto `tiny` type, which leaves `CONFIG_SECURITY` off. `SECURITY_SELINUX` is `depends on SECURITY_NETWORK && AUDIT && NET && INET`, and `SECURITY_NETWORK` in turn depends on `SECURITY`. Kconfig drops a symbol whose dependencies are unmet without saying so, so every production image built from this fragment has run without SELinux while the fragment claimed otherwise.

`os/mkosi` has had it all along, because `x86_64_defconfig` sets `CONFIG_SECURITY`. So the two guest images have been measuring different feature sets, with nothing recording that they differ.

Measured in CVMs, one per image:

| | Yocto | mkosi |
| --- | --- | --- |
| `/sys/fs/selinux` | does not exist | exists |
| `enforce` | n/a | `0` |
| `/sys/kernel/security/lsm` | file absent | `capability,selinux` |
| `/etc/selinux` | absent | `semanage.conf` only |
| `docker info` security options | none | none |

## Fix

Enable the whole chain on Yocto, and assert it on both backends.

There is a second failure mode behind the first, silent in the same way. Compiling SELinux in is not enough — an LSM only registers if `CONFIG_LSM` names it, and that string's default is selected by `DEFAULT_SECURITY_*`. Turning on `SECURITY` without naming a default lands on `DEFAULT_SECURITY_DAC`:

```
default "landlock,lockdown,yama,loadpin,safesetid,ipe,bpf" if DEFAULT_SECURITY_DAC
```

— no selinux. The hooks would build and never initialize, which is exactly the class of silent no-op this PR exists to remove. `CONFIG_DEFAULT_SECURITY_SELINUX` and the resulting `CONFIG_LSM` order are therefore both asserted, in both fragments, so neither a defconfig change nor a new `DEFAULT_SECURITY_*` branch can drop selinux without failing the build.

## What this does and does not change

**Does not change enforcement.** SELinux needs a loaded policy and neither image ships one, so the state after this change is what mkosi already has today: hooks registered, `enforce=0`, no policy, no security options reported by Docker. Nothing starts being denied.

**Does change the kernel's measurements**, so it needs the same release coordination as any guest-image change.

**Adds the audit subsystem to the Yocto image** (`AUDIT`/`AUDITSYSCALL`), which SELinux depends on (`depends on SECURITY_NETWORK && AUDIT && NET && INET`). mkosi already has it, and the Yocto guest kernel log will start carrying audit records where it carried none.

To be precise about what those records are, since it is easy to read this as "SELinux starts logging": they come from the audit subsystem, not from SELinux. Counted over a full boot plus an Incus session on the mkosi image — 32 lines total:

| type | what it is | count |
| --- | --- | --- |
| 1130 / 1131 | `SERVICE_START` / `SERVICE_STOP`, from systemd | 21 |
| 1325 | `NETFILTER_CFG`, when something programs nftables | 4 |
| 1300 / 1327 | `SYSCALL` / `PROCTITLE` | 6 |
| 2000 | audit subsystem init | 1 |
| **1400 (AVC — an SELinux denial)** | — | **0** |

No AVC records, because AVC decisions require a loaded policy. Without one SELinux makes no access decisions and logs nothing at all; `setenforce` is not a factor either way, and neither image even installs it.

## Verification

Merged the fragment onto a `kernel-config` artifact from a real build (linux-yocto 6.18.24), and separately reproduced the mkosi path from `x86_64_defconfig`, both with `olddefconfig` against Linux 6.18.40 source:

| Symbol | Yocto | mkosi |
| --- | --- | --- |
| `SECURITY` | `y` | `y` |
| `SECURITY_NETWORK` | `y` | `y` |
| `AUDIT` | `y` | `y` |
| `AUDITSYSCALL` | `y` | `y` |
| `SECURITY_SELINUX` | `y` | `y` |
| `DEFAULT_SECURITY_SELINUX` | `y` | `y` |
| `NETWORK_SECMARK` | `y` | `y` |
| `SECURITYFS` | `y` | `y` |

The two `CONFIG_LSM` strings come out byte-identical. `os/mkosi/scripts/check-kernel-config.sh` passes on the produced mkosi config. REUSE lint clean.

**Not verified:** no image was built or booted with this change. The runtime numbers in the table above are from the mkosi image as it already ships, which is the state this brings Yocto to.

## Relationship to #1042

Independent — this can merge in either order. Both touch the same region of `dstack-docker.cfg`, so whichever lands second needs a trivial rebase: #1042 removes the dead `CONFIG_SECURITY_SELINUX=y` line and documents why, this PR replaces it with a working chain. #1042 also adds a shared kernel-config gate that would then cover these assertions on the Yocto side too, which today only `os/mkosi` has.
