### PR TITLE
feat(vmm): support secure netd socket activation

### DIFF
--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -34,7 +34,6 @@ parameters = {}
 [netd]
 socket = "/run/dstack/netd.sock"
 socket_mode = 0o660 # used when netd binds the socket itself
-allowed_uids = [] # empty means root only
 libvirt_uri = "qemu:///system"
 ```
 
@@ -45,15 +44,15 @@ run directory.
 ## Architecture
 
 `netd` is a host-level privilege broker. It accepts a small, bounded JSON
-protocol over a Unix stream socket and authorizes clients with `SO_PEERCRED`.
-A single process can serve multiple VMMs; a dedicated process can use another
-socket for development or isolation.
+protocol over a Unix stream socket. The socket's filesystem owner, group, and
+mode are the authorization boundary: every process that can connect is fully
+trusted to use the netd protocol. A single process can serve multiple VMMs; a
+dedicated process can use another socket for development or isolation.
 
-When netd creates the socket itself, `socket_mode` defaults to `0o660`.
-Filesystem permissions provide the first access-control layer, while
-`SO_PEERCRED` and `allowed_uids` remain mandatory authorization checks. Ensure
+When netd creates the socket itself, `socket_mode` defaults to `0o660`. Ensure
 that each authorized VMM process can reach the socket through its owning group
-or another deliberately configured ownership arrangement.
+or another deliberately configured ownership arrangement. Never make the
+socket accessible to an untrusted local user.
 
 For libvirt mode, startup is:
 
@@ -67,11 +66,10 @@ Teardown stops QEMU first, removes the binding, and deletes the TAP. Operations
 are serialized by `netd`. The design intentionally does not add ownership
 aliases; deployments must use unique instance IDs.
 
-Every UID listed in `allowed_uids` is mutually trusted for network operations:
-the protocol does not pin an UID to an instance namespace, so any allowed UID
-can prepare, check, or remove any deterministic identity. Deploy VMM instances
-that do not share this trust boundary with dedicated netd sockets and distinct
-allowlists.
+The protocol does not pin a client to an instance namespace, so any process
+with socket access can prepare, check, or remove any deterministic identity.
+Deploy VMM instances that do not share this trust boundary with dedicated netd
+sockets and distinct filesystem permissions.
 
 `netd` invokes fixed absolute `ip` and `virsh` executables with separate
 arguments. It never accepts a command, executable path, TAP name, or raw XML
@@ -89,7 +87,6 @@ VMM instance:
 [netd]
 socket = "/run/dstack/netd.sock"
 socket_mode = 0o660
-allowed_uids = [991, 992]
 libvirt_uri = "qemu:///system"
 ```
 
@@ -138,8 +135,8 @@ Development mode is two ordinary commands:
 
 ```bash
 sudo dstack-vmm --config ./vmm.toml netd \
-  --socket /run/dstack-dev/netd.sock --allow-uid "$(id -u)"
-dstack-vmm --config ./vmm.toml \
+  --socket /run/dstack-dev/netd.sock
+sudo dstack-vmm --config ./vmm.toml \
   --netd-socket /run/dstack-dev/netd.sock
 ```
 

--- a/docs/libvirt-network-filter.md
+++ b/docs/libvirt-network-filter.md
@@ -33,6 +33,7 @@ parameters = {}
 
 [netd]
 socket = "/run/dstack/netd.sock"
+socket_mode = 0o660 # used when netd binds the socket itself
 allowed_uids = [] # empty means root only
 libvirt_uri = "qemu:///system"
 ```
@@ -47,6 +48,12 @@ run directory.
 protocol over a Unix stream socket and authorizes clients with `SO_PEERCRED`.
 A single process can serve multiple VMMs; a dedicated process can use another
 socket for development or isolation.
+
+When netd creates the socket itself, `socket_mode` defaults to `0o660`.
+Filesystem permissions provide the first access-control layer, while
+`SO_PEERCRED` and `allowed_uids` remain mandatory authorization checks. Ensure
+that each authorized VMM process can reach the socket through its owning group
+or another deliberately configured ownership arrangement.
 
 For libvirt mode, startup is:
 
@@ -81,8 +88,29 @@ VMM instance:
 # /etc/dstack/netd.toml
 [netd]
 socket = "/run/dstack/netd.sock"
+socket_mode = 0o660
 allowed_uids = [991, 992]
 libvirt_uri = "qemu:///system"
+```
+
+Production deployments can use systemd socket activation. The socket unit
+owns the filesystem mode and ownership; `netd.socket_mode` applies only to the
+standalone bind path.
+
+```ini
+# /etc/systemd/system/dstack-netd.socket
+[Unit]
+Description=dstack host networking socket
+
+[Socket]
+ListenStream=/run/dstack/netd.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=dstack-vmm
+RemoveOnStop=true
+
+[Install]
+WantedBy=sockets.target
 ```
 
 ```ini
@@ -94,10 +122,12 @@ After=libvirtd.service
 [Service]
 ExecStart=/usr/bin/dstack-vmm --config /etc/dstack/netd.toml netd
 Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
 ```
+
+The service accepts exactly one Unix stream listener through the systemd
+`LISTEN_FDS` protocol. With no activated descriptor it falls back to binding
+`netd.socket` itself. More than one descriptor, or a descriptor of the wrong
+socket type, is rejected.
 
 All VMM instance configurations point to the same socket and use distinct
 `cvm.instance_id` values. A dedicated netd uses a different socket. A

--- a/docs/macvtap-networking.md
+++ b/docs/macvtap-networking.md
@@ -19,7 +19,7 @@ Configure a NIC through the manifest or VMM RPC:
 
 `parent` must name an existing host interface. `macvtap_mode` may be
 `private`, `bridge`, `vepa`, or `passthru`; an empty value selects `private`.
-The configured netd socket and caller allowlist apply in the same way as for
+The configured netd socket permissions apply in the same way as for
 libvirt-filtered bridge networking.
 
 ## Lifecycle

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2327,6 +2327,7 @@ dependencies = [
  "insta",
  "key-provider-client",
  "libc",
+ "listenfd",
  "load_config",
  "lspci",
  "mock-attestation",

--- a/dstack/vmm/Cargo.toml
+++ b/dstack/vmm/Cargo.toml
@@ -64,6 +64,7 @@ flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 wait-timeout.workspace = true
+listenfd.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -588,6 +588,9 @@ fn default_libvirt_filter() -> String {
 pub struct NetdConfig {
     #[serde(default = "default_netd_socket")]
     pub socket: PathBuf,
+    /// Filesystem permissions applied when netd creates its own socket.
+    /// Systemd-activated sockets use `SocketMode` from the socket unit.
+    pub socket_mode: u32,
     #[serde(default)]
     pub allowed_uids: Vec<u32>,
     #[serde(default = "default_libvirt_uri")]
@@ -598,9 +601,20 @@ impl Default for NetdConfig {
     fn default() -> Self {
         Self {
             socket: default_netd_socket(),
+            socket_mode: 0o660,
             allowed_uids: Vec::new(),
             libvirt_uri: default_libvirt_uri(),
         }
+    }
+}
+
+impl NetdConfig {
+    pub fn validate(&self) -> Result<()> {
+        anyhow::ensure!(
+            self.socket_mode & !0o777 == 0,
+            "netd.socket_mode must contain only Unix permission bits"
+        );
+        Ok(())
     }
 }
 
@@ -649,6 +663,8 @@ impl Config {
         self.host_api
             .validate()
             .context("Invalid host_api configuration")?;
+
+        self.netd.validate()?;
 
         anyhow::ensure!(self.cvm.cid_start >= 3, "cvm.cid_start must be at least 3");
         anyhow::ensure!(
@@ -1142,11 +1158,21 @@ mod tests {
 
     #[test]
     fn config_validation_accepts_defaults() {
-        default_config().validate().unwrap();
+        let config = default_config();
+        assert_eq!(config.netd.socket_mode, 0o660);
+        config.validate().unwrap();
     }
 
     #[test]
     fn config_validation_rejects_invalid_static_invariants() {
+        let mut config = default_config();
+        config.netd.socket_mode = 0o1660;
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("socket_mode"));
+
         let mut config = default_config();
         config.cvm.cid_pool_size = 0;
         assert!(config

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -591,8 +591,6 @@ pub struct NetdConfig {
     /// Filesystem permissions applied when netd creates its own socket.
     /// Systemd-activated sockets use `SocketMode` from the socket unit.
     pub socket_mode: u32,
-    #[serde(default)]
-    pub allowed_uids: Vec<u32>,
     #[serde(default = "default_libvirt_uri")]
     pub libvirt_uri: String,
 }
@@ -602,7 +600,6 @@ impl Default for NetdConfig {
         Self {
             socket: default_netd_socket(),
             socket_mode: 0o660,
-            allowed_uids: Vec::new(),
             libvirt_uri: default_libvirt_uri(),
         }
     }

--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -77,9 +77,6 @@ struct NetdArgs {
     /// Override the Unix socket configured in [netd].
     #[arg(long)]
     socket: Option<String>,
-    /// Authorize an additional client UID. May be repeated.
-    #[arg(long = "allow-uid")]
-    allow_uids: Vec<u32>,
 }
 
 #[derive(ClapArgs)]
@@ -222,11 +219,6 @@ async fn main() -> Result<()> {
         if let Some(socket) = netd_args.socket.as_deref() {
             netd_config.socket = socket.into();
         }
-        netd_config
-            .allowed_uids
-            .extend(netd_args.allow_uids.iter().copied());
-        netd_config.allowed_uids.sort_unstable();
-        netd_config.allowed_uids.dedup();
         return netd::serve(netd_config).await;
     }
 

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use listenfd::ListenFd;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::{
@@ -169,19 +170,14 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
     if !nix::unistd::Uid::effective().is_root() {
         bail!("netd must run as root");
     }
+    config.validate()?;
     require_executable(IP_PATH)?;
     require_executable(VIRSH_PATH)?;
-    let listener = {
-        let _lock = OperationLock::acquire()?;
-        prepare_socket_path(&config.socket)?;
-        UnixListener::bind(&config.socket)
-            .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?
+    let listener = match activated_listener()? {
+        Some(listener) => listener,
+        None => bind_listener(&config)?,
     };
-    // Access control is based on SO_PEERCRED rather than filesystem groups so
-    // one shared service can authorize VMM instances running under different
-    // UIDs and development mode needs no system group setup.
-    std::fs::set_permissions(&config.socket, Permissions::from_mode(0o666))?;
-    info!(socket = %config.socket.display(), "netd listening");
+    info!(address = ?listener.local_addr()?, "netd listening");
     loop {
         let (mut stream, _) = listener.accept().await?;
         // This timeout bounds async socket reads and writes. handle_request is
@@ -193,6 +189,37 @@ pub async fn serve(config: NetdConfig) -> Result<()> {
             Err(_) => warn!("netd connection timed out"),
         }
     }
+}
+
+fn activated_listener() -> Result<Option<UnixListener>> {
+    let mut listenfd = ListenFd::from_env();
+    if listenfd.len() == 0 {
+        return Ok(None);
+    }
+    if listenfd.len() != 1 {
+        bail!(
+            "netd requires exactly one systemd-activated socket, received {}",
+            listenfd.len()
+        );
+    }
+    let listener = listenfd
+        .take_unix_listener(0)
+        .context("systemd fd 0 is not a Unix stream listener")?
+        .context("systemd did not provide fd 0")?;
+    listener.set_nonblocking(true)?;
+    info!("using systemd-activated socket");
+    Ok(Some(UnixListener::from_std(listener)?))
+}
+
+fn bind_listener(config: &NetdConfig) -> Result<UnixListener> {
+    let listener = {
+        let _lock = OperationLock::acquire()?;
+        prepare_socket_path(&config.socket)?;
+        UnixListener::bind(&config.socket)
+            .with_context(|| format!("failed to bind netd socket {}", config.socket.display()))?
+    };
+    std::fs::set_permissions(&config.socket, Permissions::from_mode(config.socket_mode))?;
+    Ok(listener)
 }
 
 async fn serve_connection(config: &NetdConfig, stream: &mut UnixStream) -> Result<()> {

--- a/dstack/vmm/src/netd.rs
+++ b/dstack/vmm/src/netd.rs
@@ -223,36 +223,26 @@ fn bind_listener(config: &NetdConfig) -> Result<UnixListener> {
 }
 
 async fn serve_connection(config: &NetdConfig, stream: &mut UnixStream) -> Result<()> {
-    let uid = peer_uid(stream)?;
-    let allowed = uid == 0 || config.allowed_uids.contains(&uid);
-    let response = if allowed {
-        match read_request(stream)
-            .await
-            .and_then(|request| handle_request(&config.libvirt_uri, request))
-        {
-            Ok((tap, device)) => Response {
-                ok: true,
-                tap: Some(tap),
-                device,
-                error: None,
-            },
-            Err(error) => {
-                warn!(%uid, %error, "netd request failed");
-                Response {
-                    ok: false,
-                    tap: None,
-                    device: None,
-                    error: Some(format!("{error:#}")),
-                }
+    // Access is authorized by the Unix socket's owner, group, and mode. Any
+    // process that can connect is trusted with the complete netd protocol.
+    let response = match read_request(stream)
+        .await
+        .and_then(|request| handle_request(&config.libvirt_uri, request))
+    {
+        Ok((tap, device)) => Response {
+            ok: true,
+            tap: Some(tap),
+            device,
+            error: None,
+        },
+        Err(error) => {
+            warn!(%error, "netd request failed");
+            Response {
+                ok: false,
+                tap: None,
+                device: None,
+                error: Some(format!("{error:#}")),
             }
-        }
-    } else {
-        warn!(%uid, "rejected unauthorized netd client");
-        Response {
-            ok: false,
-            tap: None,
-            device: None,
-            error: Some("caller UID is not authorized".into()),
         }
     };
     let encoded = serde_json::to_vec(&response)?;
@@ -653,30 +643,6 @@ fn prepare_socket_path(socket: &Path) -> Result<()> {
             .with_context(|| format!("failed to remove stale socket {}", socket.display()))?;
     }
     Ok(())
-}
-
-fn peer_uid(stream: &UnixStream) -> Result<u32> {
-    let mut credentials = libc::ucred {
-        pid: 0,
-        uid: 0,
-        gid: 0,
-    };
-    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-    // SAFETY: credentials and length point to valid writable storage of the
-    // exact size passed to getsockopt, and the stream owns a valid socket FD.
-    let result = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_PEERCRED,
-            (&mut credentials as *mut libc::ucred).cast(),
-            &mut length,
-        )
-    };
-    if result != 0 {
-        return Err(std::io::Error::last_os_error()).context("failed to read peer credentials");
-    }
-    Ok(credentials.uid)
 }
 
 #[cfg(test)]

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -122,6 +122,9 @@ parameters = {}
 # "libvirt". An empty allowed_uids list permits root only.
 [netd]
 socket = "/run/dstack/netd.sock"
+# Applied when netd creates the socket itself. A systemd socket unit controls
+# its own SocketMode instead.
+socket_mode = 0o660
 allowed_uids = []
 libvirt_uri = "qemu:///system"
 

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -119,13 +119,12 @@ filter = "clean-traffic"
 parameters = {}
 
 # Shared privileged networking service. Only used when network_filter.mode is
-# "libvirt". An empty allowed_uids list permits root only.
+# "libvirt". Socket filesystem permissions authorize clients.
 [netd]
 socket = "/run/dstack/netd.sock"
 # Applied when netd creates the socket itself. A systemd socket unit controls
 # its own SocketMode instead.
 socket_mode = 0o660
-allowed_uids = []
 libvirt_uri = "qemu:///system"
 
 [cvm.port_mapping]


### PR DESCRIPTION
## Summary

- change self-bound netd sockets from world-writable to configurable `socket_mode = 0o660`
- accept exactly one systemd-activated Unix stream listener through `LISTEN_FDS`
- use Unix socket owner/group/mode as the sole client authorization boundary
- remove `allowed_uids`, `SO_PEERCRED` authorization, and `--allow-uid`
- document systemd socket/service units and the resulting trust boundary

The default is defined in `vmm.toml`; the Rust field does not add a second serde default.

## Behavior

- standalone: netd binds `[netd].socket` and applies `[netd].socket_mode`
- socket activated: systemd owns socket mode/user/group and netd consumes fd 0
- zero activated descriptors falls back to standalone mode
- multiple descriptors or a non-Unix-stream descriptor fail closed
- every process able to connect to the socket is fully trusted with the netd protocol

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p dstack-vmm --no-fail-fast` (124 passed)
- `cargo clippy -p dstack-vmm --all-targets -- -D warnings`
- real systemd activation test with a temporary `.socket`/`.service` pair:
  - systemd created the socket as mode `0660`
  - an unprivileged group member triggered service activation
  - netd consumed the activated Unix listener and returned a protocol error response
  - temporary units, socket, and config were removed after the test
