### PR TITLE
fix(kms): refresh Bun lockfiles for Hono 4.12.34

### DIFF
--- a/dstack/kms/auth-eth-bun/bun.lock
+++ b/dstack/kms/auth-eth-bun/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "auth-eth-bun",
       "dependencies": {
         "@hono/zod-validator": "0.2.2",
-        "hono": "4.12.27",
+        "hono": "4.12.34",
         "viem": "2.31.7",
         "zod": "3.25.76",
       },
@@ -234,7 +233,7 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 

--- a/dstack/kms/auth-simple/bun.lock
+++ b/dstack/kms/auth-simple/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "auth-simple",
       "dependencies": {
         "@hono/zod-validator": "0.2.2",
-        "hono": "4.12.25",
+        "hono": "4.12.34",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -219,7 +218,7 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 


### PR DESCRIPTION
## Summary

- refresh the auth-simple Bun lockfile for the declared Hono 4.12.34 dependency
- refresh the auth-eth-bun Bun lockfile for the declared Hono 4.12.34 dependency
- restore reproducible frozen dependency installation

## Testing

- `bun install --frozen-lockfile` in both packages
- auth-simple: 16 Vitest tests passed under Node.js 22
- auth-eth-bun: 23 Vitest tests passed under Node.js 22
- pre-commit hooks
- `git diff --check`

Discovered by the PR #841 full-suite run; kept separate because this changes product dependency lockfiles.