### PR TITLE
dstack-mr: support QEMU 10 and 11 ACPI measurements

### DIFF
--- a/docs/tutorials/attestation-verification.md
+++ b/docs/tutorials/attestation-verification.md
@@ -259,7 +259,7 @@ sudo apt-get install -y git libslirp-dev python3-pip ninja-build \
 # Clone the custom QEMU fork
 cd ~/dstack
 git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 \
-  --branch dstack-qemu-9.2.1 --single-branch
+  --branch dstack-qemu-acpi-11.1-compat --single-branch
 
 # Configure with ACPI table dumping enabled
 cd qemu-tdx

--- a/dstack/kms/dstack-app/builder/Dockerfile
+++ b/dstack/kms/dstack-app/builder/Dockerfile
@@ -30,7 +30,7 @@ FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1
 COPY --from=build-shared /pin-packages.sh /config-qemu.sh /build/
 COPY ./shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
+ARG QEMU_REV=9de6fdfff3a84103b83ca6b2e8c4fb8e05cf9195
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -46,7 +46,7 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch && \
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-acpi-11.1-compat --single-branch && \
     cd qemu-tdx && git fetch --depth 1 origin ${QEMU_REV} && \
     git checkout ${QEMU_REV} && \
     ../config-qemu.sh ./build /usr/local && \

--- a/dstack/verifier/builder/Dockerfile
+++ b/dstack/verifier/builder/Dockerfile
@@ -34,7 +34,7 @@ FROM debian:bookworm@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1
 COPY --from=build-shared pin-packages.sh config-qemu.sh /build/
 COPY builder/shared/qemu-pinned-packages.txt /build/
 WORKDIR /build
-ARG QEMU_REV=dbcec07c0854bf873d346a09e87e4c993ccf2633
+ARG QEMU_REV=9de6fdfff3a84103b83ca6b2e8c4fb8e05cf9195
 RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -50,7 +50,7 @@ RUN ./pin-packages.sh ./qemu-pinned-packages.txt && \
     flex \
     bison && \
     rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
-RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-9.2.1 --single-branch && \
+RUN git clone https://github.com/kvinwang/qemu-tdx.git --depth 1 --branch dstack-qemu-acpi-11.1-compat --single-branch && \
     cd qemu-tdx && git fetch --depth 1 origin ${QEMU_REV} && \
     git checkout ${QEMU_REV} && \
     ../config-qemu.sh ./build /usr/local && \


### PR DESCRIPTION
## Summary

- update the pinned ACPI table generator with QEMU 10.0, 11.0, and 11.1 compatibility logic
- use the updated generator in KMS and verifier builds
- update the local build documentation

## Validation

- compared locally generated ACPI AML across upstream QEMU 9.2.1, 10.0.0, 10.1.0, 10.2.0, 11.0.0, and 11.1.0
- confirmed identical ACPI output for QEMU 10.0 through 10.2
- confirmed exact upstream AML deltas at QEMU 10.0, 11.0, and 11.1
- ran dstack-mr measurements locally for 9.2.1, 10.0.0, 10.2.0, 11.0.0, and 11.1.0
- `cargo test -p dstack-mr -p dstack-mr-cli`
- QEMU ACPI compatibility unit tests: 7 passed