### PR TITLE
feat(os): record image builder provenance

### DIFF
--- a/os/image/assemble.sh
+++ b/os/image/assemble.sh
@@ -456,6 +456,7 @@ cat <<EOF > "${OUTPUT_DIR}/metadata.json"
     "rootfs": "rootfs.img.parted.verity",
     "version": "$DSTACK_VERSION",
     "git_revision": "$GIT_REVISION",
+    "builder": "$BACKEND",
     "shared_ro": true,
     "is_dev": ${IS_DEV},
     "ovmf_variant": "$OVMF_VARIANT"

--- a/os/mkosi/tests/check-output.sh
+++ b/os/mkosi/tests/check-output.sh
@@ -12,8 +12,9 @@ grep -q 'dstack-rootfs' < <(sgdisk -p "$out/rootfs.img.parted.verity")
 python3 - "$out/metadata.json" "$flavor" <<'PY'
 import json,sys
 d=json.load(open(sys.argv[1]))
-for k in ("bios","bios-sev","kernel","cmdline","initrd","rootfs","version","git_revision","is_dev","ovmf_variant"):
+for k in ("bios","bios-sev","kernel","cmdline","initrd","rootfs","version","git_revision","builder","is_dev","ovmf_variant"):
     assert k in d, k
+assert d["builder"] == "mkosi"
 assert d["bios-sev"] == "ovmf-sev.fd"
 assert d["is_dev"] == (sys.argv[2] == "dev")
 PY


### PR DESCRIPTION
## Summary
- record the selected image builder in assembled `metadata.json`
- require mkosi output metadata to identify the `mkosi` builder

This makes artifacts produced by different builders distinguishable even when their release filenames are identical.

## Testing
- `bash -n os/image/assemble.sh os/mkosi/tests/check-output.sh`
- `shellcheck os/image/assemble.sh os/mkosi/tests/check-output.sh`
- `git diff --check`