### PR TITLE
feat(vmm): exec single-process launches in place

### DIFF
--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -6,7 +6,8 @@ use crate::{
     config::{Config, NetworkFilterMode, Networking, NetworkingMode, ProcessAnnotation, Protocol},
     logrotate,
     netd::{
-        self, InterfaceIdentity, PrepareMacvtapRequest, PrepareRequest, Request as NetdRequest,
+        self, InterfaceIdentity, PrepareBridgeRequest, PrepareMacvtapRequest,
+        Request as NetdRequest,
     },
 };
 
@@ -563,7 +564,7 @@ impl App {
                 nic_index,
             );
             let request = match network.mode {
-                NetworkingMode::Bridge => NetdRequest::Prepare(PrepareRequest {
+                NetworkingMode::Bridge => NetdRequest::PrepareBridge(PrepareBridgeRequest {
                     identity: identity.clone(),
                     bridge: network.bridge.clone(),
                     mac,

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -49,7 +49,7 @@ pub struct InterfaceIdentity {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PrepareRequest {
+pub struct PrepareBridgeRequest {
     #[serde(flatten)]
     pub identity: InterfaceIdentity,
     pub bridge: String,
@@ -73,7 +73,7 @@ pub struct PrepareMacvtapRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum Request {
-    Prepare(PrepareRequest),
+    PrepareBridge(PrepareBridgeRequest),
     PrepareMacvtap(PrepareMacvtapRequest),
     Remove {
         #[serde(flatten)]
@@ -121,7 +121,7 @@ pub struct PreparedInterface {
 
 pub async fn request(socket: &Path, request: &Request) -> Result<PreparedInterface> {
     let operation = match request {
-        Request::Prepare(_) => "prepare",
+        Request::PrepareBridge(_) => "prepare_bridge",
         Request::PrepareMacvtap(_) => "prepare_macvtap",
         Request::Remove { .. } => "remove",
         Request::Check { .. } => "check",
@@ -248,8 +248,8 @@ async fn read_request(stream: &mut UnixStream) -> Result<Request> {
 fn handle_request(libvirt_uri: &str, request: Request) -> Result<(String, Option<String>)> {
     let _lock = OperationLock::acquire()?;
     match request {
-        Request::Prepare(request) => {
-            prepare_interface(libvirt_uri, &request).map(|tap| (tap, None))
+        Request::PrepareBridge(request) => {
+            prepare_bridge(libvirt_uri, &request).map(|tap| (tap, None))
         }
         Request::PrepareMacvtap(request) => prepare_macvtap(
             libvirt_uri,
@@ -362,8 +362,8 @@ impl Drop for OperationLock {
     }
 }
 
-fn prepare_interface(libvirt_uri: &str, request: &PrepareRequest) -> Result<String> {
-    validate_prepare(request)?;
+fn prepare_bridge(libvirt_uri: &str, request: &PrepareBridgeRequest) -> Result<String> {
+    validate_prepare_bridge(request)?;
     let tap = tap_name(&request.identity);
     // A failed VMM start may leave a deterministic resource behind. Replacing
     // it makes prepare idempotent without accepting a caller-selected TAP.
@@ -430,7 +430,7 @@ fn delete_binding(uri: &str, tap: &str) -> Result<()> {
     bail!("virsh failed to delete binding {tap}: {}", error.trim())
 }
 
-fn binding_xml(request: &PrepareRequest, tap: &str) -> String {
+fn binding_xml(request: &PrepareBridgeRequest, tap: &str) -> String {
     let owner_uuid = stable_uuid(&request.identity);
     let owner_name = format!(
         "dstack:{}:{}:{}",
@@ -472,7 +472,7 @@ fn stable_uuid(identity: &InterfaceIdentity) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
-fn validate_prepare(request: &PrepareRequest) -> Result<()> {
+fn validate_prepare_bridge(request: &PrepareBridgeRequest) -> Result<()> {
     validate_identity(&request.identity)?;
     validate_name("bridge", &request.bridge, 15, "_.-")?;
     if !Path::new("/sys/class/net")
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn binding_xml_escapes_values() {
-        let request = PrepareRequest {
+        let request = PrepareBridgeRequest {
             identity: identity("instance<&", "vm", 0),
             bridge: "br0".into(),
             mac: "02:00:00:00:00:01".into(),
@@ -716,6 +716,23 @@ mod tests {
         assert_eq!(value["operation"], "prepare_macvtap");
         assert_eq!(value["instance_id"], "instance");
         assert_eq!(value["parent"], "eth0");
+        assert!(value.get("identity").is_none());
+    }
+
+    #[test]
+    fn bridge_prepare_has_a_dedicated_operation() {
+        let request = Request::PrepareBridge(PrepareBridgeRequest {
+            identity: identity("instance", "vm", 0),
+            bridge: "br0".into(),
+            mac: "02:00:00:00:00:01".into(),
+            qemu_uid: 1000,
+            filter: "clean-traffic".into(),
+            parameters: BTreeMap::new(),
+        });
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["operation"], "prepare_bridge");
+        assert_eq!(value["instance_id"], "instance");
+        assert_eq!(value["bridge"], "br0");
         assert!(value.get("identity").is_none());
     }
 

--- a/dstack/vmm/src/vm_launcher.rs
+++ b/dstack/vmm/src/vm_launcher.rs
@@ -71,12 +71,6 @@ impl Drop for SocketCleanup {
     }
 }
 
-impl LaunchSpec {
-    fn is_single_process(&self) -> bool {
-        self.swtpm.is_none()
-    }
-}
-
 struct PreparedOpenFiles {
     // Retain the original device handles through the fork or exec handoff;
     // they close automatically when this prepared set leaves scope.
@@ -120,7 +114,7 @@ fn prepare_open_files(open_files: &[OpenFile]) -> Result<PreparedOpenFiles> {
     })
 }
 
-fn prepare_exec(expected_parent: libc::pid_t, mappings: &[(i32, i32)]) -> std::io::Result<()> {
+fn prepare_child(expected_parent: libc::pid_t, mappings: &[(i32, i32)]) -> std::io::Result<()> {
     setpgid(Pid::from_raw(0), Pid::from_raw(0))?;
     prctl::set_pdeathsig(Signal::SIGKILL)?;
     if getppid().as_raw() != expected_parent {
@@ -153,21 +147,11 @@ fn spawn_child(spec: &ChildCommand, open_files: &[OpenFile]) -> Result<Child> {
     unsafe {
         command
             .as_std_mut()
-            .pre_exec(move || prepare_exec(parent, &mappings));
+            .pre_exec(move || prepare_child(parent, &mappings));
     }
     command
         .spawn()
         .with_context(|| format!("failed to start {}", spec.command))
-}
-
-fn exec_in_place(spec: &ChildCommand, open_files: &[OpenFile]) -> Result<()> {
-    let prepared = prepare_open_files(open_files)?;
-    let parent = getppid().as_raw();
-    prepare_exec(parent, &prepared.mappings).context("failed to prepare in-place QEMU exec")?;
-    let mut command = std::process::Command::new(&spec.command);
-    command.args(&spec.args);
-    let error = command.exec();
-    Err(error).with_context(|| format!("failed to exec {}", spec.command))
 }
 
 async fn stop_child(child: &mut Child, name: &str, grace: Duration) {
@@ -217,9 +201,6 @@ pub async fn run(spec_path: &Path) -> Result<()> {
     let raw = fs_err::read(spec_path)
         .with_context(|| format!("failed to read launch spec {}", spec_path.display()))?;
     let spec: LaunchSpec = serde_json::from_slice(&raw).context("failed to parse launch spec")?;
-    if spec.is_single_process() {
-        return exec_in_place(&spec.qemu, &spec.open_files);
-    }
     let _socket_cleanup = spec.swtpm_socket.clone().map(SocketCleanup);
     if let Some(socket) = &spec.swtpm_socket {
         if socket.exists() {
@@ -367,21 +348,6 @@ mod tests {
 
         assert_eq!(fs_err::read(output)?, b"macvtap-fd");
         Ok(())
-    }
-
-    #[test]
-    fn single_process_requires_no_swtpm() {
-        let mut spec = LaunchSpec {
-            qemu: shell("exit 0".into()),
-            swtpm: None,
-            swtpm_socket: None,
-            open_files: vec![],
-            startup_timeout_ms: 1_000,
-            shutdown_timeout_ms: 1_000,
-        };
-        assert!(spec.is_single_process());
-        spec.swtpm = Some(shell("exit 0".into()));
-        assert!(!spec.is_single_process());
     }
 
     #[tokio::test]

--- a/dstack/vmm/src/vm_launcher.rs
+++ b/dstack/vmm/src/vm_launcher.rs
@@ -71,6 +71,12 @@ impl Drop for SocketCleanup {
     }
 }
 
+impl LaunchSpec {
+    fn is_single_process(&self) -> bool {
+        self.swtpm.is_none()
+    }
+}
+
 struct PreparedOpenFiles {
     // Retain the original device handles through the fork or exec handoff;
     // they close automatically when this prepared set leaves scope.
@@ -114,7 +120,7 @@ fn prepare_open_files(open_files: &[OpenFile]) -> Result<PreparedOpenFiles> {
     })
 }
 
-fn prepare_child(expected_parent: libc::pid_t, mappings: &[(i32, i32)]) -> std::io::Result<()> {
+fn prepare_exec(expected_parent: libc::pid_t, mappings: &[(i32, i32)]) -> std::io::Result<()> {
     setpgid(Pid::from_raw(0), Pid::from_raw(0))?;
     prctl::set_pdeathsig(Signal::SIGKILL)?;
     if getppid().as_raw() != expected_parent {
@@ -147,11 +153,21 @@ fn spawn_child(spec: &ChildCommand, open_files: &[OpenFile]) -> Result<Child> {
     unsafe {
         command
             .as_std_mut()
-            .pre_exec(move || prepare_child(parent, &mappings));
+            .pre_exec(move || prepare_exec(parent, &mappings));
     }
     command
         .spawn()
         .with_context(|| format!("failed to start {}", spec.command))
+}
+
+fn exec_in_place(spec: &ChildCommand, open_files: &[OpenFile]) -> Result<()> {
+    let prepared = prepare_open_files(open_files)?;
+    let parent = getppid().as_raw();
+    prepare_exec(parent, &prepared.mappings).context("failed to prepare in-place QEMU exec")?;
+    let mut command = std::process::Command::new(&spec.command);
+    command.args(&spec.args);
+    let error = command.exec();
+    Err(error).with_context(|| format!("failed to exec {}", spec.command))
 }
 
 async fn stop_child(child: &mut Child, name: &str, grace: Duration) {
@@ -201,6 +217,9 @@ pub async fn run(spec_path: &Path) -> Result<()> {
     let raw = fs_err::read(spec_path)
         .with_context(|| format!("failed to read launch spec {}", spec_path.display()))?;
     let spec: LaunchSpec = serde_json::from_slice(&raw).context("failed to parse launch spec")?;
+    if spec.is_single_process() {
+        return exec_in_place(&spec.qemu, &spec.open_files);
+    }
     let _socket_cleanup = spec.swtpm_socket.clone().map(SocketCleanup);
     if let Some(socket) = &spec.swtpm_socket {
         if socket.exists() {
@@ -348,6 +367,21 @@ mod tests {
 
         assert_eq!(fs_err::read(output)?, b"macvtap-fd");
         Ok(())
+    }
+
+    #[test]
+    fn single_process_requires_no_swtpm() {
+        let mut spec = LaunchSpec {
+            qemu: shell("exit 0".into()),
+            swtpm: None,
+            swtpm_socket: None,
+            open_files: vec![],
+            startup_timeout_ms: 1_000,
+            shutdown_timeout_ms: 1_000,
+        };
+        assert!(spec.is_single_process());
+        spec.swtpm = Some(shell("exit 0".into()));
+        assert!(!spec.is_single_process());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add LaunchSpec::is_single_process to identify launches without swtpm
- install prepared file descriptors and exec QEMU in place for single-process launches
- keep the existing launcher orchestration path for QEMU plus swtpm

This keeps the process ID observed by Supervisor or systemd attached directly to QEMU and preserves the native QEMU exit status. Multi-process launches still need the launcher to coordinate startup, signals, shutdown, and cleanup.

## Stack

- based on #1061, which introduces the general launcher open-file path
- only the exec-in-place optimization is included in this PR

## Validation

- cargo clippy for dstack-vmm with all targets and warnings denied
- cargo test for dstack-vmm: 121 passed
