### PR TITLE
Generate ACPI for newer QEMU versions instead of rejecting them

### DIFF
--- a/dstack/crates/qemu-acpi/fixtures/README.md
+++ b/dstack/crates/qemu-acpi/fixtures/README.md
@@ -96,3 +96,12 @@ ninja qemu-system-x86_64
 There was no genuine upstream QEMU 11.1 release at the time of this audit, so
 the `11.1` compatibility profile remains pinned to the production compatibility
 fork rather than being described as an upstream release profile.
+
+## Versions past the newest profile
+
+A QEMU version newer than the newest profile here is generated with that
+profile (`Compatibility::LATEST`) rather than rejected: most releases leave the
+Q35 ACPI ABI untouched, and when one does change it the generated blobs stop
+matching the measured ones, which is strictly more informative than refusing to
+generate. Adding a profile therefore means adding its fixtures **and** moving
+`Compatibility::LATEST` to it.

--- a/dstack/crates/qemu-acpi/src/lib.rs
+++ b/dstack/crates/qemu-acpi/src/lib.rs
@@ -7,6 +7,11 @@
 //! This crate intentionally models the observable ACPI ABI rather than a
 //! virtual machine. Its output is expected to match QEMU byte for byte for a
 //! supported compatibility profile and machine topology.
+//!
+//! QEMU releases newer than the newest modeled profile are generated with that
+//! profile (see [`QemuVersion::compatibility`]) instead of being rejected, so a
+//! QEMU upgrade that leaves the ACPI ABI alone keeps working and one that does
+//! not surfaces as a blob mismatch the caller can act on.
 
 mod aml_patch;
 mod cpu;
@@ -33,7 +38,7 @@ pub struct AcpiBlobs {
 pub enum Error {
     #[error(transparent)]
     Topology(#[from] TopologyError),
-    #[error("unsupported QEMU compatibility profile: {0}")]
+    #[error("no ACPI compatibility profile for QEMU {0}; releases older than 8.0 are not modeled")]
     UnsupportedVersion(QemuVersion),
     #[error("malformed generated ACPI tables: missing {0}")]
     MalformedTables(String),

--- a/dstack/crates/qemu-acpi/src/profile.rs
+++ b/dstack/crates/qemu-acpi/src/profile.rs
@@ -21,6 +21,19 @@ impl QemuVersion {
         }
     }
 
+    /// Map a QEMU version onto the ACPI compatibility profile to generate with.
+    ///
+    /// Versions newer than the newest modeled profile fall back to
+    /// [`Compatibility::LATEST`] rather than failing: most QEMU releases do not
+    /// change the Q35 ACPI ABI, so extrapolating is right far more often than
+    /// not, and when it is wrong the generated blobs simply do not match the
+    /// measured ones. Refusing to generate turns every such deployment into a
+    /// verification error, which is the same outcome with less information, so
+    /// the caller is left to decide what a mismatch means.
+    ///
+    /// Versions older than 8.0 return `None`: their ABI was never modeled, and
+    /// clamping *down* to the oldest profile would be a guess in the direction
+    /// where QEMU's ACPI output is known to differ.
     pub const fn compatibility(self) -> Option<Compatibility> {
         match (self.major, self.minor) {
             (8, _) => Some(Compatibility::V8),
@@ -29,6 +42,7 @@ impl QemuVersion {
             (10, _) => Some(Compatibility::V10),
             (11, 0) => Some(Compatibility::V11_0),
             (11, 1..) => Some(Compatibility::V11_1),
+            (12.., _) => Some(Compatibility::LATEST),
             _ => None,
         }
     }
@@ -75,4 +89,55 @@ pub enum Compatibility {
     V10,
     V11_0,
     V11_1,
+}
+
+impl Compatibility {
+    /// Newest modeled profile, used for QEMU versions released after it.
+    /// Update this together with every new profile.
+    pub const LATEST: Self = Self::V11_1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn versions_map_to_their_own_profile() {
+        let cases = [
+            ((8, 2, 2), Compatibility::V8),
+            ((9, 1, 0), Compatibility::V9Pre92),
+            ((9, 2, 1), Compatibility::V9_2),
+            ((10, 0, 0), Compatibility::V10),
+            ((11, 0, 3), Compatibility::V11_0),
+            ((11, 1, 0), Compatibility::V11_1),
+        ];
+        for ((major, minor, micro), expected) in cases {
+            assert_eq!(
+                QemuVersion::new(major, minor, micro).compatibility(),
+                Some(expected),
+                "{major}.{minor}.{micro}"
+            );
+        }
+    }
+
+    /// A QEMU release newer than the newest modeled profile must still produce
+    /// blobs: if its ACPI ABI is unchanged they match, and if it changed the
+    /// caller sees a digest mismatch instead of a "cannot generate" error.
+    #[test]
+    fn versions_newer_than_the_newest_profile_clamp_to_it() {
+        for version in [
+            QemuVersion::new(11, 9, 0),
+            QemuVersion::new(12, 0, 0),
+            QemuVersion::new(99, 4, 1),
+        ] {
+            assert_eq!(version.compatibility(), Some(Compatibility::LATEST));
+        }
+    }
+
+    #[test]
+    fn versions_older_than_the_oldest_profile_are_rejected() {
+        for version in [QemuVersion::new(7, 2, 0), QemuVersion::new(0, 0, 0)] {
+            assert_eq!(version.compatibility(), None);
+        }
+    }
 }

--- a/dstack/crates/qemu-acpi/src/tables.rs
+++ b/dstack/crates/qemu-acpi/src/tables.rs
@@ -42,7 +42,9 @@ fn write_bytes(data: &mut [u8], offset: usize, value: &[u8], context: &str) -> R
 /// DSDT with `iasl`, map the relevant ASL object back to its AML byte sequence,
 /// and record the package-length or insertion offset relative to the DSDT
 /// signature. Verify every offset against the reference binary and its
-/// one-device output. Never infer offsets from a Rust-generated blob.
+/// one-device output. Never infer offsets from a Rust-generated blob. A new
+/// profile also has to move `Compatibility::LATEST`, which decides what newer
+/// QEMU versions are generated with.
 struct Layout {
     /// Trimmed QEMU `etc/acpi/tables` fixture used as the immutable template.
     base: &'static [u8],
@@ -616,6 +618,18 @@ mod tests {
             root_verity: true,
             pci_hole64_size: None,
         }
+    }
+
+    /// A QEMU release past the newest modeled profile generates with that
+    /// profile instead of erroring, so an ABI-preserving upgrade keeps
+    /// verifying and an ABI-changing one surfaces as a blob mismatch.
+    #[test]
+    fn unmodeled_newer_versions_generate_with_the_latest_profile() -> Result<(), Error> {
+        let latest = build(&config(1, 0))?;
+        let mut newer = config(1, 0);
+        newer.qemu_version = QemuVersion::new(12, 0, 0);
+        assert_eq!(build(&newer)?, latest);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`QemuVersion::compatibility()` returns `None` for any QEMU major past the newest modeled profile, and `tables::build` turns that into `Error::UnsupportedVersion`. So the day QEMU 12.0 ships, every CVM that reports it stops producing expected ACPI blobs at all — `dstack-mr`'s `Machine::build_tables()` errors out, and with it the whole TDX measurement path that depends on it.

That is the wrong default for a compatibility model. Most QEMU releases do not touch the Q35 ACPI ABI: the profiles here already collapse whole majors (`(9, _)`, `(10, _)`, `(11, 1..)`) precisely because nothing observable changed across them. Refusing to generate assumes the opposite — that every unseen release broke the ABI — and the assumption costs more than it saves, because "cannot generate" and "generated something that does not match" both end in a failed verification. Only one of the two tells the operator what actually differs.

## Fix

Versions newer than the newest modeled profile now generate with that profile:

```rust
(11, 1..) => Some(Compatibility::V11_1),
(12.., _) => Some(Compatibility::LATEST),
```

- If the new release left the ACPI ABI alone, generation matches and verification keeps working across a QEMU upgrade with no verifier release.
- If it did change the ABI, the blobs mismatch and the caller reports a digest mismatch rather than an opaque "unsupported version" — same failure, more information.

Versions **older** than 8.0 still return `None`. Clamping downward would be a guess in the direction where QEMU's ACPI output is known to differ, and `dstack-mr` rejects `< 8.0.0` before it gets here anyway.

`Compatibility::LATEST` is the single place that has to move when a profile is added; both the `Layout` doc comment and `fixtures/README.md` now say so, next to the existing "generate the four base fixtures" instructions.

## Verification

`cargo test -p qemu-acpi` — 18 passed. New tests:

- `versions_map_to_their_own_profile` — pins the existing mapping (8.2.2, 9.1.0, 9.2.1, 10.0.0, 11.0.3, 11.1.0) so the clamp arm cannot swallow a version that has its own profile.
- `versions_newer_than_the_newest_profile_clamp_to_it` — 11.9.0, 12.0.0, 99.4.1 resolve to `LATEST`.
- `versions_older_than_the_oldest_profile_are_rejected` — 7.2.0 and 0.0.0 stay `None`.
- `unmodeled_newer_versions_generate_with_the_latest_profile` — end-to-end: `build()` with 12.0.0 returns blobs byte-identical to the 11.1 output, so the clamp reaches actual generation and is not just a mapping detail.

No fixture changes; the byte-for-byte differential fixtures are untouched.
