### PR TITLE
fix(vmm): restrict deployment network overrides

### DIFF
--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -7,6 +7,11 @@ allowing libvirt to create or launch the QEMU domain. QEMU remains entirely
 owned by `dstack-vmm`, so its command line and attestation inputs do not change
 outside the explicitly selected network backend.
 
+This integration applies only to bridge interfaces. It does not filter user,
+custom, or macvtap networking. In particular, macvtap bypasses the Linux
+bridge and requires policy enforcement in the physical network or a separate
+host mechanism.
+
 The measurable acceptance criteria are:
 
 - `network_filter = "none"` preserves the existing QEMU `-netdev bridge`
@@ -36,6 +41,23 @@ socket = "/run/dstack/netd.sock"
 allowed_uids = [] # empty means root only
 libvirt_uri = "qemu:///system"
 ```
+
+Deployment RPC network choices are separately constrained by node policy:
+
+```toml
+[cvm]
+allowed_network_modes = ["user", "bridge"]
+allowed_bridges = ["tenant-br0"]
+allowed_macvtap_parents = []
+```
+
+Macvtap is excluded from `allowed_network_modes` by default. Empty bridge and
+macvtap-parent allowlists prevent RPC callers from overriding the respective
+node defaults. If macvtap is explicitly enabled, callers may select only a
+parent in `allowed_macvtap_parents`; the macvtap forwarding mode always comes
+from `[cvm.networking].macvtap_mode` and cannot be selected through deployment
+RPCs. These allowlists authorize attachment targets; an nwfilter is not a
+substitute for that authorization.
 
 Each VMM instance also has an `instance_id`. It must be unique among VMMs that
 share a host. If omitted, the VMM derives a stable namespace from its absolute

--- a/docs/macvtap-networking.md
+++ b/docs/macvtap-networking.md
@@ -7,7 +7,7 @@ the unstable `/dev/tapN` device path.
 
 ## Configuration
 
-Configure a NIC through the manifest or VMM RPC:
+Configure a NIC through node configuration or an authorized VMM RPC request:
 
 ```json
 {
@@ -21,6 +21,22 @@ Configure a NIC through the manifest or VMM RPC:
 `private`, `bridge`, `vepa`, or `passthru`; an empty value selects `private`.
 The configured netd socket and caller allowlist apply in the same way as for
 libvirt-filtered bridge networking.
+
+Deployment RPC callers cannot select `macvtap_mode`; it is inherited from the
+node's `[cvm.networking]` configuration. Macvtap is also excluded from the
+default RPC policy. A node operator must explicitly enable it and enumerate
+the host interfaces callers may select:
+
+```toml
+[cvm]
+allowed_network_modes = ["user", "bridge", "macvtap"]
+allowed_macvtap_parents = ["eth0"]
+
+[cvm.networking]
+mode = "user"
+parent = "eth0"
+macvtap_mode = "private"
+```
 
 ## Lifecycle
 
@@ -48,7 +64,8 @@ identity or cleanup key.
 - The host and a macvtap guest do not communicate directly through the parent
   interface by default. Add a host macvlan/macvtap endpoint if that path is
   required.
-- Libvirt nwfilter bindings apply only to bridge mode. Macvtap deployments
+- Libvirt nwfilter bindings apply only to bridge mode and are never installed
+  for macvtap interfaces. Macvtap deployments
   must enforce network policy in the physical network or with another host
   mechanism.
 - Real-host testing requires `CAP_NET_ADMIN`, a working udev setup for

--- a/dstack/vmm/rpc/proto/vmm_rpc.proto
+++ b/dstack/vmm/rpc/proto/vmm_rpc.proto
@@ -132,7 +132,8 @@ message NetworkingConfig {
   string bridge_name = 2;
   // Parent host interface for macvtap mode.
   string parent = 3;
-  // macvtap forwarding mode. Empty selects "private".
+  // Effective macvtap forwarding mode in responses. Deployment requests must
+  // leave this empty because the mode is controlled by node configuration.
   string macvtap_mode = 4;
 }
 

--- a/dstack/vmm/src/app/network.rs
+++ b/dstack/vmm/src/app/network.rs
@@ -19,6 +19,9 @@ pub(crate) fn resolve_networking(networking: &Networking, cfg: &CvmConfig) -> Ne
     if !networking.bridge.is_empty() {
         resolved.bridge = networking.bridge.clone();
     }
+    if !networking.parent.is_empty() {
+        resolved.parent = networking.parent.clone();
+    }
     if !networking.mac_prefix.is_empty() {
         resolved.mac_prefix = networking.mac_prefix.clone();
     }

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -363,7 +363,23 @@ pub struct CvmConfig {
     /// Networking configuration
     pub networking: Networking,
 
-    /// Optional host-side filtering for bridge interfaces.
+    /// Network backends that deployment RPC callers may request explicitly.
+    /// The node default is still used when a request omits networking.
+    #[serde(default = "default_allowed_network_modes")]
+    pub allowed_network_modes: Vec<NetworkingMode>,
+
+    /// Host bridges that deployment RPC callers may select explicitly.
+    /// An empty list permits only the node's default bridge.
+    #[serde(default)]
+    pub allowed_bridges: Vec<String>,
+
+    /// Host interfaces that deployment RPC callers may select explicitly as
+    /// macvtap parents. An empty list permits only the node default parent.
+    #[serde(default)]
+    pub allowed_macvtap_parents: Vec<String>,
+
+    /// Optional host-side filtering for bridge interfaces. This filter does
+    /// not apply to macvtap interfaces.
     #[serde(default)]
     pub network_filter: NetworkFilterConfig,
 
@@ -681,6 +697,25 @@ impl Config {
 
         validate_networking(&self.cvm.networking)?;
         anyhow::ensure!(
+            !self
+                .cvm
+                .allowed_network_modes
+                .contains(&NetworkingMode::Custom),
+            "cvm.allowed_network_modes cannot contain custom"
+        );
+        for (name, values) in [
+            ("cvm.allowed_bridges", &self.cvm.allowed_bridges),
+            (
+                "cvm.allowed_macvtap_parents",
+                &self.cvm.allowed_macvtap_parents,
+            ),
+        ] {
+            anyhow::ensure!(
+                values.iter().all(|value| !value.trim().is_empty()),
+                "{name} cannot contain empty interface names"
+            );
+        }
+        anyhow::ensure!(
             !self.supervisor.sock.trim().is_empty(),
             "supervisor.sock must not be empty"
         );
@@ -799,6 +834,10 @@ fn validate_networking(networking: &Networking) -> Result<()> {
         NetworkingMode::User => {}
     }
     Ok(())
+}
+
+fn default_allowed_network_modes() -> Vec<NetworkingMode> {
+    vec![NetworkingMode::User, NetworkingMode::Bridge]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]

--- a/dstack/vmm/src/main_service.rs
+++ b/dstack/vmm/src/main_service.rs
@@ -349,7 +349,10 @@ fn resolve_volume_source(base: &Path, source: &str) -> Result<PathBuf> {
     Ok(real)
 }
 
-fn networking_from_proto(proto: &rpc::NetworkingConfig) -> Result<Option<Networking>> {
+fn networking_from_proto(
+    proto: &rpc::NetworkingConfig,
+    cvm_config: &CvmConfig,
+) -> Result<Option<Networking>> {
     let bridge = proto.bridge_name.trim().to_string();
     let mode = match proto.mode.as_str() {
         "bridge" => NetworkingMode::Bridge,
@@ -360,19 +363,34 @@ fn networking_from_proto(proto: &rpc::NetworkingConfig) -> Result<Option<Network
         "custom" => bail!("custom networking mode is manifest-only"),
         other => bail!("unsupported networking mode '{other}'"),
     };
+    if !cvm_config.allowed_network_modes.contains(&mode) {
+        bail!(
+            "networking mode '{}' is not allowed by node policy",
+            proto.mode
+        );
+    }
     if mode != NetworkingMode::Bridge && !bridge.is_empty() {
         bail!("bridge_name is only valid for bridge networking mode");
     }
-    if mode != NetworkingMode::Macvtap
-        && (!proto.parent.trim().is_empty() || !proto.macvtap_mode.trim().is_empty())
-    {
-        bail!("parent and macvtap_mode are only valid for macvtap networking mode");
+    if mode != NetworkingMode::Macvtap && !proto.parent.trim().is_empty() {
+        bail!("parent is only valid for macvtap networking mode");
+    }
+    if !proto.macvtap_mode.trim().is_empty() {
+        bail!("macvtap_mode is node-controlled and cannot be set by deployment RPCs");
+    }
+    if !bridge.is_empty() && !cvm_config.allowed_bridges.contains(&bridge) {
+        bail!("bridge_name '{bridge}' is not allowed by node policy");
+    }
+    let parent = proto.parent.trim().to_string();
+    if !parent.is_empty() && !cvm_config.allowed_macvtap_parents.contains(&parent) {
+        bail!("macvtap parent '{parent}' is not allowed by node policy");
     }
     Ok(Some(Networking {
         mode,
         bridge,
-        parent: proto.parent.trim().to_string(),
-        macvtap_mode: proto.macvtap_mode.trim().to_string(),
+        parent,
+        // The forwarding mode is always inherited from node configuration.
+        macvtap_mode: String::new(),
         device: String::new(),
         mac_prefix: String::new(),
         net: String::new(),
@@ -382,12 +400,21 @@ fn networking_from_proto(proto: &rpc::NetworkingConfig) -> Result<Option<Network
     }))
 }
 
-fn network_from_required_proto(proto: &rpc::NetworkingConfig) -> Result<Networking> {
-    networking_from_proto(proto)?.context("networking mode is required")
+fn network_from_required_proto(
+    proto: &rpc::NetworkingConfig,
+    cvm_config: &CvmConfig,
+) -> Result<Networking> {
+    networking_from_proto(proto, cvm_config)?.context("networking mode is required")
 }
 
-fn networks_from_proto(networks: &[rpc::NetworkingConfig]) -> Result<Vec<Networking>> {
-    networks.iter().map(network_from_required_proto).collect()
+fn networks_from_proto(
+    networks: &[rpc::NetworkingConfig],
+    cvm_config: &CvmConfig,
+) -> Result<Vec<Networking>> {
+    networks
+        .iter()
+        .map(|network| network_from_required_proto(network, cvm_config))
+        .collect()
 }
 
 fn validate_default_network(cvm_config: &CvmConfig) -> Result<()> {
@@ -420,10 +447,10 @@ fn networks_from_vm_config(
     cvm_config: &CvmConfig,
 ) -> Result<Vec<Networking>> {
     if !request.networks.is_empty() {
-        let networks = networks_from_proto(&request.networks)?;
+        let networks = networks_from_proto(&request.networks, cvm_config)?;
         resolve_requested_networks(&networks, cvm_config)
     } else if let Some(networking) = request.networking.as_ref() {
-        match networking_from_proto(networking)? {
+        match networking_from_proto(networking, cvm_config)? {
             Some(networking) => resolve_requested_networks(&[networking], cvm_config),
             None => Ok(vec![]),
         }
@@ -714,7 +741,7 @@ impl VmmRpc for RpcHandler {
                 validate_default_network(&self.app.config.cvm)?;
                 vec![]
             } else {
-                let networks = networks_from_proto(&request.networks)?;
+                let networks = networks_from_proto(&request.networks, &self.app.config.cvm)?;
                 resolve_requested_networks(&networks, &self.app.config.cvm)?
             };
             let is_running = self
@@ -1243,27 +1270,113 @@ mod tests {
     }
 
     #[test]
-    fn macvtap_networking_preserves_parent_and_mode() {
-        let networks = networks_from_proto(&[rpc::NetworkingConfig {
-            mode: "macvtap".to_string(),
-            parent: "eth0".to_string(),
-            macvtap_mode: "private".to_string(),
-            ..Default::default()
-        }])
+    fn authorized_macvtap_preserves_parent_and_inherits_forwarding_mode() {
+        let mut cvm_config = test_cvm_config();
+        cvm_config
+            .allowed_network_modes
+            .push(NetworkingMode::Macvtap);
+        cvm_config.allowed_macvtap_parents.push("eth0".to_string());
+        cvm_config.networking.parent = "node-default".to_string();
+        cvm_config.networking.macvtap_mode = "private".to_string();
+        let networks = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: "macvtap".to_string(),
+                parent: "eth0".to_string(),
+                ..Default::default()
+            }],
+            &cvm_config,
+        )
         .unwrap();
 
         assert_eq!(networks[0].mode, NetworkingMode::Macvtap);
         assert_eq!(networks[0].parent, "eth0");
-        assert_eq!(networks[0].macvtap_mode, "private");
+        assert!(networks[0].macvtap_mode.is_empty());
+
+        let resolved = resolve_requested_networks(&networks, &cvm_config).unwrap();
+        assert_eq!(resolved[0].parent, "eth0");
+        assert_eq!(resolved[0].macvtap_mode, "private");
+    }
+
+    #[test]
+    fn macvtap_is_denied_by_default_rpc_policy() {
+        let err = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: "macvtap".to_string(),
+                ..Default::default()
+            }],
+            &test_cvm_config(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("not allowed by node policy"));
+    }
+
+    #[test]
+    fn bridge_override_requires_allowlist_entry() {
+        let request = [rpc::NetworkingConfig {
+            mode: "bridge".to_string(),
+            bridge_name: "tenant-br0".to_string(),
+            ..Default::default()
+        }];
+        let mut cvm_config = test_cvm_config();
+
+        let err = networks_from_proto(&request, &cvm_config).unwrap_err();
+        assert!(err.to_string().contains("bridge_name 'tenant-br0'"));
+
+        cvm_config.allowed_bridges.push("tenant-br0".to_string());
+        let networks = networks_from_proto(&request, &cvm_config).unwrap();
+        assert_eq!(networks[0].bridge, "tenant-br0");
+    }
+
+    #[test]
+    fn macvtap_parent_requires_allowlist_entry() {
+        let request = [rpc::NetworkingConfig {
+            mode: "macvtap".to_string(),
+            parent: "eth1".to_string(),
+            ..Default::default()
+        }];
+        let mut cvm_config = test_cvm_config();
+        cvm_config
+            .allowed_network_modes
+            .push(NetworkingMode::Macvtap);
+
+        let err = networks_from_proto(&request, &cvm_config).unwrap_err();
+        assert!(err.to_string().contains("macvtap parent 'eth1'"));
+
+        cvm_config.allowed_macvtap_parents.push("eth1".to_string());
+        let networks = networks_from_proto(&request, &cvm_config).unwrap();
+        assert_eq!(networks[0].parent, "eth1");
+    }
+
+    #[test]
+    fn deployment_rpc_cannot_select_macvtap_forwarding_mode() {
+        let mut cvm_config = test_cvm_config();
+        cvm_config
+            .allowed_network_modes
+            .push(NetworkingMode::Macvtap);
+        let err = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: "macvtap".to_string(),
+                macvtap_mode: "passthru".to_string(),
+                ..Default::default()
+            }],
+            &cvm_config,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("node-controlled"));
     }
 
     #[test]
     fn bridge_name_is_rejected_for_user_mode() {
-        let err = networks_from_proto(&[rpc::NetworkingConfig {
-            mode: "user".to_string(),
-            bridge_name: "dstack-br0".to_string(),
-            ..Default::default()
-        }])
+        let err = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: "user".to_string(),
+                bridge_name: "dstack-br0".to_string(),
+                ..Default::default()
+            }],
+            &test_cvm_config(),
+        )
         .unwrap_err();
 
         assert!(err.to_string().contains("bridge_name is only valid"));
@@ -1271,11 +1384,14 @@ mod tests {
 
     #[test]
     fn repeated_networks_rejects_empty_entries() {
-        let err = networks_from_proto(&[rpc::NetworkingConfig {
-            mode: String::new(),
-            bridge_name: String::new(),
-            ..Default::default()
-        }])
+        let err = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: String::new(),
+                bridge_name: String::new(),
+                ..Default::default()
+            }],
+            &test_cvm_config(),
+        )
         .unwrap_err();
 
         assert!(err.to_string().contains("networking mode is required"));
@@ -1283,11 +1399,14 @@ mod tests {
 
     #[test]
     fn repeated_networks_rejects_custom_entries() {
-        let err = networks_from_proto(&[rpc::NetworkingConfig {
-            mode: "custom".to_string(),
-            bridge_name: String::new(),
-            ..Default::default()
-        }])
+        let err = networks_from_proto(
+            &[rpc::NetworkingConfig {
+                mode: "custom".to_string(),
+                bridge_name: String::new(),
+                ..Default::default()
+            }],
+            &test_cvm_config(),
+        )
         .unwrap_err();
 
         assert!(err.to_string().contains("custom networking mode"));

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -46,6 +46,12 @@ qmp_socket = false
 # Unique namespace when multiple dstack-vmm instances share one host. When
 # empty, a stable value is derived from run_path.
 instance_id = ""
+# Network choices that deployment RPC callers may make. Macvtap is excluded
+# by default because libvirt nwfilter applies only to bridge interfaces.
+allowed_network_modes = ["user", "bridge"]
+# Empty allowlists mean callers can only use the node networking defaults.
+allowed_bridges = []
+allowed_macvtap_parents = []
 use_mrconfigid = true
 
 # QEMU flags
@@ -111,8 +117,9 @@ restrict = false
 # for mode = "bridge"
 # bridge = "virbr0"
 
-# Optional filtering for bridge interfaces. "none" preserves the existing
-# QEMU bridge-helper behavior and has no netd/libvirt dependency.
+# Optional filtering for bridge interfaces only. It does not apply to macvtap.
+# "none" preserves the existing QEMU bridge-helper behavior and has no
+# netd/libvirt dependency.
 [cvm.network_filter]
 mode = "none"
 filter = "clean-traffic"


### PR DESCRIPTION
## Summary

- add node policies for RPC-selectable network modes, bridges, and macvtap parents
- deny macvtap RPC requests by default and keep macvtap forwarding mode node-controlled
- document that libvirt nwfilter applies only to bridge interfaces

## Security behavior

- `allowed_network_modes` defaults to `user` and `bridge`
- empty `allowed_bridges` and `allowed_macvtap_parents` prevent callers from overriding node defaults
- RPC requests with a non-empty `macvtap_mode` are rejected
- explicitly authorized macvtap parents are preserved while the forwarding mode is inherited from node configuration

## Testing

- `cargo test -p dstack-vmm --no-fail-fast`
- `cargo clippy -p dstack-vmm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
