### PR TITLE
fix(kms): sync auth mock Bun lockfile

### DIFF
--- a/dstack/kms/auth-mock/bun.lock
+++ b/dstack/kms/auth-mock/bun.lock
@@ -6,7 +6,7 @@
       "name": "auth-mock",
       "dependencies": {
         "@hono/zod-validator": "0.2.2",
-        "hono": "4.12.27",
+        "hono": "4.12.34",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -169,7 +169,7 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 


### PR DESCRIPTION
## Summary

- update the auth-mock Bun lockfile to match the pinned Hono dependency
- restore reproducible frozen dependency installation

## Testing

- `bun install --frozen-lockfile`
- `bun run test:run` (12 tests passed)