### PR TITLE
fix(os): align mkosi guest identity and tooling

### DIFF
--- a/os/mkosi/mkosi.conf
+++ b/os/mkosi/mkosi.conf
@@ -54,6 +54,16 @@ Packages=
         dmsetup
         tpm2-tools
         curl
+        wget
+        iputils-ping
+        dnsutils
+        traceroute
+        netcat-openbsd
+        fdisk
+        dosfstools
+        pciutils
+        usbutils
+        cpio
         jq
         fuse3
         pigz

--- a/os/mkosi/mkosi.finalize
+++ b/os/mkosi/mkosi.finalize
@@ -9,8 +9,12 @@ FLAVOR=${DSTACK_BUILD_FLAVOR:?}
 WORK="$OUTPUTDIR/.dstack-$FLAVOR"
 KSTAGE="$WORK/kernel-stage"
 ARTIFACTS="$WORK/artifacts"
+# shellcheck source=/dev/null
+source "$SELF/versions.env"
 
 "$SELF/scripts/normalize-skeleton-modes.sh" "$TREE" "$FLAVOR"
+"$SELF/scripts/write-os-release.sh" \
+	"$TREE" "$DSTACK_VERSION" "$DSTACK_CODENAME"
 mkdir -p "$KSTAGE/usr/lib" "$OUTPUTDIR/.image-tools"
 cp -a "$TREE/usr/lib/modules" "$KSTAGE/usr/lib/"
 install -m0644 "$TREE/usr/lib/dstack/firmware/ovmf.fd" "$KSTAGE/ovmf.fd"

--- a/os/mkosi/scripts/write-os-release.sh
+++ b/os/mkosi/scripts/write-os-release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+	echo "Usage: $0 ROOT VERSION CODENAME" >&2
+	exit 2
+fi
+
+root=$1
+version=$2
+codename=$3
+install -d -m0755 "$root/usr/lib" "$root/etc"
+cat > "$root/usr/lib/os-release" <<RELEASE
+ID=dstack
+ID_LIKE=debian
+NAME="dstack"
+VERSION="$version ($codename)"
+VERSION_ID="$version"
+VERSION_CODENAME="$codename"
+PRETTY_NAME="dstack $version ($codename)"
+CPE_NAME="cpe:/o:dstack:dstack:$version"
+IMAGE_ID=dstack
+IMAGE_VERSION="$version"
+DEFAULT_HOSTNAME=dstack
+RELEASE
+ln -sfn ../usr/lib/os-release "$root/etc/os-release"

--- a/os/mkosi/tests/acceptance.sh
+++ b/os/mkosi/tests/acceptance.sh
@@ -13,6 +13,23 @@ done
 source "$D/versions.env"
 [[ $KERNEL_VERSION != *-rc* ]]
 [[ $KERNEL_SHA256 =~ ^[0-9a-f]{64}$ ]]
+[[ $DSTACK_CODENAME == trixie ]]
+release_root=$(mktemp -d)
+"$D/scripts/write-os-release.sh" \
+  "$release_root" "$DSTACK_VERSION" "$DSTACK_CODENAME"
+grep -qx 'ID=dstack' "$release_root/usr/lib/os-release"
+grep -qx 'ID_LIKE=debian' "$release_root/usr/lib/os-release"
+grep -qx 'NAME="dstack"' "$release_root/usr/lib/os-release"
+grep -qx "VERSION_ID=\"$DSTACK_VERSION\"" "$release_root/usr/lib/os-release"
+grep -qx "VERSION_CODENAME=\"$DSTACK_CODENAME\"" \
+  "$release_root/usr/lib/os-release"
+grep -qx "PRETTY_NAME=\"dstack $DSTACK_VERSION ($DSTACK_CODENAME)\"" \
+  "$release_root/usr/lib/os-release"
+[[ $(readlink "$release_root/etc/os-release") == ../usr/lib/os-release ]]
+rm -rf "$release_root"
+
+grep -qx 'DISTRO_NAME = "dstack"' \
+  "$D/../yocto/layers/meta-dstack/conf/distro/dstack.conf"
 # The guest kernel must track the same series as the production Yocto backend.
 # A different major/minor reintroduces the out-of-tree NVIDIA and ZFS
 # compatibility patches that parity with Yocto exists to avoid.
@@ -30,6 +47,13 @@ grep -q '^Output=%i-%v-rootfs$' "$D/mkosi.conf"
 grep -q "^ImageVersion=$DSTACK_VERSION\$" "$D/mkosi.conf"
 awk '/^ImageVersion=/{v=NR} /^Output=/{o=NR} END{exit !(v && o && v < o)}' "$D/mkosi.conf"
 grep -q '^Bootable=no$' "$D/mkosi.conf"
+for package in iputils-ping dnsutils traceroute netcat-openbsd wget fdisk \
+  dosfstools pciutils usbutils cpio; do
+  grep -Eq "^[[:space:]]+$package$" "$D/mkosi.conf" || {
+    echo "missing runtime diagnostic package: $package" >&2
+    exit 1
+  }
+done
 # SplitArtifacts must stay empty: the kernel split is produced even with
 # Bootable=no and would drop a stray .vmlinuz beside the release artifacts.
 grep -q '^SplitArtifacts=$' "$D/mkosi.conf"

--- a/os/mkosi/versions.env
+++ b/os/mkosi/versions.env
@@ -18,6 +18,7 @@ GO_TOOLCHAIN_VERSION=1.26.2
 GO_TOOLCHAIN_SHA256=990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282
 NITRO_TPM_TOOLS_REVISION=d76d6eeebd4169b00a3c3af9858852d48f40e748
 DSTACK_VERSION=0.6.0
+DSTACK_CODENAME=trixie
 OVMF_VARIANT=pre202505
 # Must match SRCREV in meta-dstack's dstack-ovmf_git.bb: a generic OVMF
 # produces TDX measurement material dstack-mr cannot parse.

--- a/os/yocto/layers/meta-dstack/conf/distro/dstack.conf
+++ b/os/yocto/layers/meta-dstack/conf/distro/dstack.conf
@@ -4,7 +4,7 @@
 INIT_MANAGER = "systemd"
 require conf/distro/cvm.conf
 DISTRO = "dstack"
-DISTRO_NAME = "DStack"
+DISTRO_NAME = "dstack"
 DISTRO_FEATURES:append = " virtualization seccomp systemd usrmerge security dm-verity ipv6"
 
 DISTRO_VERSION = "0.6.0"


### PR DESCRIPTION
## Summary

- write dstack-owned release metadata into mkosi guest images while retaining Debian compatibility through ID_LIKE=debian
- use the Debian trixie codename for mkosi and preserve Yocto own codename
- use lowercase dstack naming in both image backends
- add the requested network diagnostics, downloader, disk utilities, hardware inspection tools, and cpio to mkosi runtime images
- add static acceptance coverage for release metadata and the required runtime packages

## Added mkosi commands

- ping, ping6, nslookup, traceroute, nc
- wget
- fdisk, sfdisk, cfdisk, mkfs.vfat
- lspci, lsusb
- cpio

## Validation

- bash os/mkosi/tests/acceptance.sh
- pre-commit hooks
- git diff --check