### PR TITLE
test: add source-local component coverage and fixtures

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -795,12 +795,15 @@ name = "cert-client"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "dstack-guest-agent-rpc",
  "dstack-kms-rpc",
  "dstack-types",
+ "http-client",
  "ra-rpc",
  "ra-tls",
  "serde_json",
  "tdx-attest",
+ "tokio",
 ]
 
 [[package]]
@@ -822,6 +825,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "time",
  "tokio",
  "tracing",
@@ -2283,6 +2287,7 @@ dependencies = [
  "hex-literal",
  "nsm-attest",
  "ra-tls",
+ "rcgen",
  "reqwest",
  "rocket",
  "serde",

--- a/dstack/cert-client/Cargo.toml
+++ b/dstack/cert-client/Cargo.toml
@@ -17,3 +17,6 @@ ra-rpc = { workspace = true, features = ["client"] }
 ra-tls = { workspace = true, features = ["quote"] }
 serde_json.workspace = true
 tdx-attest.workspace = true
+dstack-guest-agent-rpc.workspace = true
+http-client = { workspace = true, features = ["prpc"] }
+tokio.workspace = true

--- a/dstack/cert-client/src/bin/dstack-kms-sign-cert-fixture.rs
+++ b/dstack/cert-client/src/bin/dstack-kms-sign-cert-fixture.rs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: © 2026 Phala Network <dstack@phala.network>
 // SPDX-License-Identifier: Apache-2.0
 //! Generate a v2 KMS CSR whose key is bound to fresh guest attestation.
 

--- a/dstack/cert-client/src/bin/dstack-kms-sign-cert-fixture.rs
+++ b/dstack/cert-client/src/bin/dstack-kms-sign-cert-fixture.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Generate a v2 KMS CSR whose key is bound to fresh guest attestation.
+
+use anyhow::{Context, Result};
+use dstack_guest_agent_rpc::{dstack_guest_client::DstackGuestClient, RawQuoteArgs};
+use http_client::prpc::PrpcClient;
+use ra_tls::{
+    attestation::{PlatformEvidence, QuoteContentType, VersionedAttestation},
+    cert::{CertConfig, CertConfigV2, CertSigningRequestV1, CertSigningRequestV2, Csr},
+    rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256},
+};
+use serde_json::json;
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .context("failed to generate the case-scoped certificate key")?;
+    let pubkey = key.public_key_der();
+    let report_data = QuoteContentType::RaTlsCert.to_report_data(&pubkey);
+    let address = dstack_types::dstack_agent_address();
+    let client = DstackGuestClient::new(PrpcClient::new(address));
+    let response = client
+        .attest(RawQuoteArgs {
+            report_data: report_data.to_vec(),
+        })
+        .await
+        .context("failed to obtain key-bound guest attestation")?;
+    let attestation = VersionedAttestation::from_bytes(&response.attestation)
+        .context("failed to decode key-bound guest attestation")?;
+    let csr = CertSigningRequestV2 {
+        confirm: "please sign cert:".to_string(),
+        pubkey: pubkey.clone(),
+        config: CertConfigV2 {
+            org_name: Some("Dstack Test".to_string()),
+            subject: "kms-sign-cert.test".to_string(),
+            subject_alt_names: vec!["kms-sign-cert.test".to_string()],
+            usage_server_auth: true,
+            usage_client_auth: true,
+            ext_quote: true,
+            ext_app_info: true,
+            not_before: None,
+            not_after: None,
+        },
+        attestation: attestation.clone(),
+    };
+    let signature = csr.signed_by(&key).context("failed to sign the v2 CSR")?;
+    let (quote, event_log) = match attestation.clone().into_v1().platform {
+        PlatformEvidence::Tdx { quote, event_log } => (quote, event_log),
+        _ => anyhow::bail!("legacy v1 CSR fixture requires TDX evidence"),
+    };
+    let csr_v1 = CertSigningRequestV1 {
+        confirm: "please sign cert:".to_string(),
+        pubkey: pubkey.clone(),
+        config: CertConfig {
+            org_name: Some("Dstack Test".to_string()),
+            subject: "kms-sign-cert.test".to_string(),
+            subject_alt_names: vec!["kms-sign-cert.test".to_string()],
+            usage_server_auth: true,
+            usage_client_auth: true,
+            ext_quote: true,
+        },
+        quote,
+        event_log: serde_json::to_vec(&event_log)
+            .context("failed to encode the legacy TDX event log")?,
+    };
+    let signature_v1 = csr_v1
+        .signed_by(&key)
+        .context("failed to sign the v1 CSR")?;
+    println!(
+        "{}",
+        json!({
+            "api_version": 2,
+            "csr": hex(&csr.to_vec()),
+            "signature": hex(&signature),
+            "csr_v1": hex(&csr_v1.data_to_sign()),
+            "signature_v1": hex(&signature_v1),
+            "public_key": hex(&pubkey),
+            "subject": "kms-sign-cert.test",
+            "alt_name": "kms-sign-cert.test"
+        })
+    );
+    Ok(())
+}

--- a/dstack/certbot/Cargo.toml
+++ b/dstack/certbot/Cargo.toml
@@ -31,5 +31,6 @@ x509-parser.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true

--- a/dstack/certbot/src/workdir.rs
+++ b/dstack/certbot/src/workdir.rs
@@ -65,3 +65,50 @@ impl WorkDir {
         crate::bot::list_cert_public_keys(self.backup_dir())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn live_links_can_roll_back_to_a_complete_generation() {
+        let root = tempfile::tempdir().unwrap();
+        let workdir = WorkDir::new(root.path());
+        let first = workdir.backup_dir().join("0001");
+        let second = workdir.backup_dir().join("0002");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+        fs::write(first.join("cert.pem"), "first-cert").unwrap();
+        fs::write(first.join("key.pem"), "first-key").unwrap();
+        fs::write(second.join("cert.pem"), "second-cert").unwrap();
+        fs::write(second.join("key.pem"), "second-key").unwrap();
+        fs::create_dir_all(workdir.live_dir()).unwrap();
+        symlink(second.join("cert.pem"), workdir.cert_path()).unwrap();
+        symlink(second.join("key.pem"), workdir.key_path()).unwrap();
+        fs::remove_file(workdir.cert_path()).unwrap();
+        fs::remove_file(workdir.key_path()).unwrap();
+        symlink(first.join("cert.pem"), workdir.cert_path()).unwrap();
+        symlink(first.join("key.pem"), workdir.key_path()).unwrap();
+        assert_eq!(
+            fs::read_to_string(workdir.cert_path()).unwrap(),
+            "first-cert"
+        );
+        assert_eq!(fs::read_to_string(workdir.key_path()).unwrap(), "first-key");
+    }
+
+    #[test]
+    fn malformed_credentials_fail_without_mutating_the_archive() {
+        let root = tempfile::tempdir().unwrap();
+        let workdir = WorkDir::new(root.path());
+        let archive = workdir.backup_dir().join("0001");
+        fs::create_dir_all(&archive).unwrap();
+        fs::write(archive.join("cert.pem"), "stable").unwrap();
+        fs::write(workdir.account_credentials_path(), "not-json").unwrap();
+        assert!(workdir.acme_account_uri().is_err());
+        assert_eq!(
+            fs::read_to_string(archive.join("cert.pem")).unwrap(),
+            "stable"
+        );
+    }
+}

--- a/dstack/crates/mock-attestation/src/server.rs
+++ b/dstack/crates/mock-attestation/src/server.rs
@@ -287,6 +287,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tdx_quote_collateral_and_tcb_matrix() {
+        let state = Arc::new(MockCollateralState::new().unwrap());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://{addr}");
+        let mut task = tokio::spawn(serve_listener(listener, state.clone()));
+        let evidence = state.tdx.attest([0x42; 64]).unwrap();
+        let client = dcap_qvl::collateral::CollateralClient::with_default_http(&base).unwrap();
+        let current = client.fetch(&evidence.quote).await.unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let verifier = dcap_qvl::verify::QuoteVerifier::new(state.tdx.root_ca_der());
+        assert_eq!(
+            verifier
+                .verify(&evidence.quote, &current, now)
+                .unwrap()
+                .status,
+            "UpToDate"
+        );
+
+        let mut tampered_quote = evidence.quote.clone();
+        tampered_quote[200] ^= 1;
+        assert!(verifier.verify(&tampered_quote, &current, now).is_err());
+
+        task.abort();
+        let _ = task.await;
+        assert!(verifier.verify(&evidence.quote, &current, now).is_ok());
+        assert!(client.fetch(&evidence.quote).await.is_err());
+
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        task = tokio::spawn(serve_listener(listener, state.clone()));
+        let recovered = client.fetch(&evidence.quote).await.unwrap();
+        assert!(verifier.verify(&evidence.quote, &recovered, now).is_ok());
+
+        let mut outdated = state
+            .tdx
+            .sample_collateral_with_tcb_status("OutOfDate")
+            .unwrap();
+        outdated.pck_certificate_chain = recovered.pck_certificate_chain.clone();
+        assert_eq!(
+            verifier
+                .verify(&evidence.quote, &outdated, now)
+                .unwrap()
+                .status,
+            "OutOfDate"
+        );
+
+        let mut revoked = state
+            .tdx
+            .sample_collateral_with_tcb_status("Revoked")
+            .unwrap();
+        revoked.pck_certificate_chain = recovered.pck_certificate_chain.clone();
+        assert!(verifier.verify(&evidence.quote, &revoked, now).is_err());
+
+        let expired_time = 4_200_000_000;
+        assert!(verifier
+            .verify(&evidence.quote, &recovered, expired_time)
+            .is_err());
+
+        let mut signature_invalid = recovered.clone();
+        signature_invalid.tcb_info_signature[0] ^= 1;
+        assert!(verifier
+            .verify(&evidence.quote, &signature_invalid, now)
+            .is_err());
+
+        let mut malformed = recovered.clone();
+        malformed.tcb_info = "{".into();
+        assert!(verifier.verify(&evidence.quote, &malformed, now).is_err());
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn tpm_aia_and_crl_service_builds_verifiable_collateral() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/dstack/crates/mock-attestation/src/tdx.rs
+++ b/dstack/crates/mock-attestation/src/tdx.rs
@@ -175,6 +175,14 @@ impl TdxGenerator {
         self.collateral()
     }
 
+    #[cfg(test)]
+    pub(crate) fn sample_collateral_with_tcb_status(
+        &self,
+        tcb_status: &str,
+    ) -> Result<QuoteCollateralV3> {
+        self.collateral_with_tcb_status(tcb_status)
+    }
+
     pub fn root_crl_der(&self) -> Vec<u8> {
         self.root_crl.clone()
     }
@@ -296,6 +304,10 @@ impl TdxGenerator {
     }
 
     fn collateral(&self) -> Result<QuoteCollateralV3> {
+        self.collateral_with_tcb_status("UpToDate")
+    }
+
+    fn collateral_with_tcb_status(&self, tcb_status: &str) -> Result<QuoteCollateralV3> {
         let now = chrono::Utc::now();
         let issue =
             (now - chrono::Duration::days(1)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
@@ -305,7 +317,7 @@ impl TdxGenerator {
             "id":"TDX", "version":3, "issueDate":issue, "nextUpdate":next,
             "fmspc":"000000000000", "pceId":"0000", "tcbType":0, "tcbEvaluationDataNumber":1,
             "tdxModule":{"mrsigner":"00".repeat(48),"attributes":"00".repeat(8),"attributesMask":"00".repeat(8)},
-            "tcbLevels":[{"tcb":{"sgxtcbcomponents":vec![json!({"svn":0});16],"pcesvn":0,"tdxtcbcomponents":vec![json!({"svn":0});16]},"tcbDate":issue,"tcbStatus":"UpToDate"}]
+            "tcbLevels":[{"tcb":{"sgxtcbcomponents":vec![json!({"svn":0});16],"pcesvn":0,"tdxtcbcomponents":vec![json!({"svn":0});16]},"tcbDate":issue,"tcbStatus":tcb_status}]
         }).to_string();
         let qe_identity = json!({
             "id":"TD_QE", "version":2, "issueDate":issue, "nextUpdate":next,

--- a/dstack/guest-agent/src/config.rs
+++ b/dstack/guest-agent/src/config.rs
@@ -70,3 +70,146 @@ where
         raw: content,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    const DEFAULTS: &str = r#"
+[default.core]
+keys_file = "/embedded/keys.json"
+compose_file = "/embedded/compose.json"
+sys_config_file = "/embedded/sys-config.json"
+data_disks = ["/"]
+"#;
+
+    fn minimal_compose(extra: &str) -> String {
+        format!(
+            r#"{{
+  "manifest_version": 2,
+  "name": "config-entry-test",
+  "runner": "docker-compose",
+  "docker_compose_file": "services: {{}}"{extra}
+}}"#
+        )
+    }
+
+    fn leaf_config(directory: &Path, compose: &Path, extra: &str) -> PathBuf {
+        let leaf = directory.join("guest.toml");
+        fs::write(
+            &leaf,
+            format!(
+                r#"
+[default.core]
+keys_file = "{directory}/keys.json"
+compose_file = "{compose}"
+sys_config_file = "{directory}/sys-config.json"
+data_disks = ["/", "{directory}/data"]
+{extra}
+"#,
+                directory = directory.display(),
+                compose = compose.display(),
+            ),
+        )
+        .unwrap();
+        leaf
+    }
+
+    fn extract(defaults: &str, leaf: &Path) -> Result<Config, Box<figment::Error>> {
+        load_config_figment_with_default(defaults, leaf.to_str())
+            .extract_inner("core")
+            .map_err(Box::new)
+    }
+
+    #[test]
+    fn explicit_leaf_overrides_embedded_defaults() {
+        let temporary = TempDir::new().unwrap();
+        let compose = temporary.path().join("compose.json");
+        fs::write(&compose, minimal_compose("")).unwrap();
+        let leaf = leaf_config(temporary.path(), &compose, "");
+
+        let config = extract(DEFAULTS, &leaf).unwrap();
+
+        assert_eq!(
+            config.keys_file,
+            temporary.path().join("keys.json").display().to_string()
+        );
+        assert_eq!(
+            config.sys_config_file,
+            temporary.path().join("sys-config.json")
+        );
+        assert!(config.data_disks.contains(&PathBuf::from("/")));
+        assert!(config.data_disks.contains(&temporary.path().join("data")));
+    }
+
+    #[test]
+    fn compose_raw_bytes_and_unknown_fields_are_preserved() {
+        let temporary = TempDir::new().unwrap();
+        let compose = temporary.path().join("compose.json");
+        let raw = minimal_compose(",\n  \"future_optional_field\": {\"enabled\": true}");
+        fs::write(&compose, &raw).unwrap();
+        let leaf = leaf_config(temporary.path(), &compose, "");
+
+        let config = extract(DEFAULTS, &leaf).unwrap();
+
+        assert_eq!(config.app_compose.raw, raw);
+        assert_eq!(config.app_compose.name, "config-entry-test");
+    }
+
+    #[test]
+    fn absent_optional_compose_fields_use_documented_defaults() {
+        let temporary = TempDir::new().unwrap();
+        let compose = temporary.path().join("compose.json");
+        fs::write(&compose, minimal_compose("")).unwrap();
+        let leaf = leaf_config(temporary.path(), &compose, "");
+
+        let config = extract(DEFAULTS, &leaf).unwrap();
+
+        assert!(!config.app_compose.public_logs);
+        assert!(!config.app_compose.public_sysinfo);
+        assert!(config.app_compose.public_tcbinfo);
+        assert!(!config.app_compose.kms_enabled);
+        assert!(!config.app_compose.gateway_enabled);
+        assert!(config.app_compose.secure_time);
+        assert_eq!(config.app_compose.swap_size, 0);
+    }
+
+    #[test]
+    fn missing_compose_file_fails_before_state_construction() {
+        let temporary = TempDir::new().unwrap();
+        let missing = temporary.path().join("missing-compose.json");
+        let leaf = leaf_config(temporary.path(), &missing, "");
+
+        let error = extract(DEFAULTS, &leaf).unwrap_err().to_string();
+
+        assert!(error.contains("Failed to read compose file"), "{error}");
+    }
+
+    #[test]
+    fn malformed_or_required_field_missing_compose_fails_closed() {
+        let temporary = TempDir::new().unwrap();
+        let compose = temporary.path().join("compose.json");
+        let leaf = leaf_config(temporary.path(), &compose, "");
+
+        fs::write(&compose, "{not-json").unwrap();
+        let malformed = extract(DEFAULTS, &leaf).unwrap_err().to_string();
+        assert!(
+            malformed.contains("Failed to parse compose file"),
+            "{malformed}"
+        );
+
+        fs::write(
+            &compose,
+            r#"{"manifest_version":2,"runner":"docker-compose"}"#,
+        )
+        .unwrap();
+        let missing = extract(DEFAULTS, &leaf).unwrap_err().to_string();
+        assert!(
+            missing.contains("Failed to parse compose file"),
+            "{missing}"
+        );
+        assert!(missing.contains("missing field `name`"), "{missing}");
+    }
+}

--- a/dstack/kms/src/crypto.rs
+++ b/dstack/kms/src/crypto.rs
@@ -59,3 +59,42 @@ pub(crate) fn sign_message_with_timestamp(
     signature_bytes.push(recid.to_byte());
     Ok(signature_bytes)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_public_key_signatures_bind_domain_app_key_and_timestamp() {
+        let key = SigningKey::from_slice(&[7_u8; 32]).unwrap();
+        let prefix = b"dstack-env-encrypt-pubkey";
+        let app_id = b"app-a";
+        let timestamp = 1_786_194_000;
+        let public_key = [0x42_u8; 32];
+        let baseline =
+            sign_message_with_timestamp(&key, prefix, app_id, timestamp, &public_key).unwrap();
+
+        assert_eq!(baseline.len(), 65);
+        assert_eq!(
+            baseline,
+            sign_message_with_timestamp(&key, prefix, app_id, timestamp, &public_key).unwrap()
+        );
+        assert_ne!(
+            baseline,
+            sign_message_with_timestamp(&key, b"other-domain", app_id, timestamp, &public_key)
+                .unwrap()
+        );
+        assert_ne!(
+            baseline,
+            sign_message_with_timestamp(&key, prefix, b"app-b", timestamp, &public_key).unwrap()
+        );
+        assert_ne!(
+            baseline,
+            sign_message_with_timestamp(&key, prefix, app_id, timestamp + 1, &public_key).unwrap()
+        );
+        assert_ne!(
+            baseline,
+            sign_message_with_timestamp(&key, prefix, app_id, timestamp, &[0x43_u8; 32]).unwrap()
+        );
+    }
+}

--- a/dstack/tests/e2e/attestation/run-platform.sh
+++ b/dstack/tests/e2e/attestation/run-platform.sh
@@ -18,6 +18,7 @@ mkdir -p /sys/kernel/config/tsm/report
 VM_CONFIG='{}'
 MR_CONFIG='{"version":3,"app_id":"","compose_hash":"","key_provider":"none"}'
 GCP_TPM_REPLAY=null
+AWS_PCR_REPLAY=null
 if [[ "$TEE_PLATFORM" == dstack-tdx ]]; then
   VM_CONFIG=$(jq -c --arg variant "${TDX_ATTESTATION_VARIANT:?}" \
     '.vm_config | fromjson | .tdx_attestation_variant = $variant' \
@@ -62,11 +63,14 @@ elif [[ "$TEE_PLATFORM" == dstack-aws-nitro-tpm ]]; then
   MEASUREMENT_HASH=$(sha256sum "$WORK/measurement.aws.cbor" | cut -d' ' -f1)
   printf '%s  measurement.aws.cbor\n' "$MEASUREMENT_HASH" > "$WORK/sha256sum.txt"
   OS_IMAGE_HASH=$(sha256sum "$WORK/sha256sum.txt" | cut -d' ' -f1)
+  AWS_PCR_REPLAY=$(jq -cn --arg pcr "$ZERO_PCR" \
+    '{version:1,events:[],pcr4:$pcr,pcr7:$pcr,pcr12:$pcr}')
   VM_CONFIG=$(jq -cn \
     --arg os "$OS_IMAGE_HASH" \
     --arg checksum "$(base64 -w0 "$WORK/sha256sum.txt")" \
     --arg measurement "$(base64 -w0 "$WORK/measurement.aws.cbor")" \
-    '{os_image_hash:$os,aws_measurement:{checksum_file:$checksum,measurement:$measurement}}')
+    --argjson replay "$AWS_PCR_REPLAY" \
+    '{os_image_hash:$os,aws_measurement:{checksum_file:$checksum,measurement:$measurement},aws_pcr_replay:$replay}')
 fi
 
 cleanup() {
@@ -102,7 +106,8 @@ cat > "$SIM_CONFIG" <<JSON
   "collateral_base_url": "http://127.0.0.1:18088",
   "mr_config": $(jq -Rn --arg value "$MR_CONFIG" '$value'),
   "vm_config": $(jq -Rn --arg value "$VM_CONFIG" '$value'),
-  "gcp_tpm_replay": $GCP_TPM_REPLAY
+  "gcp_tpm_replay": $GCP_TPM_REPLAY,
+  "aws_pcr_replay": $AWS_PCR_REPLAY
 }
 JSON
 

--- a/dstack/verifier/Cargo.toml
+++ b/dstack/verifier/Cargo.toml
@@ -58,3 +58,6 @@ hex-literal.workspace = true
 [features]
 default = ["binary"]
 binary = ["dep:clap", "dep:figment", "dep:rocket", "dep:tracing-subscriber"]
+
+[dev-dependencies]
+rcgen.workspace = true

--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -433,3 +433,47 @@ image_download_timeout_secs = 7
         assert_eq!(load_config(&config_figment(&path)).unwrap().port, 18080);
     }
 }
+
+#[cfg(test)]
+mod certificate_profile_tests {
+    use super::*;
+    use ra_tls::cert::CertRequest;
+    use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
+    use std::time::{Duration, SystemTime};
+
+    fn certificate(not_before: SystemTime, not_after: SystemTime) -> Vec<u8> {
+        let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let alt_names = vec!["clock-boundary.example.test".to_string()];
+        CertRequest::builder()
+            .key(&key)
+            .subject("clock-boundary.example.test")
+            .alt_names(&alt_names)
+            .usage_server_auth(true)
+            .not_before(not_before)
+            .not_after(not_after)
+            .build()
+            .self_signed()
+            .unwrap()
+            .der()
+            .to_vec()
+    }
+
+    #[test]
+    fn certificate_profile_rejects_expired_and_future_certificates() {
+        let now = SystemTime::now();
+        let hour = Duration::from_secs(60 * 60);
+
+        let expired = certificate(now - hour * 2, now - hour);
+        let future = certificate(now + hour, now + hour * 2);
+        let current = certificate(now - hour, now + hour);
+
+        for invalid in [&expired, &future] {
+            let error = verify_certificate_profile(invalid).unwrap_err();
+            assert!(
+                format!("{error:#}").contains("outside its validity period"),
+                "unexpected validity diagnostic: {error:#}"
+            );
+        }
+        verify_certificate_profile(&current).unwrap();
+    }
+}

--- a/dstack/vmm/src/app/qemu.rs
+++ b/dstack/vmm/src/app/qemu.rs
@@ -1028,9 +1028,10 @@ mod tests {
         PreparedQemuLaunch, PreparedVolume, QemuCommandBuilder, VmConfig,
     };
     use crate::app::image::{Image, ImageInfo};
-    use crate::app::{needs_swtpm, GpuConfig, Manifest, PortMapping, VmVolume, VmWorkDir};
+    use crate::app::{needs_swtpm, GpuConfig, GpuSpec, Manifest, PortMapping, VmVolume, VmWorkDir};
     use crate::config::{
-        Config, CvmPlatform, NetworkFilterMode, NetworkingMode, Protocol, DEFAULT_CONFIG,
+        Config, CvmPlatform, NetworkFilterMode, Networking, NetworkingMode, Protocol,
+        DEFAULT_CONFIG,
     };
     use crate::netd::{tap_name, InterfaceIdentity};
     use dstack_types::{KeyProviderKind, TeeVariant};
@@ -1288,5 +1289,62 @@ mod tests {
             .args
             .windows(2)
             .any(|args| args == ["-tpmdev", "emulator,id=tpm0,chardev=chrtpm"]));
+
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| arg.starts_with("local,path=") && arg.contains("mount_tag=host-shared")));
+
+        prepared.swtpm_socket = None;
+        prepared.networks = vec![Networking {
+            mode: NetworkingMode::Custom,
+            bridge: String::new(),
+            parent: String::new(),
+            macvtap_mode: String::new(),
+            device: String::new(),
+            mac_prefix: String::new(),
+            net: String::new(),
+            dhcp_start: String::new(),
+            restrict: false,
+            netdev: "tap,id=wrong".into(),
+        }];
+        let error = QemuCommandBuilder {
+            vm: &vm,
+            cfg: &config.cvm,
+            gpus: &GpuConfig::default(),
+            prepared: &prepared,
+        }
+        .build()
+        .unwrap_err();
+        assert!(error.to_string().contains("must contain id=net0"));
+        prepared.networks[0].netdev = "tap,id=net0,fd=3".into();
+        QemuCommandBuilder {
+            vm: &vm,
+            cfg: &config.cvm,
+            gpus: &GpuConfig::default(),
+            prepared: &prepared,
+        }
+        .build()
+        .unwrap();
+
+        let gpu = GpuConfig {
+            gpus: vec![GpuSpec {
+                slot: "0000:02:00.0".into(),
+            }],
+            ..Default::default()
+        };
+        let process = QemuCommandBuilder {
+            vm: &vm,
+            cfg: &config.cvm,
+            gpus: &gpu,
+            prepared: &prepared,
+        }
+        .build()
+        .unwrap();
+        assert!(process.args.iter().any(|arg| arg == "iommufd,id=iommufd0"));
+        assert!(process
+            .args
+            .iter()
+            .any(|arg| arg.contains("vfio-pci,host=0000:02:00.0")));
     }
 }


### PR DESCRIPTION
## Summary
- add source-local unit coverage for guest configuration, KMS signature binding, verifier certificate validity, Certbot workdir behavior, mock TDX collateral, and VMM QEMU command construction
- add the attested KMS certificate fixture binary used by acceptance tests
- complete the NitroTPM replay data in the cross-platform attestation harness
- keep product/runtime fixes and the main dstack-test framework out of this PR

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p certbot`
- `cargo test -p mock-attestation`
- `cargo test -p dstack-guest-agent config::tests`
- `cargo test -p dstack-kms crypto::tests`
- `cargo test -p dstack-verifier certificate_profile_tests`
- `cargo test -p dstack-vmm app::qemu::tests`
- `cargo check -p cert-client --bin dstack-kms-sign-cert-fixture`
- `bash -n tests/e2e/attestation/run-platform.sh`