### PR TITLE
feat(gateway): gate instances out of load balancing from the admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - shared API authentication (`dstack-api-auth`) protecting the full VMM HTTP/pRPC/UI surface and unifying Gateway/KMS admin auth: bearer/`X-Admin-Token`/HTTP Basic/bcrypt htpasswd, constant-time verification (#796)
+- gateway: `Admin.SetInstanceReady` takes a CVM instance out of its app's load-balancing rotation without stopping it; instance-id routing stays open so the instance can still be investigated, and the setting survives re-registration
 
 ### Changed
 - os/yocto: nerdctl 2.2.1 → 2.3.5, so `nerdctl compose` honours the Compose `healthcheck:` field (only translated into `--health-*` flags from 2.3.1 on). Requires openembedded-core to move to `wrynose` head for go 1.26.5, which also brings gcc 15.2 → 15.3 — every guest image measurement changes, so the new image hashes need whitelisting in KMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sdk: `AppCompose` in the Go SDK gained `init_script`, `storage_fs`, `swap_size`, `event_log_version`, `port_policy` and `verity_volumes`, and `Requirements` gained `gpu_policy` in the Go and Python SDKs
 - shared API authentication (`dstack-api-auth`) protecting the full VMM HTTP/pRPC/UI surface and unifying Gateway/KMS admin auth: bearer/`X-Admin-Token`/HTTP Basic/bcrypt htpasswd, constant-time verification (#796)
 - gateway: `Admin.SetInstanceReady` takes a CVM instance out of its app's load-balancing rotation without stopping it; instance-id routing stays open so the instance can still be investigated, and the setting survives re-registration
+- gateway: operator-set per-instance overrides now live under their own KV keys — `admin/<instance_id>/ready` and `admin/<instance_id>/port_policy` — instead of inside the instance record, so a CVM re-registration can no longer drop them and setting one cannot discard a peer's unsynced change to the other. An override left in an instance record by an earlier build is moved across on load
 
 ### Fixed
 - sdk: the Go and Python compose-hash helpers silently dropped every app-compose field they did not declare, so `getComposeHash` returned a digest for an app-compose that was not the one being deployed — and that digest is what gets whitelisted on chain. The missing fields are named above; both now keep unrecognised keys as well, so a guest that gains a field before the SDK does still hashes correctly

--- a/dstack/gateway/gateway.toml
+++ b/dstack/gateway/gateway.toml
@@ -187,9 +187,13 @@ persist_interval = "5m"
 # the kernel.
 #
 # A cluster recovers the window from its peers on restart. A single-node gateway
-# does not, which is the case for setting this to "0s" — force every write
-# before it returns, as releases before WaveKV 2.1 always did.
-wal_sync_interval = "5s"
+# does not, which is the case for setting this to "0s".
+#
+# Note that "0s" is the strictest setting here, not the cheapest: no window
+# means every write is forced before it returns, as releases before WaveKV 2.1
+# always did. That is the opposite of the "*_interval" settings either side of
+# it, where zero turns the work off — which is why this one is a window.
+wal_sync_window = "5s"
 # Enable periodic sync of instance connections to KV store
 sync_connections_enabled = true
 # Interval for syncing instance connections to KV store

--- a/dstack/gateway/rpc/proto/gateway_rpc.proto
+++ b/dstack/gateway/rpc/proto/gateway_rpc.proto
@@ -142,6 +142,10 @@ message HostInfo {
   uint64 latest_handshake = 6;
   // The number of connections of the host.
   uint64 num_connections = 7;
+  // Whether the operator has left this instance in its app's load-balancing
+  // rotation (see Admin.SetInstanceReady). Absent when talking to a gateway
+  // that predates the traffic gate; absent must not be read as "gated off".
+  optional bool admin_ready = 8;
 }
 
 message QuotedPublicKey {
@@ -519,6 +523,18 @@ service Admin {
   // Inspect both the admin override and the instance-reported policy for an
   // instance, plus the effective policy the proxy will enforce.
   rpc GetInstancePortPolicy(GetInstancePortPolicyRequest) returns (GetInstancePortPolicyResponse) {}
+
+  // ==================== Per-Instance Traffic Gate ====================
+  // Take an instance in or out of its app's load-balancing rotation without
+  // stopping the CVM. Errors if the instance is not registered.
+  //
+  // Only affects connections addressed to the app id. Connections addressed
+  // to the instance id are never gated, so an instance pulled from rotation
+  // stays directly reachable for investigation.
+  //
+  // The setting is persisted and survives re-registration, so an instance
+  // does not quietly rejoin the rotation by rebooting.
+  rpc SetInstanceReady(SetInstanceReadyRequest) returns (google.protobuf.Empty) {}
 }
 
 // Emergency operator request to remove one CVM's instance record.
@@ -795,6 +811,16 @@ message SetInstancePortPolicyRequest {
 // Clear the admin override for an instance.
 message ClearInstancePortPolicyRequest {
   string instance_id = 1;
+}
+
+// Take an instance in or out of its app's load-balancing rotation.
+message SetInstanceReadyRequest {
+  // The instance to gate.
+  string instance_id = 1;
+  // true puts the instance back into rotation, false removes it. Existing
+  // connections are left running either way; this only affects which
+  // instances new connections may be routed to.
+  bool ready = 2;
 }
 
 // Inspect an instance's port-policy state.

--- a/dstack/gateway/rpc/proto/gateway_rpc.proto
+++ b/dstack/gateway/rpc/proto/gateway_rpc.proto
@@ -145,7 +145,7 @@ message HostInfo {
   // Whether the operator has left this instance in its app's load-balancing
   // rotation (see Admin.SetInstanceReady). Absent when talking to a gateway
   // that predates the traffic gate; absent must not be read as "gated off".
-  optional bool admin_ready = 8;
+  optional bool ready = 8;
 }
 
 message QuotedPublicKey {

--- a/dstack/gateway/rpc/proto/gateway_rpc.proto
+++ b/dstack/gateway/rpc/proto/gateway_rpc.proto
@@ -820,7 +820,13 @@ message SetInstanceReadyRequest {
   // true puts the instance back into rotation, false removes it. Existing
   // connections are left running either way; this only affects which
   // instances new connections may be routed to.
-  bool ready = 2;
+  //
+  // Required. It is `optional` so that absent and false stay distinguishable:
+  // a proto3 scalar decodes an omitted field as its zero value, and over the
+  // JSON transport -- where unknown keys are ignored -- a request that omits
+  // the field or misspells it would otherwise be a successful call that pulls
+  // the instance out of rotation. The server rejects absent instead.
+  optional bool ready = 2;
 }
 
 // Inspect an instance's port-policy state.

--- a/dstack/gateway/rpc/proto/gateway_rpc.proto
+++ b/dstack/gateway/rpc/proto/gateway_rpc.proto
@@ -532,8 +532,10 @@ service Admin {
   // to the instance id are never gated, so an instance pulled from rotation
   // stays directly reachable for investigation.
   //
-  // The setting is persisted and survives re-registration, so an instance
-  // does not quietly rejoin the rotation by rebooting.
+  // The setting is persisted under a key only the Admin API writes, so a
+  // re-registration -- by this instance or from another gateway node -- cannot
+  // reopen the gate. An instance does not quietly rejoin the rotation by
+  // rebooting, and does not need the operator to re-issue the gate after one.
   rpc SetInstanceReady(SetInstanceReadyRequest) returns (google.protobuf.Empty) {}
 }
 

--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -745,9 +745,14 @@ impl AdminRpc for AdminRpcHandler {
     }
 
     async fn set_instance_ready(self, request: SetInstanceReadyRequest) -> Result<()> {
-        self.state
-            .lock()
-            .set_ready(&request.instance_id, request.ready)
+        // Absent is not false. Over the JSON transport an omitted -- or
+        // misspelled, since unknown keys are ignored -- `ready` would decode to
+        // the field's default and quietly pull the instance out of rotation,
+        // answering 200 while doing the opposite of nothing.
+        let ready = request
+            .ready
+            .context("`ready` is required: say true to put the instance back into rotation, false to take it out")?;
+        self.state.lock().set_ready(&request.instance_id, ready)
     }
 }
 
@@ -1167,5 +1172,37 @@ mod wavekv_status_tests {
         assert_eq!(peer.last_seen.len(), 1);
         assert_eq!(peer.last_seen[0].node_id, 2);
         assert_eq!(peer.last_seen[0].timestamp, 1234);
+    }
+}
+
+#[cfg(test)]
+mod set_instance_ready_tests {
+    use dstack_gateway_rpc::SetInstanceReadyRequest;
+
+    /// prpc gives every generated field `#[serde(default)]`, and serde ignores
+    /// keys it does not know. A plain proto3 `bool ready` therefore turns both
+    /// "I forgot the field" and "I misspelled the field" into a 200 that pulls
+    /// the instance out of rotation. `optional` keeps absent distinguishable so
+    /// the handler can refuse it.
+    #[test]
+    fn an_omitted_ready_stays_distinguishable_from_a_gate_off() {
+        let omitted: SetInstanceReadyRequest =
+            serde_json::from_str(r#"{"instance_id": "abc"}"#).expect("decodes");
+        assert_eq!(omitted.ready, None, "absent must not decode as false");
+
+        let misspelled: SetInstanceReadyRequest =
+            serde_json::from_str(r#"{"instance_id": "abc", "redy": true}"#).expect("decodes");
+        assert_eq!(
+            misspelled.ready, None,
+            "an unknown key is dropped, so this is the omitted case too"
+        );
+
+        let explicit: SetInstanceReadyRequest =
+            serde_json::from_str(r#"{"instance_id": "abc", "ready": false}"#).expect("decodes");
+        assert_eq!(
+            explicit.ready,
+            Some(false),
+            "a stated false still gates off"
+        );
     }
 }

--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -69,7 +69,7 @@ impl AdminRpcHandler {
                     base_domain: base_domain.clone(),
                     latest_handshake,
                     num_connections: instance.num_connections(),
-                    admin_ready: Some(instance.is_admin_ready()),
+                    ready: Some(instance.is_ready()),
                 }
             })
             .collect::<Vec<_>>();
@@ -142,7 +142,7 @@ impl AdminRpc for AdminRpcHandler {
                     ts
                 },
                 num_connections: instance.num_connections(),
-                admin_ready: Some(instance.is_admin_ready()),
+                ready: Some(instance.is_ready()),
             };
             Ok(GetInfoResponse {
                 found: true,
@@ -747,7 +747,7 @@ impl AdminRpc for AdminRpcHandler {
     async fn set_instance_ready(self, request: SetInstanceReadyRequest) -> Result<()> {
         self.state
             .lock()
-            .set_admin_ready(&request.instance_id, request.ready)
+            .set_ready(&request.instance_id, request.ready)
     }
 }
 

--- a/dstack/gateway/src/admin_service.rs
+++ b/dstack/gateway/src/admin_service.rs
@@ -21,8 +21,8 @@ use dstack_gateway_rpc::{
     RemoveCvmResponse, RemoveNodeRequest, RemoveNodeResponse, RenewCertResponse,
     RenewZtDomainCertRequest, RenewZtDomainCertResponse, RotateAcmeCredentialsResponse,
     SetCertbotConfigRequest, SetDefaultDnsCredentialRequest, SetInstancePortPolicyRequest,
-    SetNodeStatusRequest, SetNodeUrlRequest, StatusResponse, StoreSyncStatus,
-    UpdateDnsCredentialRequest, WaveKvStatusResponse, ZtDomainCertStatus,
+    SetInstanceReadyRequest, SetNodeStatusRequest, SetNodeUrlRequest, StatusResponse,
+    StoreSyncStatus, UpdateDnsCredentialRequest, WaveKvStatusResponse, ZtDomainCertStatus,
     ZtDomainConfig as ProtoZtDomainConfig, ZtDomainInfo,
 };
 use ra_rpc::{CallContext, RpcCall};
@@ -69,6 +69,7 @@ impl AdminRpcHandler {
                     base_domain: base_domain.clone(),
                     latest_handshake,
                     num_connections: instance.num_connections(),
+                    admin_ready: Some(instance.is_admin_ready()),
                 }
             })
             .collect::<Vec<_>>();
@@ -141,6 +142,7 @@ impl AdminRpc for AdminRpcHandler {
                     ts
                 },
                 num_connections: instance.num_connections(),
+                admin_ready: Some(instance.is_admin_ready()),
             };
             Ok(GetInfoResponse {
                 found: true,
@@ -740,6 +742,12 @@ impl AdminRpc for AdminRpcHandler {
             .instance_port_policy_view(&request.instance_id)
             .with_context(|| format!("instance {} not found", request.instance_id))?;
         Ok(port_policy_view_to_proto(view))
+    }
+
+    async fn set_instance_ready(self, request: SetInstanceReadyRequest) -> Result<()> {
+        self.state
+            .lock()
+            .set_admin_ready(&request.instance_id, request.ready)
     }
 }
 

--- a/dstack/gateway/src/config.rs
+++ b/dstack/gateway/src/config.rs
@@ -544,9 +544,14 @@ pub struct SyncConfig {
     #[serde(with = "serde_duration")]
     pub persist_interval: Duration,
     /// How long a KV write may sit in the page cache before the write-ahead log
-    /// is forced to disk. Zero forces every write before it returns.
+    /// is forced to disk.
+    ///
+    /// Zero means *no window*, which is the strictest setting and not the
+    /// cheapest one: every write is forced before it returns. It reads the
+    /// opposite way round from the `*_interval` fields either side of it, where
+    /// zero turns the work off -- which is why this one is a window.
     #[serde(with = "serde_duration")]
-    pub wal_sync_interval: Duration,
+    pub wal_sync_window: Duration,
     /// Enable periodic sync of instance connections to KV store
     pub sync_connections_enabled: bool,
     /// Interval for syncing instance connections to KV store

--- a/dstack/gateway/src/kv/import.rs
+++ b/dstack/gateway/src/kv/import.rs
@@ -282,7 +282,7 @@ mod tests {
             port_policy: None,
             port_policy_hash: String::new(),
             admin_port_policy: None,
-            admin_ready: None,
+            ready: None,
         }
     }
 

--- a/dstack/gateway/src/kv/import.rs
+++ b/dstack/gateway/src/kv/import.rs
@@ -282,6 +282,7 @@ mod tests {
             port_policy: None,
             port_policy_hash: String::new(),
             admin_port_policy: None,
+            admin_ready: None,
         }
     }
 

--- a/dstack/gateway/src/kv/import.rs
+++ b/dstack/gateway/src/kv/import.rs
@@ -281,8 +281,6 @@ mod tests {
             reg_time,
             port_policy: None,
             port_policy_hash: String::new(),
-            admin_port_policy: None,
-            ready: None,
         }
     }
 

--- a/dstack/gateway/src/kv/import.rs
+++ b/dstack/gateway/src/kv/import.rs
@@ -30,7 +30,7 @@ use std::net::Ipv4Addr;
 use anyhow::{ensure, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 
-use super::{InstanceData, LoadedInstances, MAX_CLOCK_DRIFT_SECS};
+use super::{InstanceRecord, LoadedInstances, MAX_CLOCK_DRIFT_SECS};
 use crate::config::WgConfig;
 use crate::time::now_secs;
 
@@ -71,7 +71,7 @@ pub struct RejectedInstance {
 
 /// Records accepted for import, plus the ones that were skipped.
 pub struct AcceptedInstances {
-    pub instances: BTreeMap<String, InstanceData>,
+    pub instances: BTreeMap<String, InstanceRecord>,
     pub rejected: Vec<RejectedInstance>,
 }
 
@@ -139,7 +139,7 @@ fn validate_instance(
     wg: &WgConfig,
     now: u64,
     instance_id: &str,
-    data: &InstanceData,
+    data: &InstanceRecord,
 ) -> Result<()> {
     validate_id("instance_id", instance_id)?;
     validate_id("app_id", &data.app_id)?;
@@ -190,7 +190,7 @@ fn accept_instances_at(wg: &WgConfig, loaded: LoadedInstances, now: u64) -> Acce
         undecodable,
     } = loaded;
 
-    let mut ordered: Vec<(String, InstanceData)> = decoded.into_iter().collect();
+    let mut ordered: Vec<(String, InstanceRecord)> = decoded.into_iter().collect();
     ordered.sort_by(|(left_id, left), (right_id, right)| {
         left.reg_time
             .cmp(&right.reg_time)
@@ -273,8 +273,8 @@ mod tests {
         STANDARD.encode([seed; WG_PUBLIC_KEY_BYTES])
     }
 
-    fn instance(ip: &str, public_key: &str, reg_time: u64) -> InstanceData {
-        InstanceData {
+    fn instance(ip: &str, public_key: &str, reg_time: u64) -> InstanceRecord {
+        InstanceRecord {
             app_id: "0123456789abcdef".to_string(),
             ip: ip.parse().unwrap(),
             public_key: public_key.to_string(),
@@ -284,7 +284,7 @@ mod tests {
         }
     }
 
-    fn loaded(records: Vec<(&str, InstanceData)>) -> LoadedInstances {
+    fn loaded(records: Vec<(&str, InstanceRecord)>) -> LoadedInstances {
         LoadedInstances {
             decoded: records
                 .into_iter()
@@ -294,7 +294,7 @@ mod tests {
         }
     }
 
-    fn accept(records: Vec<(&str, InstanceData)>) -> AcceptedInstances {
+    fn accept(records: Vec<(&str, InstanceRecord)>) -> AcceptedInstances {
         accept_instances_at(&wg_config(), loaded(records), NOW)
     }
 

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -1179,18 +1179,33 @@ impl KvStore {
         let gate = self.delete_persistent(keys::admin_ready(instance_id), FailWrite::ADMIN);
         let override_policy =
             self.delete_persistent(keys::admin_port_policy(instance_id), FailWrite::ADMIN);
+        let observations = self.sync_forget_local_observations(instance_id);
+
+        let previous = previous?;
+        gate?;
+        override_policy?;
+        observations?;
+        Ok(previous.is_some_and(|entry| !entry.is_deleted()))
+    }
+
+    /// Withdraw this node's observations of an instance.
+    ///
+    /// `conn/` and `handshake/` are keyed by observer, so a delete can only
+    /// withdraw the deleting node's own -- they are the only ones it owns.
+    /// Every other node has to withdraw its own when it learns of the deletion,
+    /// or its observation outlives the CVM it describes: nothing sweeps those
+    /// prefixes, and a node's recycle loop cannot see an instance it has
+    /// already dropped from memory. They are ephemeral, so a restart collects
+    /// them, but a gateway's uptime is measured in months.
+    pub fn sync_forget_local_observations(&self, instance_id: &str) -> Result<()> {
         let conn = self.delete_ephemeral(keys::conn(instance_id, self.my_node_id), FailWrite::CONN);
         let handshake = self.delete_ephemeral(
             keys::handshake(instance_id, self.my_node_id),
             FailWrite::HANDSHAKE,
         );
-
-        let previous = previous?;
-        gate?;
-        override_policy?;
         conn?;
         handshake?;
-        Ok(previous.is_some_and(|entry| !entry.is_deleted()))
+        Ok(())
     }
 
     fn delete_persistent(&self, key: String, _which: u8) -> Result<Option<wavekv::types::Entry>> {

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -214,9 +214,13 @@ pub struct LoadedOverrides {
     pub decoded: BTreeMap<String, AdminOverrides>,
     /// Which of an instance's override keys exist, readable or not.
     ///
-    /// Separate from `decoded` because absent and cleared are different
-    /// answers: a cleared port-policy override is a present record holding
-    /// `None`, and only this tells it from a key that was never written.
+    /// Carried beside `decoded` because absent and cleared are different
+    /// answers and `decoded` can only show one of them: a cleared port-policy
+    /// override is a present record holding `None`, which is the same `None` a
+    /// key that was never written produces. The two together are three states
+    /// -- no key, a key saying "cleared", a key carrying a value -- and every
+    /// reader needs all three, because only the first may fall back to the copy
+    /// an older build left in the instance record.
     pub present: BTreeMap<String, BTreeSet<String>>,
     /// Instance IDs whose override record is present but no longer decodes,
     /// mapped to the decode error.
@@ -228,6 +232,25 @@ pub struct LoadedOverrides {
     /// never gated, so the instance stays reachable for investigation either
     /// way, which is the property the gate itself is built on.
     pub unreadable: BTreeMap<String, String>,
+}
+
+impl LoadedOverrides {
+    /// Which override keys an instance actually has, readable or not.
+    ///
+    /// Answered per key because they are per key. A caller that asks per
+    /// instance gets the two confused, and confusing them drops an override.
+    pub fn written_keys(&self, instance_id: &str) -> WrittenKeys<'_> {
+        WrittenKeys(self.present.get(instance_id))
+    }
+}
+
+/// The override keys one instance has. See [`LoadedOverrides::written_keys`].
+pub struct WrittenKeys<'a>(Option<&'a BTreeSet<String>>);
+
+impl WrittenKeys<'_> {
+    pub fn contains(&self, name: &str) -> bool {
+        self.0.is_some_and(|names| names.contains(name))
+    }
 }
 
 /// The `inst/` records currently in the KV store, split by readability.
@@ -1099,8 +1122,8 @@ impl KvStore {
         let existing = self.load_all_instance_overrides();
         let mut moved = Vec::new();
         for (instance_id, overrides) in legacy {
-            let present = existing.present.get(&instance_id);
-            let has = |name: &str| present.is_some_and(|names| names.contains(name));
+            let written = existing.written_keys(&instance_id);
+            let has = |name: &str| written.contains(name);
             if let Some(ready) = overrides.ready {
                 if !has(keys::ADMIN_READY) {
                     self.record_migration(

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -49,12 +49,7 @@ pub use https_client::{AppIdValidator, HttpsClientConfig};
 pub use sync_service::{fetch_peers_from_bootnode, PersistentWriteNotifier, WaveKvSyncService};
 use tracing::{error, warn};
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    net::Ipv4Addr,
-    path::Path,
-    time::Duration,
-};
+use std::{collections::BTreeMap, net::Ipv4Addr, path::Path, time::Duration};
 
 use anyhow::{Context, Result};
 
@@ -105,79 +100,41 @@ pub struct InstanceData {
     pub port_policy_hash: String,
 }
 
-/// The operator's traffic gate for one instance, under `admin/<id>/ready`.
-///
-/// A struct rather than a bare `bool` so the record can gain a field the way
-/// every other value here can -- who set it, when, why.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub struct InstanceGate {
-    /// false takes the instance out of its app's load-balancing rotation.
-    pub ready: bool,
-}
-
-/// The operator's port-policy override for one instance, under
+/// What an operator has said about an instance's ports, under
 /// `admin/<id>/port_policy`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AdminPortPolicy {
-    /// `None` is an operator having cleared the override, which is not the same
-    /// as never having set one. Absent lets the copy an older build left in the
-    /// instance record apply; cleared does not, or clearing an override would
-    /// be undone by that copy.
-    #[serde(default)]
-    pub policy: Option<PortPolicy>,
+///
+/// Three answers, not two, which is why this is not an `Option<PortPolicy>`:
+/// the key not existing is not the same as a key that says "cleared". Never set
+/// falls back to the copy an older build left in the instance record; cleared
+/// does not, or clearing an override would be undone by that copy. The wire
+/// form is `Option<PortPolicy>` -- the key's existence carries the third state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortPolicyOverride {
+    /// An operator cleared it.
+    Cleared,
+    /// An operator set it.
+    Set(PortPolicy),
 }
 
-/// What an operator has decided about one instance.
+/// The overrides an instance record still carries from before they had keys of
+/// their own.
 ///
-/// A read-side view assembled from the two keys above, not a stored record.
-/// Both live outside [`InstanceData`] because the writer is different, and that
-/// is what decides which key a fact lives in. `inst/` states what the CVM
-/// reports about itself, and is rewritten in full by whichever node the CVM
-/// registers against, from that node's own memory -- so anything in it the CVM
-/// does not report is dropped the moment a node that has not yet synced
-/// re-registers the instance. `gateway_checker` re-registers every 180s, so
-/// that window is hit routinely.
-///
-/// For a CVM-reported fact that is harmless: the CVM restates it. For the
-/// cached `port_policy` it is harmless too: it is re-fetched. For an operator's
-/// decision it is not, and the two fail in the direction that matters --
-/// a lost gate silently returns a quarantined instance to rotation, and a lost
-/// port-policy override silently widens the ports the app will serve. Only the
-/// operator writes those keys, so a re-registration cannot touch them.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AdminOverrides {
-    pub port_policy: Option<PortPolicy>,
-    pub ready: Option<bool>,
-}
-
-impl AdminOverrides {
-    /// Whether an operator has actually set anything.
-    pub fn is_empty(&self) -> bool {
-        self.port_policy.is_none() && self.ready.is_none()
-    }
-}
-
-/// The same two overrides as they were once stored: inside the instance record.
-///
-/// `InstanceData` no longer declares them, which is deliberate on both sides of
-/// an upgrade. Reading, this type recovers them for the move to their own keys.
+/// `InstanceData` no longer declares these fields, which is deliberate on both
+/// sides of an upgrade. Reading, this type recovers them for the move across.
 /// Writing, an undeclared field is one [`compat::carry_unknown_fields`]
 /// preserves verbatim, so a node still on the previous build keeps finding its
 /// copy where it left it for as long as the upgrade takes.
-#[derive(Debug, Clone, Deserialize)]
-struct LegacyInstanceOverrides {
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct LegacyOverrides {
     #[serde(default)]
-    admin_port_policy: Option<PortPolicy>,
+    pub admin_port_policy: Option<PortPolicy>,
     #[serde(default)]
-    ready: Option<bool>,
+    pub ready: Option<bool>,
 }
 
-impl From<LegacyInstanceOverrides> for AdminOverrides {
-    fn from(legacy: LegacyInstanceOverrides) -> Self {
-        Self {
-            port_policy: legacy.admin_port_policy,
-            ready: legacy.ready,
-        }
+impl LegacyOverrides {
+    fn is_empty(&self) -> bool {
+        self.admin_port_policy.is_none() && self.ready.is_none()
     }
 }
 
@@ -201,55 +158,6 @@ impl From<&InstanceInfo> for InstanceData {
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
         }
-    }
-}
-
-/// The `admin/` records currently in the KV store, split by readability.
-#[derive(Debug, Default)]
-pub struct LoadedOverrides {
-    /// What each instance's readable override records say, keyed by instance
-    /// ID. An instance appears once both keys are accounted for; a field is
-    /// `None` when its key is absent, which is what lets the legacy copy in the
-    /// instance record still apply.
-    pub decoded: BTreeMap<String, AdminOverrides>,
-    /// Which of an instance's override keys exist, readable or not.
-    ///
-    /// Carried beside `decoded` because absent and cleared are different
-    /// answers and `decoded` can only show one of them: a cleared port-policy
-    /// override is a present record holding `None`, which is the same `None` a
-    /// key that was never written produces. The two together are three states
-    /// -- no key, a key saying "cleared", a key carrying a value -- and every
-    /// reader needs all three, because only the first may fall back to the copy
-    /// an older build left in the instance record.
-    pub present: BTreeMap<String, BTreeSet<String>>,
-    /// Instance IDs whose override record is present but no longer decodes,
-    /// mapped to the decode error.
-    ///
-    /// Read as "unknown", not as "nothing is overridden". The gate is an
-    /// operator saying an instance must not be given work, so an unreadable
-    /// answer keeps it out of app-id rotation until the record is readable
-    /// again -- re-issuing either override rewrites it. Instance-id routing is
-    /// never gated, so the instance stays reachable for investigation either
-    /// way, which is the property the gate itself is built on.
-    pub unreadable: BTreeMap<String, String>,
-}
-
-impl LoadedOverrides {
-    /// Which override keys an instance actually has, readable or not.
-    ///
-    /// Answered per key because they are per key. A caller that asks per
-    /// instance gets the two confused, and confusing them drops an override.
-    pub fn written_keys(&self, instance_id: &str) -> WrittenKeys<'_> {
-        WrittenKeys(self.present.get(instance_id))
-    }
-}
-
-/// The override keys one instance has. See [`LoadedOverrides::written_keys`].
-pub struct WrittenKeys<'a>(Option<&'a BTreeSet<String>>);
-
-impl WrittenKeys<'_> {
-    pub fn contains(&self, name: &str) -> bool {
-        self.0.is_some_and(|names| names.contains(name))
     }
 }
 
@@ -568,16 +476,6 @@ pub mod keys {
         key.strip_prefix(INST_PREFIX)
     }
 
-    /// Parse (instance_id, override name) from an admin/{instance_id}/{name} key.
-    ///
-    /// Split from the right, so an instance id is not required to be free of
-    /// `/` for the override name to come out right.
-    pub fn parse_admin_key(key: &str) -> Option<(&str, &str)> {
-        let rest = key.strip_prefix(ADMIN_PREFIX)?;
-        let (instance_id, name) = rest.rsplit_once('/')?;
-        (!instance_id.is_empty() && !name.is_empty()).then_some((instance_id, name))
-    }
-
     /// Parse node_id from node/info/{node_id} key
     pub fn parse_node_info_key(key: &str) -> Option<NodeId> {
         key.strip_prefix(NODE_INFO_PREFIX)?.parse().ok()
@@ -820,7 +718,7 @@ impl GetPutCodec for NodeState {
 /// tombstone that did not land and nothing about an ephemeral observation that
 /// did not, so "a delete failed" is not a useful thing to be told.
 ///
-/// It is also what [`KvStore::fail_writes_for_test`] aims at, which is why the
+/// It is also what `KvStore::fail_writes_for_test` aims at, which is why the
 /// write paths take one instead of a `u8` that means nothing outside a test
 /// build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1034,65 +932,70 @@ impl KvStore {
 
     // ==================== Operator Override Sync ====================
 
-    /// Load every instance's operator-set overrides.
+    /// The operator's traffic gate for one instance. `None` means no key.
     ///
-    /// A record that no longer decodes is reported rather than skipped. Skipping
-    /// it would read as "no operator has decided anything", which is the one
-    /// answer that must not be guessed: it returns a quarantined instance to
-    /// rotation and drops a port-policy override back to whatever the instance
-    /// says about itself. See [`LoadedOverrides::unreadable`].
-    pub fn load_all_instance_overrides(&self) -> LoadedOverrides {
-        let mut loaded = LoadedOverrides::default();
-        let store = self.persistent.read();
-        for (key, entry) in store.iter_by_prefix(keys::ADMIN_PREFIX) {
-            // A tombstone is a key that was deleted, which is the same as one
-            // that was never written.
-            let Some(bytes) = entry.value.as_ref() else {
-                continue;
-            };
-            let Some((instance_id, name)) = keys::parse_admin_key(key) else {
-                continue;
-            };
-            loaded
-                .present
-                .entry(instance_id.to_string())
-                .or_default()
-                .insert(name.to_string());
-            let overrides = loaded.decoded.entry(instance_id.to_string()).or_default();
-            let decoded = match name {
-                keys::ADMIN_READY => {
-                    decode::<InstanceGate>(bytes).map(|gate| overrides.ready = Some(gate.ready))
-                }
-                keys::ADMIN_PORT_POLICY => decode::<AdminPortPolicy>(bytes)
-                    .map(|stored| overrides.port_policy = stored.policy),
-                // A key this build does not know. A newer peer may have added
-                // one; leaving it alone is what lets it.
-                _ => continue,
-            };
-            if let Err(err) = decoded {
-                loaded
-                    .unreadable
-                    .insert(instance_id.to_string(), format!("{key}: {err:#}"));
-            }
-        }
-        loaded
+    /// An unreadable record is an error, not a `None`. Reading it as "nobody
+    /// gated this" is the one answer that must not be guessed: it returns a
+    /// quarantined instance to rotation.
+    pub fn instance_gate(&self, instance_id: &str) -> Result<Option<bool>> {
+        self.persistent
+            .read()
+            .decode_strict::<bool>(&keys::admin_ready(instance_id))
+    }
+
+    /// The operator's port-policy override for one instance. `None` means no
+    /// key -- which is not [`PortPolicyOverride::Cleared`].
+    pub fn instance_port_policy_override(
+        &self,
+        instance_id: &str,
+    ) -> Result<Option<PortPolicyOverride>> {
+        let stored = self
+            .persistent
+            .read()
+            .decode_strict::<Option<PortPolicy>>(&keys::admin_port_policy(instance_id))?;
+        Ok(stored.map(|policy| match policy {
+            Some(policy) => PortPolicyOverride::Set(policy),
+            None => PortPolicyOverride::Cleared,
+        }))
+    }
+
+    /// Publish an instance's operator-set traffic gate.
+    pub fn set_instance_gate(&self, instance_id: &str, ready: bool) -> Result<()> {
+        self.put_admin_override(InstanceRecord::Gate, keys::admin_ready(instance_id), &ready)
+    }
+
+    /// Publish an instance's operator-set port-policy override. `None` clears it.
+    ///
+    /// A cleared override is written, not deleted: an absent key is what lets
+    /// the copy an older build left in the instance record apply, so deleting
+    /// would put the override straight back.
+    pub fn set_instance_port_policy_override(
+        &self,
+        instance_id: &str,
+        policy: Option<PortPolicy>,
+    ) -> Result<()> {
+        self.put_admin_override(
+            InstanceRecord::PortPolicyOverride,
+            keys::admin_port_policy(instance_id),
+            &policy,
+        )
     }
 
     /// The overrides an instance record still carries from before they had keys
-    /// of their own, for instances that have not been moved across yet.
+    /// of their own.
     ///
     /// Read from the same `inst/` bytes as [`InstanceData`], through a type
-    /// that declares only the retired fields.
-    pub fn legacy_instance_overrides(&self) -> BTreeMap<String, AdminOverrides> {
+    /// that declares only the retired fields. Bulk rather than per instance
+    /// because the only caller wants to know whether *any* remain.
+    pub fn legacy_instance_overrides(&self) -> BTreeMap<String, LegacyOverrides> {
         self.persistent
             .read()
-            .iter_decoded::<LegacyInstanceOverrides>(keys::INST_PREFIX)
+            .iter_decoded::<LegacyOverrides>(keys::INST_PREFIX)
             .filter_map(|(key, legacy)| {
-                let overrides = AdminOverrides::from(legacy);
-                if overrides.is_empty() {
+                if legacy.is_empty() {
                     return None;
                 }
-                Some((keys::parse_inst_key(&key)?.to_string(), overrides))
+                Some((keys::parse_inst_key(&key)?.to_string(), legacy))
             })
             .collect()
     }
@@ -1109,39 +1012,33 @@ impl KvStore {
     /// key each. Only where the key does not exist at all: once it does it is
     /// the answer, including when it says "no override", which is what clearing
     /// one leaves behind. Without that rule, clearing an override here would be
-    /// undone by the stale copy an old node left in the instance record.
+    /// undone by the stale copy an old node left in the instance record. An
+    /// unreadable key counts as existing for the same reason.
     ///
     /// Returns the keys written. Failures are logged and skipped: the next
     /// reload tries again, and the read-side fallback keeps the override in
     /// force in the meantime.
     pub fn migrate_legacy_instance_overrides(&self) -> Vec<String> {
-        let legacy = self.legacy_instance_overrides();
-        if legacy.is_empty() {
-            return Vec::new();
-        }
-        let existing = self.load_all_instance_overrides();
         let mut moved = Vec::new();
-        for (instance_id, overrides) in legacy {
-            let written = existing.written_keys(&instance_id);
-            let has = |name: &str| written.contains(name);
-            if let Some(ready) = overrides.ready {
-                if !has(keys::ADMIN_READY) {
+        for (instance_id, legacy) in self.legacy_instance_overrides() {
+            if let Some(ready) = legacy.ready {
+                if matches!(self.instance_gate(&instance_id), Ok(None)) {
                     self.record_migration(
                         &mut moved,
                         InstanceRecord::Gate,
                         keys::admin_ready(&instance_id),
-                        &InstanceGate { ready },
+                        &ready,
                     );
                 }
             }
-            if overrides.port_policy.is_some() && !has(keys::ADMIN_PORT_POLICY) {
+            if legacy.admin_port_policy.is_some()
+                && matches!(self.instance_port_policy_override(&instance_id), Ok(None))
+            {
                 self.record_migration(
                     &mut moved,
                     InstanceRecord::PortPolicyOverride,
                     keys::admin_port_policy(&instance_id),
-                    &AdminPortPolicy {
-                        policy: overrides.port_policy,
-                    },
+                    &legacy.admin_port_policy,
                 );
             }
         }
@@ -1159,28 +1056,6 @@ impl KvStore {
             Ok(()) => moved.push(key),
             Err(err) => warn!("failed to move operator override to {key}: {err:?}"),
         }
-    }
-
-    /// Publish an instance's operator-set traffic gate.
-    pub fn sync_instance_gate(&self, instance_id: &str, gate: &InstanceGate) -> Result<()> {
-        self.put_admin_override(InstanceRecord::Gate, keys::admin_ready(instance_id), gate)
-    }
-
-    /// Publish an instance's operator-set port-policy override.
-    ///
-    /// A cleared override is written, not deleted: an absent key is what lets
-    /// the copy an older build left in the instance record apply, so deleting
-    /// would put the override straight back.
-    pub fn sync_instance_port_policy_override(
-        &self,
-        instance_id: &str,
-        data: &AdminPortPolicy,
-    ) -> Result<()> {
-        self.put_admin_override(
-            InstanceRecord::PortPolicyOverride,
-            keys::admin_port_policy(instance_id),
-            data,
-        )
     }
 
     /// Written as a replacement rather than an update: each record states one
@@ -2885,8 +2760,8 @@ mod corruption_tests {
         // Until the move, the read-side fallback is what keeps them in force.
         assert_eq!(
             kv.legacy_instance_overrides()["legacy"],
-            AdminOverrides {
-                port_policy: Some(restrictive()),
+            LegacyOverrides {
+                admin_port_policy: Some(restrictive()),
                 ready: Some(false),
             }
         );
@@ -2897,12 +2772,10 @@ mod corruption_tests {
                 keys::admin_port_policy("legacy")
             ]
         );
+        assert_eq!(kv.instance_gate("legacy").unwrap(), Some(false));
         assert_eq!(
-            kv.load_all_instance_overrides().decoded["legacy"],
-            AdminOverrides {
-                port_policy: Some(restrictive()),
-                ready: Some(false),
-            }
+            kv.instance_port_policy_override("legacy").unwrap(),
+            Some(PortPolicyOverride::Set(restrictive()))
         );
         assert!(
             kv.migrate_legacy_instance_overrides().is_empty(),
@@ -2921,9 +2794,12 @@ mod corruption_tests {
             kv.migrate_legacy_instance_overrides(),
             vec![keys::admin_ready("legacy")]
         );
-        let loaded = kv.load_all_instance_overrides();
-        assert_eq!(loaded.decoded["legacy"].ready, Some(false));
-        assert!(!loaded.present["legacy"].contains(keys::ADMIN_PORT_POLICY));
+        assert_eq!(kv.instance_gate("legacy").unwrap(), Some(false));
+        assert_eq!(
+            kv.instance_port_policy_override("legacy").unwrap(),
+            None,
+            "the port-policy key was never written"
+        );
     }
 
     /// Two overrides in one record meant setting one on this node discarded a
@@ -2934,23 +2810,15 @@ mod corruption_tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let kv = test_kv(dir.path());
         // What a peer set, arriving through sync.
-        kv.sync_instance_port_policy_override(
-            "cvm",
-            &AdminPortPolicy {
-                policy: Some(restrictive()),
-            },
-        )
-        .expect("peer override");
+        kv.set_instance_port_policy_override("cvm", Some(restrictive()))
+            .expect("peer override");
         // What this node sets, from a snapshot that never saw it.
-        kv.sync_instance_gate("cvm", &InstanceGate { ready: false })
-            .expect("gate");
+        kv.set_instance_gate("cvm", false).expect("gate");
 
+        assert_eq!(kv.instance_gate("cvm").unwrap(), Some(false));
         assert_eq!(
-            kv.load_all_instance_overrides().decoded["cvm"],
-            AdminOverrides {
-                port_policy: Some(restrictive()),
-                ready: Some(false),
-            }
+            kv.instance_port_policy_override("cvm").unwrap(),
+            Some(PortPolicyOverride::Set(restrictive()))
         );
     }
 
@@ -2970,16 +2838,20 @@ mod corruption_tests {
         );
 
         // The operator clears it. Cleared is written, not deleted.
-        kv.sync_instance_port_policy_override("legacy", &AdminPortPolicy::default())
+        kv.set_instance_port_policy_override("legacy", None)
             .expect("clear");
-        assert!(kv.load_all_instance_overrides().decoded["legacy"].is_empty());
+        assert_eq!(
+            kv.instance_port_policy_override("legacy").unwrap(),
+            Some(PortPolicyOverride::Cleared)
+        );
 
         assert!(
             kv.migrate_legacy_instance_overrides().is_empty(),
-            "an override record that says nothing is still an answer"
+            "a key that says \"cleared\" is still an answer"
         );
-        assert!(
-            kv.load_all_instance_overrides().decoded["legacy"].is_empty(),
+        assert_eq!(
+            kv.instance_port_policy_override("legacy").unwrap(),
+            Some(PortPolicyOverride::Cleared),
             "the copy in the instance record must not come back"
         );
     }
@@ -2991,19 +2863,14 @@ mod corruption_tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let kv = test_kv(dir.path());
         seed_instance(&kv, "cvm");
-        kv.sync_instance_gate("cvm", &InstanceGate { ready: false })
-            .expect("seed gate");
-        kv.sync_instance_port_policy_override(
-            "cvm",
-            &AdminPortPolicy {
-                policy: Some(restrictive()),
-            },
-        )
-        .expect("seed override");
+        kv.set_instance_gate("cvm", false).expect("seed gate");
+        kv.set_instance_port_policy_override("cvm", Some(restrictive()))
+            .expect("seed override");
 
         kv.sync_delete_instance("cvm").expect("delete");
         assert!(
-            !kv.load_all_instance_overrides().decoded.contains_key("cvm"),
+            kv.instance_gate("cvm").unwrap().is_none()
+                && kv.instance_port_policy_override("cvm").unwrap().is_none(),
             "the override record must not outlive the instance"
         );
     }
@@ -3312,14 +3179,6 @@ mod key_schema_tests {
     #[test]
     fn every_key_parses_back_to_what_built_it() {
         assert_eq!(keys::parse_inst_key(&keys::inst("inst-a")), Some("inst-a"));
-        assert_eq!(
-            keys::parse_admin_key(&keys::admin_ready("inst-a")),
-            Some(("inst-a", keys::ADMIN_READY))
-        );
-        assert_eq!(
-            keys::parse_admin_key(&keys::admin_port_policy("inst-a")),
-            Some(("inst-a", keys::ADMIN_PORT_POLICY))
-        );
         assert_eq!(keys::parse_node_info_key(&keys::node_info(42)), Some(42));
         assert_eq!(
             keys::parse_cert_domain(&keys::cert_attestation_latest("a.example")),
@@ -3337,19 +3196,20 @@ mod key_schema_tests {
     fn a_parser_refuses_a_key_from_another_namespace() {
         assert_eq!(keys::parse_inst_key(&keys::node_info(1)), None);
         assert_eq!(keys::parse_cert_domain(&keys::inst("inst-a")), None);
-        // The overrides and the instance record are keyed by the same id and
-        // iterated by prefix. Either namespace claiming the other would make an
-        // operator's decision arrive as an instance record, or the reverse.
-        assert_eq!(keys::parse_admin_key(&keys::inst("inst-a")), None);
+        // The overrides and the instance record are keyed by the same id, and
+        // the instance record is iterated by prefix. Either namespace claiming
+        // the other would make an operator's decision arrive as an instance
+        // record, or the reverse.
         assert_eq!(keys::parse_inst_key(&keys::admin_ready("inst-a")), None);
         assert!(!keys::admin_ready("inst-a").starts_with(keys::INST_PREFIX));
         assert!(!keys::inst("inst-a").starts_with(keys::ADMIN_PREFIX));
-        // `inst-a` must not swallow `inst-ab`: the id is not the last segment,
-        // so the parse has to split from the right to stay unambiguous.
-        assert_eq!(
-            keys::parse_admin_key(&keys::admin_ready("inst-ab")),
-            Some(("inst-ab", keys::ADMIN_READY))
+        // Two overrides of one instance, and the same override of two
+        // instances, must all be distinct keys.
+        assert_ne!(
+            keys::admin_ready("inst-a"),
+            keys::admin_port_policy("inst-a")
         );
+        assert_ne!(keys::admin_ready("inst-a"), keys::admin_ready("inst-ab"));
         assert_eq!(keys::parse_node_info_key(&keys::node_status(1)), None);
         assert_eq!(keys::parse_node_info_key(&keys::inst("inst-a")), None);
         // `node/info/` and `node/status/` share a stem; neither may claim the other.

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -105,11 +105,29 @@ pub struct InstanceData {
     /// Operator traffic gate (`Admin.SetInstanceReady`). `None` means no
     /// operator ever set one, which reads as ready.
     ///
-    /// Carried in the instance record rather than a key of its own. A separate
-    /// key would only buy protection against a node whose build predates this
-    /// field rewriting the record and dropping it -- and that needs a cluster
-    /// containing a pre-feature node, which cannot happen: multi-node has never
-    /// been deployed, so by the time it is, every node will know this field.
+    /// Carried in the instance record rather than under a key of its own. Every
+    /// writer rewrites the whole record from its own in-memory copy, so a copy
+    /// that does not carry the gate drops it. Two paths get there:
+    ///
+    /// - A build that predates the field. Records are msgpack named maps, so it
+    ///   reads the record fine and just does not write the field back. This
+    ///   needs no cluster -- a single node rolled back is enough.
+    /// - A node on the *current* build that has not seen the gate yet. The lazy
+    ///   port-policy fetch rewrites the record on the first proxied connection,
+    ///   so between `SetInstanceReady` landing on one node and the sync reaching
+    ///   another, that other node can clobber it. Normally the window is one
+    ///   sync round; under a partition it is as long as the partition.
+    ///
+    /// A key of its own would survive both. It is still not worth one:
+    /// `port_policy` and `admin_port_policy` ride in the same record, are
+    /// rewritten by the same code, and are lost the same two ways, so guarding
+    /// one field of three buys inconsistency rather than safety.
+    ///
+    /// What differs is the cost, and it is worth being explicit that this is
+    /// not free: a lost `port_policy` is re-fetched and a lost
+    /// `admin_port_policy` falls back to what the instance reports, whereas a
+    /// lost gate silently returns an instance to rotation. Re-issuing the gate
+    /// rewrites the record and fixes it.
     #[serde(default)]
     pub admin_ready: Option<bool>,
 }

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -53,7 +53,8 @@ use std::{collections::BTreeMap, net::Ipv4Addr, path::Path, time::Duration};
 
 use anyhow::{Context, Result};
 
-use crate::time::now_secs;
+use crate::models::InstanceInfo;
+use crate::time::{encode_ts, now_secs};
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use wavekv::{node::NodeState, types::NodeId, Node};
@@ -138,6 +139,27 @@ pub struct InstanceData {
     /// rewrites the record and fixes it.
     #[serde(default)]
     pub ready: Option<bool>,
+}
+
+/// The record this node would publish for `info`.
+///
+/// Every writer rewrites the whole record, so every writer has to name every
+/// field -- and each hand-written copy is one more place a field added later
+/// can be forgotten. `admin_port_policy` was dropped that way once already.
+/// Going through one conversion makes the compiler the thing that remembers.
+impl From<&InstanceInfo> for InstanceData {
+    fn from(info: &InstanceInfo) -> Self {
+        Self {
+            app_id: info.app_id.clone(),
+            ip: info.ip,
+            public_key: info.public_key.clone(),
+            reg_time: encode_ts(info.reg_time),
+            port_policy: info.port_policy.clone(),
+            port_policy_hash: info.port_policy_hash.clone(),
+            admin_port_policy: info.admin_port_policy.clone(),
+            ready: info.ready,
+        }
+    }
 }
 
 /// The `inst/` records currently in the KV store, split by readability.

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -49,7 +49,12 @@ pub use https_client::{AppIdValidator, HttpsClientConfig};
 pub use sync_service::{fetch_peers_from_bootnode, PersistentWriteNotifier, WaveKvSyncService};
 use tracing::{error, warn};
 
-use std::{collections::BTreeMap, net::Ipv4Addr, path::Path, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::Ipv4Addr,
+    path::Path,
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 
@@ -98,47 +103,82 @@ pub struct InstanceData {
     /// the cache is invalidated and re-fetched lazily.
     #[serde(default)]
     pub port_policy_hash: String,
-    /// Operator-set override applied via the Admin RPC. Takes precedence over
-    /// the instance-reported `port_policy` when set, and survives app upgrades
-    /// (compose_hash changes do not clear it). Cleared explicitly via
-    /// ClearInstancePortPolicy.
+}
+
+/// The operator's traffic gate for one instance, under `admin/<id>/ready`.
+///
+/// A struct rather than a bare `bool` so the record can gain a field the way
+/// every other value here can -- who set it, when, why.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstanceGate {
+    /// false takes the instance out of its app's load-balancing rotation.
+    pub ready: bool,
+}
+
+/// The operator's port-policy override for one instance, under
+/// `admin/<id>/port_policy`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdminPortPolicy {
+    /// `None` is an operator having cleared the override, which is not the same
+    /// as never having set one. Absent lets the copy an older build left in the
+    /// instance record apply; cleared does not, or clearing an override would
+    /// be undone by that copy.
     #[serde(default)]
-    pub admin_port_policy: Option<PortPolicy>,
-    /// Operator traffic gate (`Admin.SetInstanceReady`). `None` means no
-    /// operator ever set one, which reads as ready.
-    ///
-    /// Carried in the instance record rather than under a key of its own. Every
-    /// writer rewrites the whole record from its own in-memory copy, so a copy
-    /// that does not carry the gate drops it.
-    ///
-    /// A build that predates the field is not one of those copies:
-    /// `sync_instance` writes as an update, and [`compat::carry_unknown_fields`]
-    /// re-appends the fields the writer does not declare, so a rolled-back node
-    /// round-trips the gate without understanding it.
-    ///
-    /// What the merge cannot cover is a node on the *current* build that has not
-    /// seen the gate yet, because that node does declare the field -- it just
-    /// holds `None`. That needs more than one node. The rewrite that reaches it
-    /// first is the CVM's own re-registration: `gateway_checker` re-registers
-    /// every 180s, and `new_client_by_id` writes the whole record from that
-    /// node's memory. So between `SetInstanceReady` landing on one node and the
-    /// sync reaching another, the CVM hitting that other node clobbers it. (The
-    /// lazy port-policy fetch rewrites the record too, but it only fires when no
-    /// policy is cached, which a current-build CVM never leaves true -- it
-    /// reports one at registration.)
-    ///
-    /// A key of its own would survive that. It is still not worth one:
-    /// `port_policy` and `admin_port_policy` ride in the same record, are
-    /// rewritten by the same code, and are lost the same way, so guarding one
-    /// field of three buys inconsistency rather than safety.
-    ///
-    /// What differs is the cost, and it is worth being explicit that this is
-    /// not free: a lost `port_policy` is re-fetched and a lost
-    /// `admin_port_policy` falls back to what the instance reports, whereas a
-    /// lost gate silently returns an instance to rotation. Re-issuing the gate
-    /// rewrites the record and fixes it.
-    #[serde(default)]
+    pub policy: Option<PortPolicy>,
+}
+
+/// What an operator has decided about one instance.
+///
+/// A read-side view assembled from the two keys above, not a stored record.
+/// Both live outside [`InstanceData`] because the writer is different, and that
+/// is what decides which key a fact lives in. `inst/` states what the CVM
+/// reports about itself, and is rewritten in full by whichever node the CVM
+/// registers against, from that node's own memory -- so anything in it the CVM
+/// does not report is dropped the moment a node that has not yet synced
+/// re-registers the instance. `gateway_checker` re-registers every 180s, so
+/// that window is hit routinely.
+///
+/// For a CVM-reported fact that is harmless: the CVM restates it. For the
+/// cached `port_policy` it is harmless too: it is re-fetched. For an operator's
+/// decision it is not, and the two fail in the direction that matters --
+/// a lost gate silently returns a quarantined instance to rotation, and a lost
+/// port-policy override silently widens the ports the app will serve. Only the
+/// operator writes those keys, so a re-registration cannot touch them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AdminOverrides {
+    pub port_policy: Option<PortPolicy>,
     pub ready: Option<bool>,
+}
+
+impl AdminOverrides {
+    /// Whether an operator has actually set anything.
+    pub fn is_empty(&self) -> bool {
+        self.port_policy.is_none() && self.ready.is_none()
+    }
+}
+
+/// The same two overrides as they were once stored: inside the instance record.
+///
+/// `InstanceData` no longer declares them, which is deliberate on both sides of
+/// an upgrade. Reading, this type recovers them for the move to their own keys.
+/// Writing, an undeclared field is one [`compat::carry_unknown_fields`]
+/// preserves verbatim, so a node still on the previous build keeps finding its
+/// copy where it left it for as long as the upgrade takes.
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyInstanceOverrides {
+    #[serde(default)]
+    admin_port_policy: Option<PortPolicy>,
+    #[serde(default)]
+    ready: Option<bool>,
+}
+
+impl From<LegacyInstanceOverrides> for AdminOverrides {
+    fn from(legacy: LegacyInstanceOverrides) -> Self {
+        Self {
+            port_policy: legacy.admin_port_policy,
+            ready: legacy.ready,
+        }
+    }
 }
 
 /// The record this node would publish for `info`.
@@ -147,6 +187,10 @@ pub struct InstanceData {
 /// field -- and each hand-written copy is one more place a field added later
 /// can be forgotten. `admin_port_policy` was dropped that way once already.
 /// Going through one conversion makes the compiler the thing that remembers.
+///
+/// What an operator set is deliberately absent: it lives under `admin/`,
+/// written only from the Admin RPCs, so this rewrite -- which any node performs
+/// on any registration -- cannot reach it.
 impl From<&InstanceInfo> for InstanceData {
     fn from(info: &InstanceInfo) -> Self {
         Self {
@@ -156,10 +200,34 @@ impl From<&InstanceInfo> for InstanceData {
             reg_time: encode_ts(info.reg_time),
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
-            admin_port_policy: info.admin_port_policy.clone(),
-            ready: info.ready,
         }
     }
+}
+
+/// The `admin/` records currently in the KV store, split by readability.
+#[derive(Debug, Default)]
+pub struct LoadedOverrides {
+    /// What each instance's readable override records say, keyed by instance
+    /// ID. An instance appears once both keys are accounted for; a field is
+    /// `None` when its key is absent, which is what lets the legacy copy in the
+    /// instance record still apply.
+    pub decoded: BTreeMap<String, AdminOverrides>,
+    /// Which of an instance's override keys exist, readable or not.
+    ///
+    /// Separate from `decoded` because absent and cleared are different
+    /// answers: a cleared port-policy override is a present record holding
+    /// `None`, and only this tells it from a key that was never written.
+    pub present: BTreeMap<String, BTreeSet<String>>,
+    /// Instance IDs whose override record is present but no longer decodes,
+    /// mapped to the decode error.
+    ///
+    /// Read as "unknown", not as "nothing is overridden". The gate is an
+    /// operator saying an instance must not be given work, so an unreadable
+    /// answer keeps it out of app-id rotation until the record is readable
+    /// again -- re-issuing either override rewrites it. Instance-id routing is
+    /// never gated, so the instance stays reachable for investigation either
+    /// way, which is the property the gate itself is built on.
+    pub unreadable: BTreeMap<String, String>,
 }
 
 /// The `inst/` records currently in the KV store, split by readability.
@@ -347,6 +415,11 @@ pub mod keys {
     use super::NodeId;
 
     pub const INST_PREFIX: &str = "inst/";
+    pub const ADMIN_PREFIX: &str = "admin/";
+    /// Suffix of the traffic-gate key. See [`admin_ready`].
+    pub const ADMIN_READY: &str = "ready";
+    /// Suffix of the port-policy override key. See [`admin_port_policy`].
+    pub const ADMIN_PORT_POLICY: &str = "port_policy";
     pub const NODE_PREFIX: &str = "node/";
     pub const NODE_INFO_PREFIX: &str = "node/info/";
     pub const NODE_STATUS_PREFIX: &str = "node/status/";
@@ -366,6 +439,29 @@ pub mod keys {
 
     pub fn inst(instance_id: &str) -> String {
         format!("{INST_PREFIX}{instance_id}")
+    }
+
+    /// Key for an instance's operator-set traffic gate.
+    ///
+    /// One key per override rather than one record holding both: WaveKV
+    /// resolves a conflict by taking a whole value, so two overrides sharing a
+    /// key means setting one on this node discards a peer's unsynced change to
+    /// the other. They are independent decisions and are set by independent
+    /// calls, so they get independent keys.
+    pub fn admin_ready(instance_id: &str) -> String {
+        format!("{ADMIN_PREFIX}{instance_id}/{ADMIN_READY}")
+    }
+
+    /// Key for an instance's operator-set port-policy override.
+    /// See [`admin_ready`] for why this is not a field of the same record.
+    pub fn admin_port_policy(instance_id: &str) -> String {
+        format!("{ADMIN_PREFIX}{instance_id}/{ADMIN_PORT_POLICY}")
+    }
+
+    /// Prefix covering every override key for one instance.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn admin_prefix(instance_id: &str) -> String {
+        format!("{ADMIN_PREFIX}{instance_id}/")
     }
 
     pub fn node_info(node_id: NodeId) -> String {
@@ -453,6 +549,16 @@ pub mod keys {
     /// Parse instance_id from key
     pub fn parse_inst_key(key: &str) -> Option<&str> {
         key.strip_prefix(INST_PREFIX)
+    }
+
+    /// Parse (instance_id, override name) from an admin/{instance_id}/{name} key.
+    ///
+    /// Split from the right, so an instance id is not required to be free of
+    /// `/` for the override name to come out right.
+    pub fn parse_admin_key(key: &str) -> Option<(&str, &str)> {
+        let rest = key.strip_prefix(ADMIN_PREFIX)?;
+        let (instance_id, name) = rest.rsplit_once('/')?;
+        (!instance_id.is_empty() && !name.is_empty()).then_some((instance_id, name))
     }
 
     /// Parse node_id from node/info/{node_id} key
@@ -699,11 +805,13 @@ pub(crate) struct FailWrite;
 #[cfg_attr(not(test), allow(dead_code))]
 impl FailWrite {
     /// The persistent `inst/` record, and its tombstone.
-    pub(crate) const INST: u8 = 0b001;
+    pub(crate) const INST: u8 = 0b0001;
     /// The ephemeral `conn/` key.
-    pub(crate) const CONN: u8 = 0b010;
+    pub(crate) const CONN: u8 = 0b0010;
     /// The ephemeral `handshake/` key.
-    pub(crate) const HANDSHAKE: u8 = 0b100;
+    pub(crate) const HANDSHAKE: u8 = 0b0100;
+    /// The persistent `admin/` record, and its tombstone.
+    pub(crate) const ADMIN: u8 = 0b1000;
 }
 
 /// Sync store wrapping two WaveKV Nodes (persistent and ephemeral).
@@ -876,6 +984,163 @@ impl KvStore {
             .put_encoded(keys::inst(instance_id), data, true)
     }
 
+    // ==================== Operator Override Sync ====================
+
+    /// Load every instance's operator-set overrides.
+    ///
+    /// A record that no longer decodes is reported rather than skipped. Skipping
+    /// it would read as "no operator has decided anything", which is the one
+    /// answer that must not be guessed: it returns a quarantined instance to
+    /// rotation and drops a port-policy override back to whatever the instance
+    /// says about itself. See [`LoadedOverrides::unreadable`].
+    pub fn load_all_instance_overrides(&self) -> LoadedOverrides {
+        let mut loaded = LoadedOverrides::default();
+        let store = self.persistent.read();
+        for (key, entry) in store.iter_by_prefix(keys::ADMIN_PREFIX) {
+            // A tombstone is a key that was deleted, which is the same as one
+            // that was never written.
+            let Some(bytes) = entry.value.as_ref() else {
+                continue;
+            };
+            let Some((instance_id, name)) = keys::parse_admin_key(key) else {
+                continue;
+            };
+            loaded
+                .present
+                .entry(instance_id.to_string())
+                .or_default()
+                .insert(name.to_string());
+            let overrides = loaded.decoded.entry(instance_id.to_string()).or_default();
+            let decoded = match name {
+                keys::ADMIN_READY => {
+                    decode::<InstanceGate>(bytes).map(|gate| overrides.ready = Some(gate.ready))
+                }
+                keys::ADMIN_PORT_POLICY => decode::<AdminPortPolicy>(bytes)
+                    .map(|stored| overrides.port_policy = stored.policy),
+                // A key this build does not know. A newer peer may have added
+                // one; leaving it alone is what lets it.
+                _ => continue,
+            };
+            if let Err(err) = decoded {
+                loaded
+                    .unreadable
+                    .insert(instance_id.to_string(), format!("{key}: {err:#}"));
+            }
+        }
+        loaded
+    }
+
+    /// The overrides an instance record still carries from before they had keys
+    /// of their own, for instances that have not been moved across yet.
+    ///
+    /// Read from the same `inst/` bytes as [`InstanceData`], through a type
+    /// that declares only the retired fields.
+    pub fn legacy_instance_overrides(&self) -> BTreeMap<String, AdminOverrides> {
+        self.persistent
+            .read()
+            .iter_decoded::<LegacyInstanceOverrides>(keys::INST_PREFIX)
+            .filter_map(|(key, legacy)| {
+                let overrides = AdminOverrides::from(legacy);
+                if overrides.is_empty() {
+                    return None;
+                }
+                Some((keys::parse_inst_key(&key)?.to_string(), overrides))
+            })
+            .collect()
+    }
+
+    /// Move any overrides still living in an instance record to their own keys.
+    ///
+    /// Runs on every reload rather than once at startup, because the source is
+    /// not only this node's own data directory: a node still on the previous
+    /// build writes overrides into `inst/`, and this is how they reach the new
+    /// keys during a rolling upgrade instead of being lost at that instance's
+    /// next re-registration.
+    ///
+    /// Per override, not per instance -- which is the point of them having a
+    /// key each. Only where the key does not exist at all: once it does it is
+    /// the answer, including when it says "no override", which is what clearing
+    /// one leaves behind. Without that rule, clearing an override here would be
+    /// undone by the stale copy an old node left in the instance record.
+    ///
+    /// Returns the keys written. Failures are logged and skipped: the next
+    /// reload tries again, and the read-side fallback keeps the override in
+    /// force in the meantime.
+    pub fn migrate_legacy_instance_overrides(&self) -> Vec<String> {
+        let legacy = self.legacy_instance_overrides();
+        if legacy.is_empty() {
+            return Vec::new();
+        }
+        let existing = self.load_all_instance_overrides();
+        let mut moved = Vec::new();
+        for (instance_id, overrides) in legacy {
+            let present = existing.present.get(&instance_id);
+            let has = |name: &str| present.is_some_and(|names| names.contains(name));
+            if let Some(ready) = overrides.ready {
+                if !has(keys::ADMIN_READY) {
+                    self.record_migration(
+                        &mut moved,
+                        keys::admin_ready(&instance_id),
+                        &InstanceGate { ready },
+                    );
+                }
+            }
+            if overrides.port_policy.is_some() && !has(keys::ADMIN_PORT_POLICY) {
+                self.record_migration(
+                    &mut moved,
+                    keys::admin_port_policy(&instance_id),
+                    &AdminPortPolicy {
+                        policy: overrides.port_policy,
+                    },
+                );
+            }
+        }
+        moved
+    }
+
+    fn record_migration<T: Serialize + serde::de::DeserializeOwned>(
+        &self,
+        moved: &mut Vec<String>,
+        key: String,
+        value: &T,
+    ) {
+        match self.put_admin_override(key.clone(), value) {
+            Ok(()) => moved.push(key),
+            Err(err) => warn!("failed to move operator override to {key}: {err:?}"),
+        }
+    }
+
+    /// Publish an instance's operator-set traffic gate.
+    pub fn sync_instance_gate(&self, instance_id: &str, gate: &InstanceGate) -> Result<()> {
+        self.put_admin_override(keys::admin_ready(instance_id), gate)
+    }
+
+    /// Publish an instance's operator-set port-policy override.
+    ///
+    /// A cleared override is written, not deleted: an absent key is what lets
+    /// the copy an older build left in the instance record apply, so deleting
+    /// would put the override straight back.
+    pub fn sync_instance_port_policy_override(
+        &self,
+        instance_id: &str,
+        data: &AdminPortPolicy,
+    ) -> Result<()> {
+        self.put_admin_override(keys::admin_port_policy(instance_id), data)
+    }
+
+    /// Written as a replacement rather than an update: each record states one
+    /// complete fact, so carrying a field a peer wrote would leave half of one
+    /// operator's decision beside half of another's.
+    fn put_admin_override<T: Serialize + serde::de::DeserializeOwned>(
+        &self,
+        key: String,
+        value: &T,
+    ) -> Result<()> {
+        #[cfg(test)]
+        self.injected_failure(FailWrite::ADMIN)?;
+        self.persistent.write().put_encoded(key, value, false)
+    }
+
     /// See [`KvStore::injected_failures`].
     #[cfg(test)]
     pub(crate) fn fail_writes_for_test(&self, mask: u8) {
@@ -906,7 +1171,14 @@ impl KvStore {
         // `inst/` -- the only one of the three that is persistent, and the one an
         // operator needs to know about -- is not masked by an ephemeral key that
         // also happened to fail.
-        let previous = self.delete_persistent(keys::inst(instance_id));
+        let previous = self.delete_persistent(keys::inst(instance_id), FailWrite::INST);
+        // The overrides outlive the instance record unless they are tombstoned
+        // too, and instance ids are recycled -- an id reused after a delete
+        // would inherit the gate and port policy an operator set for whatever
+        // ran under it before.
+        let gate = self.delete_persistent(keys::admin_ready(instance_id), FailWrite::ADMIN);
+        let override_policy =
+            self.delete_persistent(keys::admin_port_policy(instance_id), FailWrite::ADMIN);
         let conn = self.delete_ephemeral(keys::conn(instance_id, self.my_node_id), FailWrite::CONN);
         let handshake = self.delete_ephemeral(
             keys::handshake(instance_id, self.my_node_id),
@@ -914,14 +1186,16 @@ impl KvStore {
         );
 
         let previous = previous?;
+        gate?;
+        override_policy?;
         conn?;
         handshake?;
         Ok(previous.is_some_and(|entry| !entry.is_deleted()))
     }
 
-    fn delete_persistent(&self, key: String) -> Result<Option<wavekv::types::Entry>> {
+    fn delete_persistent(&self, key: String, _which: u8) -> Result<Option<wavekv::types::Entry>> {
         #[cfg(test)]
-        self.injected_failure(FailWrite::INST)?;
+        self.injected_failure(_which)?;
         self.persistent.write().delete(key)
     }
 
@@ -1164,6 +1438,16 @@ impl KvStore {
     /// Watch for remote instance changes (for updating local ProxyState)
     pub fn watch_instances(&self) -> watch::Receiver<()> {
         self.persistent.watch_prefix(keys::INST_PREFIX)
+    }
+
+    /// Watch for changes to any instance's operator-set overrides.
+    ///
+    /// A separate watcher because they are a separate key: a peer opening or
+    /// closing a traffic gate touches `admin/` and nothing else, so the
+    /// instance watcher never fires and the gate would sit in the store
+    /// unapplied on every node but the one that took the RPC.
+    pub fn watch_instance_overrides(&self) -> watch::Receiver<()> {
+        self.persistent.watch_prefix(keys::ADMIN_PREFIX)
     }
 
     /// Watch for remote node changes
@@ -2102,8 +2386,6 @@ mod value_encoding_tests {
                 reg_time: 1_700_000_100,
                 port_policy: None,
                 port_policy_hash: String::new(),
-                admin_port_policy: None,
-                ready: None,
             },
         )
         .expect("sync should succeed");
@@ -2377,8 +2659,6 @@ mod corruption_tests {
                 reg_time: 1,
                 port_policy: None,
                 port_policy_hash: String::new(),
-                admin_port_policy: None,
-                ready: None,
             },
         )
         .expect("seed");
@@ -2448,11 +2728,190 @@ mod corruption_tests {
         );
     }
 
-    /// The gate rides in the instance record, so its forward compatibility is
-    /// the record's. A build that adds a field must not make the record
-    /// unreadable to one that does not know it: msgpack named maps let the
-    /// older reader skip what it does not recognise. If this ever fails,
-    /// widening `InstanceData` has stopped being a no-op for older nodes.
+    /// Write an instance record the way the build before the overrides moved
+    /// out of it did: with both operator fields inside.
+    fn seed_legacy_record(
+        kv: &KvStore,
+        id: &str,
+        port_policy: Option<PortPolicy>,
+        ready: Option<bool>,
+    ) {
+        #[derive(serde::Serialize)]
+        struct LegacyRecord {
+            app_id: String,
+            ip: std::net::Ipv4Addr,
+            public_key: String,
+            reg_time: u64,
+            port_policy: Option<PortPolicy>,
+            port_policy_hash: String,
+            admin_port_policy: Option<PortPolicy>,
+            ready: Option<bool>,
+        }
+        let encoded = encode(&LegacyRecord {
+            app_id: "app".to_string(),
+            ip: "10.0.0.20".parse().unwrap(),
+            public_key: format!("key-{id}"),
+            reg_time: 1,
+            port_policy: None,
+            port_policy_hash: String::new(),
+            admin_port_policy: port_policy,
+            ready,
+        })
+        .expect("encode");
+        put_raw(kv, &keys::inst(id), &encoded);
+    }
+
+    fn restrictive() -> PortPolicy {
+        PortPolicy {
+            ports: BTreeMap::from([(8443, PortFlags { pp: false })]),
+            restrict_mode: true,
+        }
+    }
+
+    /// A gateway upgrading from a build that kept the overrides inside the
+    /// instance record has them only there, and nothing rewrites that record on
+    /// the operator's behalf. Losing the port-policy override silently widens
+    /// the ports the app serves, so the move has to happen on load.
+    #[test]
+    fn overrides_left_in_an_instance_record_are_moved_to_their_own_keys() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_legacy_record(&kv, "legacy", Some(restrictive()), Some(false));
+
+        // Until the move, the read-side fallback is what keeps them in force.
+        assert_eq!(
+            kv.legacy_instance_overrides()["legacy"],
+            AdminOverrides {
+                port_policy: Some(restrictive()),
+                ready: Some(false),
+            }
+        );
+        assert_eq!(
+            kv.migrate_legacy_instance_overrides(),
+            vec![
+                keys::admin_ready("legacy"),
+                keys::admin_port_policy("legacy")
+            ]
+        );
+        assert_eq!(
+            kv.load_all_instance_overrides().decoded["legacy"],
+            AdminOverrides {
+                port_policy: Some(restrictive()),
+                ready: Some(false),
+            }
+        );
+        assert!(
+            kv.migrate_legacy_instance_overrides().is_empty(),
+            "the move is not repeated once the keys exist"
+        );
+    }
+
+    /// One key per override, so a legacy record holding only one of them moves
+    /// only that one -- and the other stays open to being set later.
+    #[test]
+    fn each_override_is_moved_on_its_own() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_legacy_record(&kv, "legacy", None, Some(false));
+        assert_eq!(
+            kv.migrate_legacy_instance_overrides(),
+            vec![keys::admin_ready("legacy")]
+        );
+        let loaded = kv.load_all_instance_overrides();
+        assert_eq!(loaded.decoded["legacy"].ready, Some(false));
+        assert!(!loaded.present["legacy"].contains(keys::ADMIN_PORT_POLICY));
+    }
+
+    /// Two overrides in one record meant setting one on this node discarded a
+    /// peer's unsynced change to the other, because WaveKV resolves a conflict
+    /// by taking a whole value. Separate keys are what make them independent.
+    #[test]
+    fn setting_one_override_leaves_the_other_alone() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        // What a peer set, arriving through sync.
+        kv.sync_instance_port_policy_override(
+            "cvm",
+            &AdminPortPolicy {
+                policy: Some(restrictive()),
+            },
+        )
+        .expect("peer override");
+        // What this node sets, from a snapshot that never saw it.
+        kv.sync_instance_gate("cvm", &InstanceGate { ready: false })
+            .expect("gate");
+
+        assert_eq!(
+            kv.load_all_instance_overrides().decoded["cvm"],
+            AdminOverrides {
+                port_policy: Some(restrictive()),
+                ready: Some(false),
+            }
+        );
+    }
+
+    /// The instance record keeps its copy through the upgrade -- this build no
+    /// longer declares those fields, so `carry_unknown_fields` preserves them
+    /// and a node still on the previous build finds them where it left them.
+    /// That is also why an empty override record has to stop the move: without
+    /// it, clearing an override here would be undone by the stale copy.
+    #[test]
+    fn a_cleared_override_is_not_resurrected_from_the_instance_record() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_legacy_record(&kv, "legacy", Some(restrictive()), None);
+        assert_eq!(
+            kv.migrate_legacy_instance_overrides(),
+            vec![keys::admin_port_policy("legacy")]
+        );
+
+        // The operator clears it. Cleared is written, not deleted.
+        kv.sync_instance_port_policy_override("legacy", &AdminPortPolicy::default())
+            .expect("clear");
+        assert!(kv.load_all_instance_overrides().decoded["legacy"].is_empty());
+
+        assert!(
+            kv.migrate_legacy_instance_overrides().is_empty(),
+            "an override record that says nothing is still an answer"
+        );
+        assert!(
+            kv.load_all_instance_overrides().decoded["legacy"].is_empty(),
+            "the copy in the instance record must not come back"
+        );
+    }
+
+    /// Instance ids are recycled. An id reused after a delete would inherit the
+    /// gate and port policy an operator set for whatever ran under it before.
+    #[test]
+    fn deleting_an_instance_tombstones_its_overrides() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_instance(&kv, "cvm");
+        kv.sync_instance_gate("cvm", &InstanceGate { ready: false })
+            .expect("seed gate");
+        kv.sync_instance_port_policy_override(
+            "cvm",
+            &AdminPortPolicy {
+                policy: Some(restrictive()),
+            },
+        )
+        .expect("seed override");
+
+        kv.sync_delete_instance("cvm").expect("delete");
+        assert!(
+            !kv.load_all_instance_overrides().decoded.contains_key("cvm"),
+            "the override record must not outlive the instance"
+        );
+    }
+
+    /// A build that adds a field must not make the record unreadable to one
+    /// that does not know it: msgpack named maps let the older reader skip what
+    /// it does not recognise. If this ever fails, widening `InstanceData` has
+    /// stopped being a no-op for older nodes.
+    ///
+    /// `admin_port_policy` and `ready` stand in for the retired case as well as
+    /// the future one: this build no longer declares them, so they arrive here
+    /// the same way a field from a newer peer would.
     #[test]
     fn an_instance_record_with_an_unknown_field_still_decodes() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
@@ -2486,7 +2945,7 @@ mod corruption_tests {
 
         let loaded = kv.load_all_instances();
         assert!(loaded.undecodable.is_empty(), "{:?}", loaded.undecodable);
-        assert_eq!(loaded.decoded["future"].ready, Some(false));
+        assert_eq!(loaded.decoded["future"].public_key, "k");
     }
 
     #[test]
@@ -2623,8 +3082,6 @@ mod corruption_tests {
                     reg_time: 1,
                     port_policy: None,
                     port_policy_hash: String::new(),
-                    admin_port_policy: None,
-                    ready: None,
                 },
             )
             .expect("sync should succeed");
@@ -2751,6 +3208,14 @@ mod key_schema_tests {
     #[test]
     fn every_key_parses_back_to_what_built_it() {
         assert_eq!(keys::parse_inst_key(&keys::inst("inst-a")), Some("inst-a"));
+        assert_eq!(
+            keys::parse_admin_key(&keys::admin_ready("inst-a")),
+            Some(("inst-a", keys::ADMIN_READY))
+        );
+        assert_eq!(
+            keys::parse_admin_key(&keys::admin_port_policy("inst-a")),
+            Some(("inst-a", keys::ADMIN_PORT_POLICY))
+        );
         assert_eq!(keys::parse_node_info_key(&keys::node_info(42)), Some(42));
         assert_eq!(
             keys::parse_cert_domain(&keys::cert_attestation_latest("a.example")),
@@ -2768,6 +3233,15 @@ mod key_schema_tests {
     fn a_parser_refuses_a_key_from_another_namespace() {
         assert_eq!(keys::parse_inst_key(&keys::node_info(1)), None);
         assert_eq!(keys::parse_cert_domain(&keys::inst("inst-a")), None);
+        // The overrides and the instance record are keyed by the same id and
+        // iterated by prefix. Either namespace claiming the other would make an
+        // operator's decision arrive as an instance record, or the reverse.
+        assert_eq!(keys::parse_admin_key(&keys::inst("inst-a")), None);
+        assert_eq!(keys::parse_inst_key(&keys::admin_ready("inst-a")), None);
+        assert!(!keys::admin_ready("inst-a").starts_with(keys::INST_PREFIX));
+        assert!(!keys::inst("inst-a").starts_with(keys::ADMIN_PREFIX));
+        // `inst-a` must not swallow `inst-ab`.
+        assert!(!keys::admin_ready("inst-ab").starts_with(&keys::admin_prefix("inst-a")));
         assert_eq!(keys::parse_node_info_key(&keys::node_status(1)), None);
         assert_eq!(keys::parse_node_info_key(&keys::inst("inst-a")), None);
         // `node/info/` and `node/status/` share a stem; neither may claim the other.

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -129,7 +129,7 @@ pub struct InstanceData {
     /// lost gate silently returns an instance to rotation. Re-issuing the gate
     /// rewrites the record and fixes it.
     #[serde(default)]
-    pub admin_ready: Option<bool>,
+    pub ready: Option<bool>,
 }
 
 /// The `inst/` records currently in the KV store, split by readability.
@@ -2019,7 +2019,7 @@ mod corruption_tests {
             port_policy: Option<PortPolicy>,
             port_policy_hash: &'a str,
             admin_port_policy: Option<PortPolicy>,
-            admin_ready: Option<bool>,
+            ready: Option<bool>,
             reason: &'a str,
         }
         let widened = encode(&FutureRecord {
@@ -2030,7 +2030,7 @@ mod corruption_tests {
             port_policy: None,
             port_policy_hash: "",
             admin_port_policy: None,
-            admin_ready: Some(false),
+            ready: Some(false),
             reason: "under investigation",
         })
         .expect("encode should succeed");
@@ -2038,7 +2038,7 @@ mod corruption_tests {
 
         let loaded = kv.load_all_instances();
         assert!(loaded.undecodable.is_empty(), "{:?}", loaded.undecodable);
-        assert_eq!(loaded.decoded["future"].admin_ready, Some(false));
+        assert_eq!(loaded.decoded["future"].ready, Some(false));
     }
 
     #[test]
@@ -2172,7 +2172,7 @@ mod corruption_tests {
                     port_policy: None,
                     port_policy_hash: String::new(),
                     admin_port_policy: None,
-                    admin_ready: None,
+                    ready: None,
                 },
             )
             .expect("sync should succeed");

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -767,10 +767,13 @@ impl KvStore {
     /// Returns whether a live record (including an undecodable one) existed
     /// before the tombstone was written.
     pub fn sync_delete_instance(&self, instance_id: &str) -> Result<bool> {
-        // Every delete is attempted even if an earlier one fails, and the first
-        // error is returned afterwards. Short-circuiting on `?` would leave the
-        // later keys behind while the `inst/` tombstone is already published,
-        // and nothing garbage-collects orphans.
+        // Every delete is attempted even if an earlier one fails. Short-circuiting
+        // on `?` would leave the later keys behind while the `inst/` tombstone is
+        // already published, and nothing garbage-collects orphans. They are then
+        // reported in the order they were issued, so a failure to tombstone
+        // `inst/` -- the only one of the three that is persistent, and the one an
+        // operator needs to know about -- is not masked by an ephemeral key that
+        // also happened to fail.
         let previous = self.persistent.write().delete(keys::inst(instance_id));
         let conn = self
             .ephemeral
@@ -781,9 +784,10 @@ impl KvStore {
             .write()
             .delete(keys::handshake(instance_id, self.my_node_id));
 
+        let previous = previous?;
         conn?;
         handshake?;
-        Ok(previous?.is_some_and(|entry| !entry.is_deleted()))
+        Ok(previous.is_some_and(|entry| !entry.is_deleted()))
     }
 
     /// Load all instances from the sync store.

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -907,7 +907,7 @@ impl KvStore {
     /// the ACME account and DNS credentials is the difference between a restart
     /// and a rebuild.
     ///
-    /// `wal_sync_interval` is how long a write may sit in the page cache before
+    /// `wal_sync_window` is how long a write may sit in the page cache before
     /// the log is forced to disk; `None` forces every write before it returns.
     /// It applies only to the persistent store — the ephemeral one keeps no log
     /// and never touches the disk.
@@ -915,11 +915,13 @@ impl KvStore {
         my_node_id: NodeId,
         peer_ids: Vec<NodeId>,
         data_dir: impl AsRef<Path>,
-        wal_sync_interval: Option<Duration>,
+        wal_sync_window: Option<Duration>,
     ) -> Result<Self> {
         let data_dir = data_dir.as_ref();
         let node_config = wavekv::NodeConfig {
-            wal_sync_interval,
+            // wavekv still calls it an interval; the gateway calls it a window
+            // because zero here means "no window", not "off".
+            wal_sync_interval: wal_sync_window,
             ..Default::default()
         };
         let persistent = match Node::with_persistence_and_config(

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -108,25 +108,28 @@ pub struct InstanceData {
     ///
     /// Carried in the instance record rather than under a key of its own. Every
     /// writer rewrites the whole record from its own in-memory copy, so a copy
-    /// that does not carry the gate drops it. Two paths get there:
+    /// that does not carry the gate drops it.
     ///
-    /// - A build that predates the field. Records are msgpack named maps, so it
-    ///   reads the record fine and just does not write the field back. This
-    ///   needs no cluster -- a single node rolled back is enough.
-    /// - A node on the *current* build that has not seen the gate yet, once
-    ///   there is more than one node. The rewrite that reaches it first is the
-    ///   CVM's own re-registration: `gateway_checker` re-registers every 180s,
-    ///   and `new_client_by_id` writes the whole record from that node's memory.
-    ///   So between `SetInstanceReady` landing on one node and the sync reaching
-    ///   another, the CVM hitting that other node clobbers it. (The lazy
-    ///   port-policy fetch rewrites the record too, but it only fires when no
-    ///   policy is cached, which a current-build CVM never leaves true -- it
-    ///   reports one at registration.)
+    /// A build that predates the field is not one of those copies:
+    /// `sync_instance` writes as an update, and [`compat::carry_unknown_fields`]
+    /// re-appends the fields the writer does not declare, so a rolled-back node
+    /// round-trips the gate without understanding it.
     ///
-    /// A key of its own would survive both. It is still not worth one:
+    /// What the merge cannot cover is a node on the *current* build that has not
+    /// seen the gate yet, because that node does declare the field -- it just
+    /// holds `None`. That needs more than one node. The rewrite that reaches it
+    /// first is the CVM's own re-registration: `gateway_checker` re-registers
+    /// every 180s, and `new_client_by_id` writes the whole record from that
+    /// node's memory. So between `SetInstanceReady` landing on one node and the
+    /// sync reaching another, the CVM hitting that other node clobbers it. (The
+    /// lazy port-policy fetch rewrites the record too, but it only fires when no
+    /// policy is cached, which a current-build CVM never leaves true -- it
+    /// reports one at registration.)
+    ///
+    /// A key of its own would survive that. It is still not worth one:
     /// `port_policy` and `admin_port_policy` ride in the same record, are
-    /// rewritten by the same code, and are lost the same two ways, so guarding
-    /// one field of three buys inconsistency rather than safety.
+    /// rewritten by the same code, and are lost the same way, so guarding one
+    /// field of three buys inconsistency rather than safety.
     ///
     /// What differs is the cost, and it is worth being explicit that this is
     /// not free: a lost `port_policy` is re-fetched and a lost
@@ -2078,6 +2081,7 @@ mod value_encoding_tests {
                 port_policy: None,
                 port_policy_hash: String::new(),
                 admin_port_policy: None,
+                ready: None,
             },
         )
         .expect("sync should succeed");

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -10,7 +10,7 @@
 //! Key schema:
 //!
 //! # Persistent WaveKV (needs persistence + sync)
-//! - `inst/{instance_id}` → InstanceData
+//! - `inst/{instance_id}` → InstanceRecord
 //! - `node/{node_id}` → NodeData
 //! - `dns_cred/{cred_id}` → DnsCredential
 //! - `dns_cred_default` → cred_id (default credential ID)
@@ -81,9 +81,17 @@ pub struct PortPolicy {
     pub restrict_mode: bool,
 }
 
-/// Instance core data (persistent)
+/// What a CVM registered, stored at `inst/<instance_id>`.
+///
+/// Every field here came from the CVM, which is what makes it safe for any node
+/// to rewrite the whole record on any registration -- and what decides that an
+/// operator's decisions do not live here. Those are separate keys; see
+/// [`PortPolicyOverride`].
+///
+/// The assembled view the proxy routes on is [`crate::models::InstanceInfo`],
+/// which is this plus those keys plus a live connection count.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct InstanceData {
+pub struct InstanceRecord {
     pub app_id: String,
     pub ip: Ipv4Addr,
     pub public_key: String,
@@ -119,7 +127,7 @@ pub enum PortPolicyOverride {
 /// The overrides an instance record still carries from before they had keys of
 /// their own.
 ///
-/// `InstanceData` no longer declares these fields, which is deliberate on both
+/// `InstanceRecord` no longer declares these fields, which is deliberate on both
 /// sides of an upgrade. Reading, this type recovers them for the move across.
 /// Writing, an undeclared field is one [`compat::carry_unknown_fields`]
 /// preserves verbatim, so a node still on the previous build keeps finding its
@@ -148,7 +156,7 @@ impl LegacyOverrides {
 /// What an operator set is deliberately absent: it lives under `admin/`,
 /// written only from the Admin RPCs, so this rewrite -- which any node performs
 /// on any registration -- cannot reach it.
-impl From<&InstanceInfo> for InstanceData {
+impl From<&InstanceInfo> for InstanceRecord {
     fn from(info: &InstanceInfo) -> Self {
         Self {
             app_id: info.app_id.clone(),
@@ -172,7 +180,7 @@ impl From<&InstanceInfo> for InstanceData {
 #[derive(Debug, Default)]
 pub struct LoadedInstances {
     /// Records that decoded successfully, keyed by instance ID.
-    pub decoded: BTreeMap<String, InstanceData>,
+    pub decoded: BTreeMap<String, InstanceRecord>,
     /// Instance IDs whose stored bytes are present but no longer decode,
     /// mapped to the decode error. Loading does not log these: the reload
     /// path reports them on transitions, and read-only listings must stay
@@ -711,7 +719,7 @@ impl GetPutCodec for NodeState {
     }
 }
 
-/// Which of an instance's records a write is touching.
+/// Which of an instance's five keys a write is touching.
 ///
 /// Named at every call site because the delete path issues all of them and
 /// reports them individually: an operator can do something about an `inst/`
@@ -722,7 +730,7 @@ impl GetPutCodec for NodeState {
 /// write paths take one instead of a `u8` that means nothing outside a test
 /// build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum InstanceRecord {
+pub(crate) enum InstanceKey {
     /// The persistent `inst/` record, and its tombstone.
     Instance,
     /// The persistent `admin/<id>/ready` record, and its tombstone.
@@ -735,7 +743,7 @@ pub(crate) enum InstanceRecord {
     Handshake,
 }
 
-impl InstanceRecord {
+impl InstanceKey {
     /// What an error message calls it.
     fn name(self) -> &'static str {
         match self {
@@ -923,8 +931,8 @@ impl KvStore {
     // ==================== Instance Sync ====================
 
     /// Sync instance data to other nodes
-    pub fn sync_instance(&self, instance_id: &str, data: &InstanceData) -> Result<()> {
-        self.injected_failure(InstanceRecord::Instance)?;
+    pub fn sync_instance(&self, instance_id: &str, data: &InstanceRecord) -> Result<()> {
+        self.injected_failure(InstanceKey::Instance)?;
         self.persistent
             .write()
             .put_encoded(keys::inst(instance_id), data, true)
@@ -961,7 +969,7 @@ impl KvStore {
 
     /// Publish an instance's operator-set traffic gate.
     pub fn set_instance_gate(&self, instance_id: &str, ready: bool) -> Result<()> {
-        self.put_admin_override(InstanceRecord::Gate, keys::admin_ready(instance_id), &ready)
+        self.put_admin_override(InstanceKey::Gate, keys::admin_ready(instance_id), &ready)
     }
 
     /// Publish an instance's operator-set port-policy override. `None` clears it.
@@ -975,7 +983,7 @@ impl KvStore {
         policy: Option<PortPolicy>,
     ) -> Result<()> {
         self.put_admin_override(
-            InstanceRecord::PortPolicyOverride,
+            InstanceKey::PortPolicyOverride,
             keys::admin_port_policy(instance_id),
             &policy,
         )
@@ -984,7 +992,7 @@ impl KvStore {
     /// The overrides an instance record still carries from before they had keys
     /// of their own.
     ///
-    /// Read from the same `inst/` bytes as [`InstanceData`], through a type
+    /// Read from the same `inst/` bytes as [`InstanceRecord`], through a type
     /// that declares only the retired fields. Bulk rather than per instance
     /// because the only caller wants to know whether *any* remain.
     pub fn legacy_instance_overrides(&self) -> BTreeMap<String, LegacyOverrides> {
@@ -1025,7 +1033,7 @@ impl KvStore {
                 if matches!(self.instance_gate(&instance_id), Ok(None)) {
                     self.record_migration(
                         &mut moved,
-                        InstanceRecord::Gate,
+                        InstanceKey::Gate,
                         keys::admin_ready(&instance_id),
                         &ready,
                     );
@@ -1036,7 +1044,7 @@ impl KvStore {
             {
                 self.record_migration(
                     &mut moved,
-                    InstanceRecord::PortPolicyOverride,
+                    InstanceKey::PortPolicyOverride,
                     keys::admin_port_policy(&instance_id),
                     &legacy.admin_port_policy,
                 );
@@ -1048,7 +1056,7 @@ impl KvStore {
     fn record_migration<T: Serialize + serde::de::DeserializeOwned>(
         &self,
         moved: &mut Vec<String>,
-        record: InstanceRecord,
+        record: InstanceKey,
         key: String,
         value: &T,
     ) {
@@ -1063,7 +1071,7 @@ impl KvStore {
     /// operator's decision beside half of another's.
     fn put_admin_override<T: Serialize + serde::de::DeserializeOwned>(
         &self,
-        record: InstanceRecord,
+        record: InstanceKey,
         key: String,
         value: &T,
     ) -> Result<()> {
@@ -1075,7 +1083,7 @@ impl KvStore {
     /// Fail every write touching one of `records` until called again. See
     /// [`KvStore::injected_failures`].
     #[cfg(test)]
-    pub(crate) fn fail_writes_for_test(&self, records: &[InstanceRecord]) {
+    pub(crate) fn fail_writes_for_test(&self, records: &[InstanceKey]) {
         let mask = records.iter().fold(0u8, |mask, record| mask | record.bit());
         self.injected_failures
             .store(mask, std::sync::atomic::Ordering::Relaxed);
@@ -1084,7 +1092,7 @@ impl KvStore {
     /// Deliberately terse: what an operator reads is the context the write path
     /// adds, so a test that asserts on the message is asserting on the real one.
     #[cfg(test)]
-    fn injected_failure(&self, record: InstanceRecord) -> Result<()> {
+    fn injected_failure(&self, record: InstanceKey) -> Result<()> {
         let mask = self
             .injected_failures
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -1096,7 +1104,7 @@ impl KvStore {
     /// in both instead of carrying a `cfg` in their bodies.
     #[cfg(not(test))]
     #[inline(always)]
-    fn injected_failure(&self, _record: InstanceRecord) -> Result<()> {
+    fn injected_failure(&self, _record: InstanceKey) -> Result<()> {
         Ok(())
     }
 
@@ -1112,15 +1120,15 @@ impl KvStore {
         // `inst/` -- the only one of the three that is persistent, and the one an
         // operator needs to know about -- is not masked by an ephemeral key that
         // also happened to fail.
-        let previous = self.delete_persistent(keys::inst(instance_id), InstanceRecord::Instance);
+        let previous = self.delete_persistent(keys::inst(instance_id), InstanceKey::Instance);
         // The overrides outlive the instance record unless they are tombstoned
         // too, and instance ids are recycled -- an id reused after a delete
         // would inherit the gate and port policy an operator set for whatever
         // ran under it before.
-        let gate = self.delete_persistent(keys::admin_ready(instance_id), InstanceRecord::Gate);
+        let gate = self.delete_persistent(keys::admin_ready(instance_id), InstanceKey::Gate);
         let override_policy = self.delete_persistent(
             keys::admin_port_policy(instance_id),
-            InstanceRecord::PortPolicyOverride,
+            InstanceKey::PortPolicyOverride,
         );
         let observations = self.sync_forget_local_observations(instance_id);
 
@@ -1143,11 +1151,11 @@ impl KvStore {
     pub fn sync_forget_local_observations(&self, instance_id: &str) -> Result<()> {
         let conn = self.delete_ephemeral(
             keys::conn(instance_id, self.my_node_id),
-            InstanceRecord::Connections,
+            InstanceKey::Connections,
         );
         let handshake = self.delete_ephemeral(
             keys::handshake(instance_id, self.my_node_id),
-            InstanceRecord::Handshake,
+            InstanceKey::Handshake,
         );
         conn?;
         handshake?;
@@ -1157,7 +1165,7 @@ impl KvStore {
     fn delete_persistent(
         &self,
         key: String,
-        record: InstanceRecord,
+        record: InstanceKey,
     ) -> Result<Option<wavekv::types::Entry>> {
         self.injected_failure(record)
             .and_then(|()| self.persistent.write().delete(key))
@@ -1167,7 +1175,7 @@ impl KvStore {
     fn delete_ephemeral(
         &self,
         key: String,
-        record: InstanceRecord,
+        record: InstanceKey,
     ) -> Result<Option<wavekv::types::Entry>> {
         self.injected_failure(record)
             .and_then(|()| self.ephemeral.write().delete(key))
@@ -1180,7 +1188,7 @@ impl KvStore {
         for (key, result) in self
             .persistent
             .read()
-            .iter_decoded_strict::<InstanceData>(keys::INST_PREFIX)
+            .iter_decoded_strict::<InstanceRecord>(keys::INST_PREFIX)
         {
             let Some(instance_id) = keys::parse_inst_key(&key) else {
                 continue;
@@ -2314,7 +2322,7 @@ mod value_encoding_tests {
 
     /// An instance record as some later release will declare it.
     #[derive(Debug, Serialize, Deserialize)]
-    struct FutureInstanceData {
+    struct FutureInstanceRecord {
         app_id: String,
         ip: Ipv4Addr,
         public_key: String,
@@ -2332,7 +2340,7 @@ mod value_encoding_tests {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let kv = KvStore::new(1, vec![], dir.path(), None).expect("failed to create kv store");
 
-        let written_by_a_newer_node = encode(&FutureInstanceData {
+        let written_by_a_newer_node = encode(&FutureInstanceRecord {
             app_id: "app".to_string(),
             ip: Ipv4Addr::new(10, 0, 0, 1),
             public_key: "pubkey".to_string(),
@@ -2348,7 +2356,7 @@ mod value_encoding_tests {
         // This build re-registers the instance, knowing nothing of the new field.
         kv.sync_instance(
             "app",
-            &InstanceData {
+            &InstanceRecord {
                 app_id: "app".to_string(),
                 ip: Ipv4Addr::new(10, 0, 0, 2),
                 public_key: "pubkey".to_string(),
@@ -2365,7 +2373,7 @@ mod value_encoding_tests {
             .get(&keys::inst("app"))
             .and_then(|entry| entry.value)
             .expect("record should exist");
-        let seen_by_a_newer_node: FutureInstanceData =
+        let seen_by_a_newer_node: FutureInstanceRecord =
             decode(&stored).expect("the newer node must still read its own field");
         assert_eq!(
             seen_by_a_newer_node.health_probe_path, "/healthz",
@@ -2376,7 +2384,7 @@ mod value_encoding_tests {
             Ipv4Addr::new(10, 0, 0, 2),
             "the writer's own fields must still take effect"
         );
-        let seen_by_this_build: InstanceData =
+        let seen_by_this_build: InstanceRecord =
             decode(&stored).expect("this build must still read the record");
         assert_eq!(seen_by_this_build.reg_time, 1_700_000_100);
     }
@@ -2621,7 +2629,7 @@ mod corruption_tests {
     fn seed_instance(kv: &KvStore, id: &str) {
         kv.sync_instance(
             id,
-            &InstanceData {
+            &InstanceRecord {
                 app_id: "app".to_string(),
                 ip: "10.0.0.20".parse().unwrap(),
                 public_key: "key".to_string(),
@@ -2643,7 +2651,7 @@ mod corruption_tests {
         let kv = test_kv(dir.path());
         seed_instance(&kv, "cvm");
 
-        kv.fail_writes_for_test(&[InstanceRecord::Connections]);
+        kv.fail_writes_for_test(&[InstanceKey::Connections]);
         kv.sync_delete_instance("cvm")
             .expect_err("the conn delete was made to fail");
         kv.fail_writes_for_test(&[]);
@@ -2675,9 +2683,9 @@ mod corruption_tests {
         seed_instance(&kv, "cvm");
 
         kv.fail_writes_for_test(&[
-            InstanceRecord::Instance,
-            InstanceRecord::Connections,
-            InstanceRecord::Handshake,
+            InstanceKey::Instance,
+            InstanceKey::Connections,
+            InstanceKey::Handshake,
         ]);
         let err = kv
             .sync_delete_instance("cvm")
@@ -2686,11 +2694,11 @@ mod corruption_tests {
 
         let message = format!("{err:#}");
         assert!(
-            message.contains(InstanceRecord::Instance.name()),
+            message.contains(InstanceKey::Instance.name()),
             "expected the instance record to be named, got: {message}"
         );
         assert!(
-            !message.contains(InstanceRecord::Handshake.name()),
+            !message.contains(InstanceKey::Handshake.name()),
             "the ephemeral failure must not mask it, got: {message}"
         );
     }
@@ -2877,7 +2885,7 @@ mod corruption_tests {
 
     /// A build that adds a field must not make the record unreadable to one
     /// that does not know it: msgpack named maps let the older reader skip what
-    /// it does not recognise. If this ever fails, widening `InstanceData` has
+    /// it does not recognise. If this ever fails, widening `InstanceRecord` has
     /// stopped being a no-op for older nodes.
     ///
     /// `admin_port_policy` and `ready` stand in for the retired case as well as
@@ -3046,7 +3054,7 @@ mod corruption_tests {
             let kv = test_kv(&data_dir);
             kv.sync_instance(
                 "cvm",
-                &InstanceData {
+                &InstanceRecord {
                     app_id: "app".to_string(),
                     ip: "10.0.0.20".parse().unwrap(),
                     public_key: "key".to_string(),

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -112,11 +112,15 @@ pub struct InstanceData {
     /// - A build that predates the field. Records are msgpack named maps, so it
     ///   reads the record fine and just does not write the field back. This
     ///   needs no cluster -- a single node rolled back is enough.
-    /// - A node on the *current* build that has not seen the gate yet. The lazy
-    ///   port-policy fetch rewrites the record on the first proxied connection,
-    ///   so between `SetInstanceReady` landing on one node and the sync reaching
-    ///   another, that other node can clobber it. Normally the window is one
-    ///   sync round; under a partition it is as long as the partition.
+    /// - A node on the *current* build that has not seen the gate yet, once
+    ///   there is more than one node. The rewrite that reaches it first is the
+    ///   CVM's own re-registration: `gateway_checker` re-registers every 180s,
+    ///   and `new_client_by_id` writes the whole record from that node's memory.
+    ///   So between `SetInstanceReady` landing on one node and the sync reaching
+    ///   another, the CVM hitting that other node clobbers it. (The lazy
+    ///   port-policy fetch rewrites the record too, but it only fires when no
+    ///   policy is cached, which a current-build CVM never leaves true -- it
+    ///   reports one at registration.)
     ///
     /// A key of its own would survive both. It is still not worth one:
     /// `port_policy` and `admin_port_policy` ride in the same record, are
@@ -629,6 +633,22 @@ impl GetPutCodec for NodeState {
     }
 }
 
+/// Which write [`KvStore::fail_writes_for_test`] should fail.
+///
+/// Named at every call site rather than only under `cfg(test)`, so the deletes
+/// below read the same in both builds.
+pub(crate) struct FailWrite;
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl FailWrite {
+    /// The persistent `inst/` record, and its tombstone.
+    pub(crate) const INST: u8 = 0b001;
+    /// The ephemeral `conn/` key.
+    pub(crate) const CONN: u8 = 0b010;
+    /// The ephemeral `handshake/` key.
+    pub(crate) const HANDSHAKE: u8 = 0b100;
+}
+
 /// Sync store wrapping two WaveKV Nodes (persistent and ephemeral).
 ///
 /// This is the sync layer - not the primary data store.
@@ -641,6 +661,19 @@ pub struct KvStore {
     ephemeral: Node,
     /// This gateway's node ID
     my_node_id: NodeId,
+    /// Which instance writes to fail, so the paths that report a failure can
+    /// be tested at all.
+    ///
+    /// The real failures here are WAL I/O -- no space, permission denied, the
+    /// data volume unmounted -- and none of them can be provoked from a test
+    /// without a filesystem to sabotage. Faking the outcome is the only way to
+    /// cover the code that reports them, which is the whole reason
+    /// `persist_instance_record` returns a `Result` and the whole reason
+    /// `sync_delete_instance` does not short-circuit.
+    ///
+    /// A bitmask of [`FailWrite`].
+    #[cfg(test)]
+    injected_failures: std::sync::Arc<std::sync::atomic::AtomicU8>,
 }
 
 /// Whether opening the persistent store failed because the storage is
@@ -738,6 +771,8 @@ impl KvStore {
             persistent,
             ephemeral,
             my_node_id,
+            #[cfg(test)]
+            injected_failures: Default::default(),
         })
     }
 
@@ -757,9 +792,29 @@ impl KvStore {
 
     /// Sync instance data to other nodes
     pub fn sync_instance(&self, instance_id: &str, data: &InstanceData) -> Result<()> {
+        #[cfg(test)]
+        self.injected_failure(FailWrite::INST)?;
         self.persistent
             .write()
             .put_encoded(keys::inst(instance_id), data)
+    }
+
+    /// See [`KvStore::injected_failures`].
+    #[cfg(test)]
+    pub(crate) fn fail_writes_for_test(&self, mask: u8) {
+        self.injected_failures
+            .store(mask, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn injected_failure(&self, which: u8) -> Result<()> {
+        let mask = self
+            .injected_failures
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if mask & which != 0 {
+            anyhow::bail!("injected store failure for {which:#04b}");
+        }
+        Ok(())
     }
 
     /// Sync instance deletion to other nodes
@@ -774,20 +829,29 @@ impl KvStore {
         // `inst/` -- the only one of the three that is persistent, and the one an
         // operator needs to know about -- is not masked by an ephemeral key that
         // also happened to fail.
-        let previous = self.persistent.write().delete(keys::inst(instance_id));
-        let conn = self
-            .ephemeral
-            .write()
-            .delete(keys::conn(instance_id, self.my_node_id));
-        let handshake = self
-            .ephemeral
-            .write()
-            .delete(keys::handshake(instance_id, self.my_node_id));
+        let previous = self.delete_persistent(keys::inst(instance_id));
+        let conn = self.delete_ephemeral(keys::conn(instance_id, self.my_node_id), FailWrite::CONN);
+        let handshake = self.delete_ephemeral(
+            keys::handshake(instance_id, self.my_node_id),
+            FailWrite::HANDSHAKE,
+        );
 
         let previous = previous?;
         conn?;
         handshake?;
         Ok(previous.is_some_and(|entry| !entry.is_deleted()))
+    }
+
+    fn delete_persistent(&self, key: String) -> Result<Option<wavekv::types::Entry>> {
+        #[cfg(test)]
+        self.injected_failure(FailWrite::INST)?;
+        self.persistent.write().delete(key)
+    }
+
+    fn delete_ephemeral(&self, key: String, _which: u8) -> Result<Option<wavekv::types::Entry>> {
+        #[cfg(test)]
+        self.injected_failure(_which)?;
+        self.ephemeral.write().delete(key)
     }
 
     /// Load all instances from the sync store.
@@ -1998,6 +2062,87 @@ mod corruption_tests {
             .write()
             .put(key.to_string(), value.to_vec())
             .expect("raw put should succeed");
+    }
+
+    fn seed_instance(kv: &KvStore, id: &str) {
+        kv.sync_instance(
+            id,
+            &InstanceData {
+                app_id: "app".to_string(),
+                ip: "10.0.0.20".parse().unwrap(),
+                public_key: "key".to_string(),
+                reg_time: 1,
+                port_policy: None,
+                port_policy_hash: String::new(),
+                admin_port_policy: None,
+                ready: None,
+            },
+        )
+        .expect("seed");
+        kv.sync_connections(id, 0).expect("seed conn");
+        kv.sync_instance_handshake(id, 1).expect("seed handshake");
+    }
+
+    /// Short-circuiting on `?` would publish the `inst/` tombstone and then
+    /// leave the ephemeral keys behind, and nothing garbage-collects orphans.
+    #[test]
+    fn a_failed_delete_does_not_abandon_the_remaining_keys() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_instance(&kv, "cvm");
+
+        kv.fail_writes_for_test(FailWrite::CONN);
+        kv.sync_delete_instance("cvm")
+            .expect_err("the conn delete was made to fail");
+        kv.fail_writes_for_test(0);
+
+        assert!(
+            kv.persistent
+                .read()
+                .get(&keys::inst("cvm"))
+                .is_none_or(|entry| entry.is_deleted()),
+            "the inst/ tombstone should still have been written"
+        );
+        assert!(
+            kv.ephemeral
+                .read()
+                .get(&keys::handshake("cvm", kv.my_node_id))
+                .is_none_or(|entry| entry.is_deleted()),
+            "the handshake delete must be attempted even after conn/ failed"
+        );
+    }
+
+    /// `inst/` is the only one of the three that is persistent, and the only
+    /// one an operator can do anything about, so its failure must not be
+    /// masked by an ephemeral key that also happened to fail.
+    #[test]
+    fn the_persistent_failure_is_the_one_reported() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_instance(&kv, "cvm");
+
+        kv.fail_writes_for_test(FailWrite::INST | FailWrite::CONN | FailWrite::HANDSHAKE);
+        let err = kv
+            .sync_delete_instance("cvm")
+            .expect_err("all three were made to fail");
+        kv.fail_writes_for_test(0);
+
+        assert!(
+            format!("{err:#}").contains(&format!("{:#04b}", FailWrite::INST)),
+            "expected the inst/ failure, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_clean_delete_still_reports_that_the_record_existed() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let kv = test_kv(dir.path());
+        seed_instance(&kv, "cvm");
+        assert!(kv.sync_delete_instance("cvm").expect("delete"));
+        assert!(
+            !kv.sync_delete_instance("cvm").expect("second delete"),
+            "a tombstone is not a live record"
+        );
     }
 
     /// The gate rides in the instance record, so its forward compatibility is

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -102,6 +102,16 @@ pub struct InstanceData {
     /// ClearInstancePortPolicy.
     #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
+    /// Operator traffic gate (`Admin.SetInstanceReady`). `None` means no
+    /// operator ever set one, which reads as ready.
+    ///
+    /// Carried in the instance record rather than a key of its own. A separate
+    /// key would only buy protection against a node whose build predates this
+    /// field rewriting the record and dropping it -- and that needs a cluster
+    /// containing a pre-feature node, which cannot happen: multi-node has never
+    /// been deployed, so by the time it is, every node will know this field.
+    #[serde(default)]
+    pub admin_ready: Option<bool>,
 }
 
 /// The `inst/` records currently in the KV store, split by readability.
@@ -739,15 +749,23 @@ impl KvStore {
     /// Returns whether a live record (including an undecodable one) existed
     /// before the tombstone was written.
     pub fn sync_delete_instance(&self, instance_id: &str) -> Result<bool> {
-        let previous = self.persistent.write().delete(keys::inst(instance_id))?;
-        self.ephemeral
+        // Every delete is attempted even if an earlier one fails, and the first
+        // error is returned afterwards. Short-circuiting on `?` would leave the
+        // later keys behind while the `inst/` tombstone is already published,
+        // and nothing garbage-collects orphans.
+        let previous = self.persistent.write().delete(keys::inst(instance_id));
+        let conn = self
+            .ephemeral
             .write()
-            .delete(keys::conn(instance_id, self.my_node_id))?;
-        // Delete this node's handshake record
-        self.ephemeral
+            .delete(keys::conn(instance_id, self.my_node_id));
+        let handshake = self
+            .ephemeral
             .write()
-            .delete(keys::handshake(instance_id, self.my_node_id))?;
-        Ok(previous.is_some_and(|entry| !entry.is_deleted()))
+            .delete(keys::handshake(instance_id, self.my_node_id));
+
+        conn?;
+        handshake?;
+        Ok(previous?.is_some_and(|entry| !entry.is_deleted()))
     }
 
     /// Load all instances from the sync store.
@@ -1960,6 +1978,47 @@ mod corruption_tests {
             .expect("raw put should succeed");
     }
 
+    /// The gate rides in the instance record, so its forward compatibility is
+    /// the record's. A build that adds a field must not make the record
+    /// unreadable to one that does not know it: msgpack named maps let the
+    /// older reader skip what it does not recognise. If this ever fails,
+    /// widening `InstanceData` has stopped being a no-op for older nodes.
+    #[test]
+    fn an_instance_record_with_an_unknown_field_still_decodes() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let kv = test_kv(dir.path());
+
+        #[derive(serde::Serialize)]
+        struct FutureRecord<'a> {
+            app_id: &'a str,
+            ip: std::net::Ipv4Addr,
+            public_key: &'a str,
+            reg_time: u64,
+            port_policy: Option<PortPolicy>,
+            port_policy_hash: &'a str,
+            admin_port_policy: Option<PortPolicy>,
+            admin_ready: Option<bool>,
+            reason: &'a str,
+        }
+        let widened = encode(&FutureRecord {
+            app_id: "app",
+            ip: "10.0.0.5".parse().unwrap(),
+            public_key: "k",
+            reg_time: 1,
+            port_policy: None,
+            port_policy_hash: "",
+            admin_port_policy: None,
+            admin_ready: Some(false),
+            reason: "under investigation",
+        })
+        .expect("encode should succeed");
+        put_raw(&kv, &keys::inst("future"), &widened);
+
+        let loaded = kv.load_all_instances();
+        assert!(loaded.undecodable.is_empty(), "{:?}", loaded.undecodable);
+        assert_eq!(loaded.decoded["future"].admin_ready, Some(false));
+    }
+
     #[test]
     fn a_corrupt_certbot_config_does_not_read_as_the_default() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
@@ -2091,6 +2150,7 @@ mod corruption_tests {
                     port_policy: None,
                     port_policy_hash: String::new(),
                     admin_port_policy: None,
+                    admin_ready: None,
                 },
             )
             .expect("sync should succeed");

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -458,12 +458,6 @@ pub mod keys {
         format!("{ADMIN_PREFIX}{instance_id}/{ADMIN_PORT_POLICY}")
     }
 
-    /// Prefix covering every override key for one instance.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub fn admin_prefix(instance_id: &str) -> String {
-        format!("{ADMIN_PREFIX}{instance_id}/")
-    }
-
     pub fn node_info(node_id: NodeId) -> String {
         format!("{NODE_INFO_PREFIX}{node_id}")
     }
@@ -796,22 +790,52 @@ impl GetPutCodec for NodeState {
     }
 }
 
-/// Which write [`KvStore::fail_writes_for_test`] should fail.
+/// Which of an instance's records a write is touching.
 ///
-/// Named at every call site rather than only under `cfg(test)`, so the deletes
-/// below read the same in both builds.
-pub(crate) struct FailWrite;
-
-#[cfg_attr(not(test), allow(dead_code))]
-impl FailWrite {
+/// Named at every call site because the delete path issues all of them and
+/// reports them individually: an operator can do something about an `inst/`
+/// tombstone that did not land and nothing about an ephemeral observation that
+/// did not, so "a delete failed" is not a useful thing to be told.
+///
+/// It is also what [`KvStore::fail_writes_for_test`] aims at, which is why the
+/// write paths take one instead of a `u8` that means nothing outside a test
+/// build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstanceRecord {
     /// The persistent `inst/` record, and its tombstone.
-    pub(crate) const INST: u8 = 0b0001;
-    /// The ephemeral `conn/` key.
-    pub(crate) const CONN: u8 = 0b0010;
-    /// The ephemeral `handshake/` key.
-    pub(crate) const HANDSHAKE: u8 = 0b0100;
-    /// The persistent `admin/` record, and its tombstone.
-    pub(crate) const ADMIN: u8 = 0b1000;
+    Instance,
+    /// The persistent `admin/<id>/ready` record, and its tombstone.
+    Gate,
+    /// The persistent `admin/<id>/port_policy` record, and its tombstone.
+    PortPolicyOverride,
+    /// The ephemeral `conn/` key this node owns.
+    Connections,
+    /// The ephemeral `handshake/` key this node owns.
+    Handshake,
+}
+
+impl InstanceRecord {
+    /// What an error message calls it.
+    fn name(self) -> &'static str {
+        match self {
+            Self::Instance => "instance",
+            Self::Gate => "traffic gate",
+            Self::PortPolicyOverride => "port-policy override",
+            Self::Connections => "connection count",
+            Self::Handshake => "handshake observation",
+        }
+    }
+
+    #[cfg(test)]
+    fn bit(self) -> u8 {
+        match self {
+            Self::Instance => 0b00001,
+            Self::Gate => 0b00010,
+            Self::PortPolicyOverride => 0b00100,
+            Self::Connections => 0b01000,
+            Self::Handshake => 0b10000,
+        }
+    }
 }
 
 /// Sync store wrapping two WaveKV Nodes (persistent and ephemeral).
@@ -977,8 +1001,7 @@ impl KvStore {
 
     /// Sync instance data to other nodes
     pub fn sync_instance(&self, instance_id: &str, data: &InstanceData) -> Result<()> {
-        #[cfg(test)]
-        self.injected_failure(FailWrite::INST)?;
+        self.injected_failure(InstanceRecord::Instance)?;
         self.persistent
             .write()
             .put_encoded(keys::inst(instance_id), data, true)
@@ -1080,6 +1103,7 @@ impl KvStore {
                 if !has(keys::ADMIN_READY) {
                     self.record_migration(
                         &mut moved,
+                        InstanceRecord::Gate,
                         keys::admin_ready(&instance_id),
                         &InstanceGate { ready },
                     );
@@ -1088,6 +1112,7 @@ impl KvStore {
             if overrides.port_policy.is_some() && !has(keys::ADMIN_PORT_POLICY) {
                 self.record_migration(
                     &mut moved,
+                    InstanceRecord::PortPolicyOverride,
                     keys::admin_port_policy(&instance_id),
                     &AdminPortPolicy {
                         policy: overrides.port_policy,
@@ -1101,10 +1126,11 @@ impl KvStore {
     fn record_migration<T: Serialize + serde::de::DeserializeOwned>(
         &self,
         moved: &mut Vec<String>,
+        record: InstanceRecord,
         key: String,
         value: &T,
     ) {
-        match self.put_admin_override(key.clone(), value) {
+        match self.put_admin_override(record, key.clone(), value) {
             Ok(()) => moved.push(key),
             Err(err) => warn!("failed to move operator override to {key}: {err:?}"),
         }
@@ -1112,7 +1138,7 @@ impl KvStore {
 
     /// Publish an instance's operator-set traffic gate.
     pub fn sync_instance_gate(&self, instance_id: &str, gate: &InstanceGate) -> Result<()> {
-        self.put_admin_override(keys::admin_ready(instance_id), gate)
+        self.put_admin_override(InstanceRecord::Gate, keys::admin_ready(instance_id), gate)
     }
 
     /// Publish an instance's operator-set port-policy override.
@@ -1125,7 +1151,11 @@ impl KvStore {
         instance_id: &str,
         data: &AdminPortPolicy,
     ) -> Result<()> {
-        self.put_admin_override(keys::admin_port_policy(instance_id), data)
+        self.put_admin_override(
+            InstanceRecord::PortPolicyOverride,
+            keys::admin_port_policy(instance_id),
+            data,
+        )
     }
 
     /// Written as a replacement rather than an update: each record states one
@@ -1133,29 +1163,40 @@ impl KvStore {
     /// operator's decision beside half of another's.
     fn put_admin_override<T: Serialize + serde::de::DeserializeOwned>(
         &self,
+        record: InstanceRecord,
         key: String,
         value: &T,
     ) -> Result<()> {
-        #[cfg(test)]
-        self.injected_failure(FailWrite::ADMIN)?;
-        self.persistent.write().put_encoded(key, value, false)
+        self.injected_failure(record)
+            .and_then(|()| self.persistent.write().put_encoded(key, value, false))
+            .with_context(|| format!("failed to write the {} record", record.name()))
     }
 
-    /// See [`KvStore::injected_failures`].
+    /// Fail every write touching one of `records` until called again. See
+    /// [`KvStore::injected_failures`].
     #[cfg(test)]
-    pub(crate) fn fail_writes_for_test(&self, mask: u8) {
+    pub(crate) fn fail_writes_for_test(&self, records: &[InstanceRecord]) {
+        let mask = records.iter().fold(0u8, |mask, record| mask | record.bit());
         self.injected_failures
             .store(mask, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Deliberately terse: what an operator reads is the context the write path
+    /// adds, so a test that asserts on the message is asserting on the real one.
     #[cfg(test)]
-    fn injected_failure(&self, which: u8) -> Result<()> {
+    fn injected_failure(&self, record: InstanceRecord) -> Result<()> {
         let mask = self
             .injected_failures
             .load(std::sync::atomic::Ordering::Relaxed);
-        if mask & which != 0 {
-            anyhow::bail!("injected store failure for {which:#04b}");
-        }
+        anyhow::ensure!(mask & record.bit() == 0, "injected store failure");
+        Ok(())
+    }
+
+    /// Nothing to inject outside a test build, so the write paths read the same
+    /// in both instead of carrying a `cfg` in their bodies.
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn injected_failure(&self, _record: InstanceRecord) -> Result<()> {
         Ok(())
     }
 
@@ -1171,14 +1212,16 @@ impl KvStore {
         // `inst/` -- the only one of the three that is persistent, and the one an
         // operator needs to know about -- is not masked by an ephemeral key that
         // also happened to fail.
-        let previous = self.delete_persistent(keys::inst(instance_id), FailWrite::INST);
+        let previous = self.delete_persistent(keys::inst(instance_id), InstanceRecord::Instance);
         // The overrides outlive the instance record unless they are tombstoned
         // too, and instance ids are recycled -- an id reused after a delete
         // would inherit the gate and port policy an operator set for whatever
         // ran under it before.
-        let gate = self.delete_persistent(keys::admin_ready(instance_id), FailWrite::ADMIN);
-        let override_policy =
-            self.delete_persistent(keys::admin_port_policy(instance_id), FailWrite::ADMIN);
+        let gate = self.delete_persistent(keys::admin_ready(instance_id), InstanceRecord::Gate);
+        let override_policy = self.delete_persistent(
+            keys::admin_port_policy(instance_id),
+            InstanceRecord::PortPolicyOverride,
+        );
         let observations = self.sync_forget_local_observations(instance_id);
 
         let previous = previous?;
@@ -1198,26 +1241,37 @@ impl KvStore {
     /// already dropped from memory. They are ephemeral, so a restart collects
     /// them, but a gateway's uptime is measured in months.
     pub fn sync_forget_local_observations(&self, instance_id: &str) -> Result<()> {
-        let conn = self.delete_ephemeral(keys::conn(instance_id, self.my_node_id), FailWrite::CONN);
+        let conn = self.delete_ephemeral(
+            keys::conn(instance_id, self.my_node_id),
+            InstanceRecord::Connections,
+        );
         let handshake = self.delete_ephemeral(
             keys::handshake(instance_id, self.my_node_id),
-            FailWrite::HANDSHAKE,
+            InstanceRecord::Handshake,
         );
         conn?;
         handshake?;
         Ok(())
     }
 
-    fn delete_persistent(&self, key: String, _which: u8) -> Result<Option<wavekv::types::Entry>> {
-        #[cfg(test)]
-        self.injected_failure(_which)?;
-        self.persistent.write().delete(key)
+    fn delete_persistent(
+        &self,
+        key: String,
+        record: InstanceRecord,
+    ) -> Result<Option<wavekv::types::Entry>> {
+        self.injected_failure(record)
+            .and_then(|()| self.persistent.write().delete(key))
+            .with_context(|| format!("failed to delete the {} record", record.name()))
     }
 
-    fn delete_ephemeral(&self, key: String, _which: u8) -> Result<Option<wavekv::types::Entry>> {
-        #[cfg(test)]
-        self.injected_failure(_which)?;
-        self.ephemeral.write().delete(key)
+    fn delete_ephemeral(
+        &self,
+        key: String,
+        record: InstanceRecord,
+    ) -> Result<Option<wavekv::types::Entry>> {
+        self.injected_failure(record)
+            .and_then(|()| self.ephemeral.write().delete(key))
+            .with_context(|| format!("failed to delete the {} record", record.name()))
     }
 
     /// Load all instances from the sync store.
@@ -2689,10 +2743,10 @@ mod corruption_tests {
         let kv = test_kv(dir.path());
         seed_instance(&kv, "cvm");
 
-        kv.fail_writes_for_test(FailWrite::CONN);
+        kv.fail_writes_for_test(&[InstanceRecord::Connections]);
         kv.sync_delete_instance("cvm")
             .expect_err("the conn delete was made to fail");
-        kv.fail_writes_for_test(0);
+        kv.fail_writes_for_test(&[]);
 
         assert!(
             kv.persistent
@@ -2710,24 +2764,34 @@ mod corruption_tests {
         );
     }
 
-    /// `inst/` is the only one of the three that is persistent, and the only
-    /// one an operator can do anything about, so its failure must not be
-    /// masked by an ephemeral key that also happened to fail.
+    /// `inst/` is the only persistent one of the pair an operator can do
+    /// anything about, so its failure must not be masked by an ephemeral key
+    /// that also happened to fail -- and the message has to say which record it
+    /// was, or the ordering buys nothing.
     #[test]
     fn the_persistent_failure_is_the_one_reported() {
         let dir = tempfile::tempdir().expect("temp dir");
         let kv = test_kv(dir.path());
         seed_instance(&kv, "cvm");
 
-        kv.fail_writes_for_test(FailWrite::INST | FailWrite::CONN | FailWrite::HANDSHAKE);
+        kv.fail_writes_for_test(&[
+            InstanceRecord::Instance,
+            InstanceRecord::Connections,
+            InstanceRecord::Handshake,
+        ]);
         let err = kv
             .sync_delete_instance("cvm")
             .expect_err("all three were made to fail");
-        kv.fail_writes_for_test(0);
+        kv.fail_writes_for_test(&[]);
 
+        let message = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains(&format!("{:#04b}", FailWrite::INST)),
-            "expected the inst/ failure, got: {err:#}"
+            message.contains(InstanceRecord::Instance.name()),
+            "expected the instance record to be named, got: {message}"
+        );
+        assert!(
+            !message.contains(InstanceRecord::Handshake.name()),
+            "the ephemeral failure must not mask it, got: {message}"
         );
     }
 
@@ -3255,8 +3319,12 @@ mod key_schema_tests {
         assert_eq!(keys::parse_inst_key(&keys::admin_ready("inst-a")), None);
         assert!(!keys::admin_ready("inst-a").starts_with(keys::INST_PREFIX));
         assert!(!keys::inst("inst-a").starts_with(keys::ADMIN_PREFIX));
-        // `inst-a` must not swallow `inst-ab`.
-        assert!(!keys::admin_ready("inst-ab").starts_with(&keys::admin_prefix("inst-a")));
+        // `inst-a` must not swallow `inst-ab`: the id is not the last segment,
+        // so the parse has to split from the right to stay unambiguous.
+        assert_eq!(
+            keys::parse_admin_key(&keys::admin_ready("inst-ab")),
+            Some(("inst-ab", keys::ADMIN_READY))
+        );
         assert_eq!(keys::parse_node_info_key(&keys::node_status(1)), None);
         assert_eq!(keys::parse_node_info_key(&keys::inst("inst-a")), None);
         // `node/info/` and `node/status/` share a stem; neither may claim the other.

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -40,9 +40,9 @@ use crate::{
     cert_store::{CertResolver, CertStoreBuilder},
     config::{Config, TlsConfig},
     kv::{
-        fetch_peers_from_bootnode, import, keys, AdminOverrides, AdminPortPolicy, AppIdValidator,
-        CertData, HttpsClientConfig, InstanceData, InstanceGate, KvStore, LoadedInstances,
-        LoadedOverrides, NodeData, NodeStatus, PortPolicy, WaveKvSyncService,
+        fetch_peers_from_bootnode, import, AppIdValidator, CertData, HttpsClientConfig,
+        InstanceData, KvStore, LegacyOverrides, LoadedInstances, NodeData, NodeStatus, PortPolicy,
+        PortPolicyOverride, WaveKvSyncService,
     },
     models::{InstanceInfo, PortPolicyView, WgConf, WgPeer},
     proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo, AppAddressResolver},
@@ -289,9 +289,8 @@ impl ProxyInner {
         );
         // Read-only: nothing may be written before the bootstrap below, so the
         // move of any legacy overrides waits for the first reload.
-        let overrides = kv_store.load_all_instance_overrides();
         let legacy_overrides = kv_store.legacy_instance_overrides();
-        let state = build_state_from_kv_store(&config, instances, &overrides, &legacy_overrides);
+        let state = build_state_from_kv_store(&config, &kv_store, instances, &legacy_overrides);
 
         // This node's own records are written *after* the bootstrap below, not
         // here. A local write allocates a sequence number, and after a
@@ -747,77 +746,69 @@ fn report_new_rejections(
 
 /// The operator overrides in force for `instance_id`.
 ///
-/// The `admin/` record wins whenever there is one, including when it says
-/// nothing is overridden. Only when there is none does the copy an older build
-/// left inside the instance record apply -- that is the same rule
-/// [`KvStore::migrate_legacy_instance_overrides`] writes by, so a reload before
-/// the move and one after it answer the same thing.
+/// Per key, because they are separate keys: one of them existing says nothing
+/// about the other. Asking per instance is what would drop the port-policy
+/// override of an instance whose gate had already been moved across.
 ///
-/// A record that will not decode is neither. Guessing "nothing is overridden"
-/// is what would return a quarantined instance to rotation, so the instance is
-/// held out of app-id selection until the record is readable again; it stays
-/// reachable by instance id throughout, as a gated instance always is.
+/// A key that exists answers, including when it says "cleared". Only a key that
+/// does not exist falls back to the copy an older build left in the instance
+/// record -- otherwise clearing an override would be undone by that copy.
+///
+/// `Err` is not "nothing is overridden". The gate is an operator saying an
+/// instance must not be given work, so an unreadable answer keeps it out of
+/// app-id rotation until the record is readable again; instance-id routing is
+/// never gated, so it stays reachable for investigation either way.
 fn effective_overrides(
+    store: &KvStore,
     instance_id: &str,
-    current: &LoadedOverrides,
-    legacy: &BTreeMap<String, AdminOverrides>,
-) -> AdminOverrides {
-    if current.unreadable.contains_key(instance_id) {
-        return AdminOverrides {
-            port_policy: None,
-            ready: Some(false),
-        };
-    }
-    // Per key, not per instance. They are separate keys, so one of them
-    // existing says nothing about the other: an operator who sets the gate
-    // through the new path on an instance whose port-policy override is still
-    // in the instance record would otherwise have the override dropped, which
-    // is the failure this whole split exists to remove.
-    let written = current.written_keys(instance_id);
-    let stored = current.decoded.get(instance_id);
-    let legacy = legacy.get(instance_id);
-    AdminOverrides {
-        ready: if written.contains(keys::ADMIN_READY) {
-            stored.and_then(|stored| stored.ready)
-        } else {
-            legacy.and_then(|legacy| legacy.ready)
-        },
-        port_policy: if written.contains(keys::ADMIN_PORT_POLICY) {
-            stored.and_then(|stored| stored.port_policy.clone())
-        } else {
-            legacy.and_then(|legacy| legacy.port_policy.clone())
-        },
-    }
+    legacy: Option<&LegacyOverrides>,
+) -> Result<(Option<PortPolicy>, Option<bool>)> {
+    let ready = match store.instance_gate(instance_id)? {
+        Some(ready) => Some(ready),
+        None => legacy.and_then(|legacy| legacy.ready),
+    };
+    let port_policy = match store.instance_port_policy_override(instance_id)? {
+        Some(PortPolicyOverride::Set(policy)) => Some(policy),
+        Some(PortPolicyOverride::Cleared) => None,
+        None => legacy.and_then(|legacy| legacy.admin_port_policy.clone()),
+    };
+    Ok((port_policy, ready))
 }
+
+/// What [`effective_overrides`] answers when it cannot read a record: the
+/// instance takes no app-id traffic until an operator rewrites one.
+const OVERRIDES_UNREADABLE: (Option<PortPolicy>, Option<bool>) = (None, Some(false));
 
 /// Report override records this node cannot read, once per transition.
 ///
 /// Unreadable means the instance is held out of app-id rotation, so it is not a
 /// quiet condition -- but a record that stays bad would otherwise be reported on
 /// every reload, and reloads are driven by cluster activity.
-fn report_unreadable_overrides(proxy: &Proxy, loaded: &LoadedOverrides) {
-    let mut state = proxy.lock();
-    for (instance_id, reason) in &loaded.unreadable {
-        if state.reported_bad_overrides.get(instance_id) != Some(reason) {
+fn report_unreadable_overrides(
+    reported: &mut BTreeMap<String, String>,
+    unreadable: BTreeMap<String, String>,
+) {
+    for (instance_id, reason) in &unreadable {
+        if reported.get(instance_id) != Some(reason) {
             error!(
                 "cannot read the operator overrides for instance {instance_id}, holding it \
                  out of load balancing until they are readable again: {reason}"
             );
         }
     }
-    for instance_id in state.reported_bad_overrides.keys() {
-        if !loaded.unreadable.contains_key(instance_id) {
+    for instance_id in reported.keys() {
+        if !unreadable.contains_key(instance_id) {
             info!("operator overrides for instance {instance_id} are readable again");
         }
     }
-    state.reported_bad_overrides = loaded.unreadable.clone();
+    *reported = unreadable;
 }
 
 fn build_state_from_kv_store(
     config: &Config,
+    store: &KvStore,
     instances: LoadedInstances,
-    overrides: &LoadedOverrides,
-    legacy_overrides: &BTreeMap<String, AdminOverrides>,
+    legacy_overrides: &BTreeMap<String, LegacyOverrides>,
 ) -> ProxyStateMut {
     let mut state = ProxyStateMut::default();
 
@@ -826,7 +817,15 @@ fn build_state_from_kv_store(
 
     // Build instances
     for (instance_id, data) in accepted.instances {
-        let admin = effective_overrides(&instance_id, overrides, legacy_overrides);
+        let (admin_port_policy, ready) =
+            effective_overrides(store, &instance_id, legacy_overrides.get(&instance_id))
+                .unwrap_or_else(|err| {
+                    error!(
+                        "cannot read the operator overrides for instance {instance_id}, \
+                         holding it out of load balancing until they are readable again: {err:#}"
+                    );
+                    OVERRIDES_UNREADABLE
+                });
         let info = InstanceInfo {
             id: instance_id.clone(),
             app_id: data.app_id.clone(),
@@ -837,8 +836,8 @@ fn build_state_from_kv_store(
                 .unwrap_or(UNIX_EPOCH),
             port_policy: data.port_policy,
             port_policy_hash: data.port_policy_hash,
-            admin_port_policy: admin.port_policy,
-            ready: admin.ready,
+            admin_port_policy,
+            ready,
             connections: Default::default(),
         };
         state.allocated_addresses.insert(data.ip);
@@ -1229,8 +1228,6 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
             moved.join(", ")
         );
     }
-    let overrides = store.load_all_instance_overrides();
-    report_unreadable_overrides(proxy, &overrides);
     let legacy_overrides = store.legacy_instance_overrides();
     let accepted = import::accept_instances(&proxy.config.wg, store.load_all_instances());
     // An unreadable record is not a deletion. Its instance keeps whatever the
@@ -1271,8 +1268,14 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
         wg_changed = true;
     }
 
+    let mut unreadable_overrides = BTreeMap::new();
     for (instance_id, data) in instances {
-        let admin = effective_overrides(&instance_id, &overrides, &legacy_overrides);
+        let (admin_port_policy, ready) =
+            effective_overrides(store, &instance_id, legacy_overrides.get(&instance_id))
+                .unwrap_or_else(|err| {
+                    unreadable_overrides.insert(instance_id.clone(), format!("{err:#}"));
+                    OVERRIDES_UNREADABLE
+                });
         let mut new_info = InstanceInfo {
             id: instance_id.clone(),
             app_id: data.app_id.clone(),
@@ -1283,8 +1286,8 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
                 .unwrap_or(UNIX_EPOCH),
             port_policy: data.port_policy.clone(),
             port_policy_hash: data.port_policy_hash.clone(),
-            admin_port_policy: admin.port_policy,
-            ready: admin.ready,
+            admin_port_policy,
+            ready,
             connections: Default::default(),
         };
 
@@ -1341,6 +1344,8 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
             .insert(instance_id.clone());
         state.state.instances.insert(instance_id, new_info);
     }
+
+    report_unreadable_overrides(&mut state.reported_bad_overrides, unreadable_overrides);
 
     if wg_changed {
         state.reconfigure()?;
@@ -1738,7 +1743,7 @@ impl ProxyState {
             return Ok(());
         };
         self.kv_store
-            .sync_instance_gate(instance_id, &InstanceGate { ready })
+            .set_instance_gate(instance_id, ready)
             .with_context(|| {
                 format!("failed to sync the gate for instance {instance_id} to KvStore")
             })
@@ -1749,11 +1754,9 @@ impl ProxyState {
         let Some(info) = self.state.instances.get(instance_id) else {
             return Ok(());
         };
-        let data = AdminPortPolicy {
-            policy: info.admin_port_policy.clone(),
-        };
+        let policy = info.admin_port_policy.clone();
         self.kv_store
-            .sync_instance_port_policy_override(instance_id, &data)
+            .set_instance_port_policy_override(instance_id, policy)
             .with_context(|| {
                 format!(
                     "failed to sync the port-policy override for instance {instance_id} to KvStore"

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -7,7 +7,7 @@ use std::{
     net::Ipv4Addr,
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard},
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime},
 };
 
 use anyhow::{bail, ensure, Context, Result};
@@ -744,21 +744,56 @@ fn report_new_rejections(
     *reported = current;
 }
 
-/// The operator overrides in force for `instance_id`.
+/// The data plane's view of an instance: what the CVM reported in `data`, plus
+/// what an operator decided about it under `admin/`.
 ///
-/// Per key, because they are separate keys: one of them existing says nothing
-/// about the other. Asking per instance is what would drop the port-policy
-/// override of an instance whose gate had already been moved across.
+/// One conversion for both the startup build and the reload. They had a
+/// hand-written copy each, which is how `admin_port_policy` came to be dropped
+/// once already -- the compiler says nothing when a field is missing from one
+/// of two literals that are supposed to agree.
 ///
-/// A key that exists answers, including when it says "cleared". Only a key that
-/// does not exist falls back to the copy an older build left in the instance
-/// record -- otherwise clearing an override would be undone by that copy.
+/// The overrides are read per key, because they are separate keys: one of them
+/// existing says nothing about the other. Asking per instance is what would
+/// drop the port-policy override of an instance whose gate had already been
+/// moved across. A key that exists answers, including when it says "cleared";
+/// only a key that does not exist falls back to the copy an older build left
+/// in the instance record, or clearing an override would be undone by it.
 ///
-/// `Err` is not "nothing is overridden". The gate is an operator saying an
-/// instance must not be given work, so an unreadable answer keeps it out of
-/// app-id rotation until the record is readable again; instance-id routing is
-/// never gated, so it stays reachable for investigation either way.
-fn effective_overrides(
+/// Returns why the overrides could not be read, if they could not. That is not
+/// "nothing is overridden": the gate is an operator saying an instance must not
+/// be given work, so an unreadable answer keeps it out of app-id rotation until
+/// the record is readable again. Instance-id routing is never gated, so the
+/// instance stays reachable for investigation either way.
+fn instance_info_from_record(
+    store: &KvStore,
+    instance_id: String,
+    data: InstanceData,
+    legacy: Option<&LegacyOverrides>,
+) -> (InstanceInfo, Option<String>) {
+    let mut unreadable = None;
+    let (admin_port_policy, ready) = match read_overrides(store, &instance_id, legacy) {
+        Ok(overrides) => overrides,
+        Err(err) => {
+            unreadable = Some(format!("{err:#}"));
+            (None, Some(false))
+        }
+    };
+    let info = InstanceInfo {
+        id: instance_id,
+        app_id: data.app_id,
+        ip: data.ip,
+        public_key: data.public_key,
+        reg_time: decode_ts(data.reg_time),
+        port_policy: data.port_policy,
+        port_policy_hash: data.port_policy_hash,
+        admin_port_policy,
+        ready,
+        connections: Default::default(),
+    };
+    (info, unreadable)
+}
+
+fn read_overrides(
     store: &KvStore,
     instance_id: &str,
     legacy: Option<&LegacyOverrides>,
@@ -774,10 +809,6 @@ fn effective_overrides(
     };
     Ok((port_policy, ready))
 }
-
-/// What [`effective_overrides`] answers when it cannot read a record: the
-/// instance takes no app-id traffic until an operator rewrites one.
-const OVERRIDES_UNREADABLE: (Option<PortPolicy>, Option<bool>) = (None, Some(false));
 
 /// Report override records this node cannot read, once per transition.
 ///
@@ -817,33 +848,21 @@ fn build_state_from_kv_store(
 
     // Build instances
     for (instance_id, data) in accepted.instances {
-        let (admin_port_policy, ready) =
-            effective_overrides(store, &instance_id, legacy_overrides.get(&instance_id))
-                .unwrap_or_else(|err| {
-                    error!(
-                        "cannot read the operator overrides for instance {instance_id}, \
-                         holding it out of load balancing until they are readable again: {err:#}"
-                    );
-                    OVERRIDES_UNREADABLE
-                });
-        let info = InstanceInfo {
-            id: instance_id.clone(),
-            app_id: data.app_id.clone(),
-            ip: data.ip,
-            public_key: data.public_key,
-            reg_time: UNIX_EPOCH
-                .checked_add(Duration::from_secs(data.reg_time))
-                .unwrap_or(UNIX_EPOCH),
-            port_policy: data.port_policy,
-            port_policy_hash: data.port_policy_hash,
-            admin_port_policy,
-            ready,
-            connections: Default::default(),
-        };
-        state.allocated_addresses.insert(data.ip);
+        let ip = data.ip;
+        let app_id = data.app_id.clone();
+        let legacy = legacy_overrides.get(&instance_id);
+        let (info, unreadable) =
+            instance_info_from_record(store, instance_id.clone(), data, legacy);
+        if let Some(reason) = unreadable {
+            error!(
+                "cannot read the operator overrides for instance {instance_id}, holding it \
+                 out of load balancing until they are readable again: {reason}"
+            );
+        }
+        state.allocated_addresses.insert(ip);
         state
             .apps
-            .entry(data.app_id)
+            .entry(app_id)
             .or_default()
             .insert(instance_id.clone());
         state.instances.insert(instance_id, info);
@@ -1270,31 +1289,17 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
 
     let mut unreadable_overrides = BTreeMap::new();
     for (instance_id, data) in instances {
-        let (admin_port_policy, ready) =
-            effective_overrides(store, &instance_id, legacy_overrides.get(&instance_id))
-                .unwrap_or_else(|err| {
-                    unreadable_overrides.insert(instance_id.clone(), format!("{err:#}"));
-                    OVERRIDES_UNREADABLE
-                });
-        let mut new_info = InstanceInfo {
-            id: instance_id.clone(),
-            app_id: data.app_id.clone(),
-            ip: data.ip,
-            public_key: data.public_key.clone(),
-            reg_time: UNIX_EPOCH
-                .checked_add(Duration::from_secs(data.reg_time))
-                .unwrap_or(UNIX_EPOCH),
-            port_policy: data.port_policy.clone(),
-            port_policy_hash: data.port_policy_hash.clone(),
-            admin_port_policy,
-            ready,
-            connections: Default::default(),
-        };
+        let legacy = legacy_overrides.get(&instance_id);
+        let (mut new_info, unreadable) =
+            instance_info_from_record(store, instance_id.clone(), data, legacy);
+        if let Some(reason) = unreadable {
+            unreadable_overrides.insert(instance_id.clone(), reason);
+        }
 
         let existing = state.state.instances.get(&instance_id).cloned();
         if let Some(existing) = &existing {
             // Check if wg config needs update
-            if existing.public_key != data.public_key || existing.ip != data.ip {
+            if existing.public_key != new_info.public_key || existing.ip != new_info.ip {
                 wg_changed = true;
             }
             // WaveKV has already selected the winning value. Materialize it
@@ -1306,10 +1311,10 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
 
         // Release old IP if it changed (prevent IP leak)
         if let Some(existing) = &existing {
-            if existing.ip != data.ip {
+            if existing.ip != new_info.ip {
                 state.state.allocated_addresses.remove(&existing.ip);
             }
-            if existing.app_id != data.app_id {
+            if existing.app_id != new_info.app_id {
                 if let Some(app_instances) = state.state.apps.get_mut(&existing.app_id) {
                     app_instances.remove(&instance_id);
                     if app_instances.is_empty() {
@@ -1330,16 +1335,16 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
             None => true,
         };
         if selection_is_stale {
-            state.state.top_n.remove(&data.app_id);
+            state.state.top_n.remove(&new_info.app_id);
             if let Some(existing) = &existing {
                 state.state.top_n.remove(&existing.app_id);
             }
         }
-        state.state.allocated_addresses.insert(data.ip);
+        state.state.allocated_addresses.insert(new_info.ip);
         state
             .state
             .apps
-            .entry(data.app_id)
+            .entry(new_info.app_id.clone())
             .or_default()
             .insert(instance_id.clone());
         state.state.instances.insert(instance_id, new_info);

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -40,8 +40,8 @@ use crate::{
     config::{Config, TlsConfig},
     kv::{
         fetch_peers_from_bootnode, import, AppIdValidator, CertData, HttpsClientConfig,
-        InstanceData, KvStore, LegacyOverrides, LoadedInstances, NodeData, NodeStatus, PortPolicy,
-        PortPolicyOverride, WaveKvSyncService,
+        InstanceRecord, KvStore, LegacyOverrides, LoadedInstances, NodeData, NodeStatus,
+        PortPolicy, PortPolicyOverride, WaveKvSyncService,
     },
     models::{InstanceInfo, PortPolicyView, WgConf, WgPeer},
     proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo, AppAddressResolver},
@@ -771,7 +771,7 @@ fn report_new_rejections(
 fn instance_info_from_record(
     store: &KvStore,
     instance_id: String,
-    data: InstanceData,
+    data: InstanceRecord,
     legacy: Option<&LegacyOverrides>,
 ) -> (InstanceInfo, Option<String>) {
     let mut unreadable = None;
@@ -1447,8 +1447,8 @@ impl ProxyState {
             let existing = existing.clone();
             if self.valid_ip(existing.ip) {
                 // Sync existing instance to KvStore (might be from legacy state)
-                let data = InstanceData::from(&existing);
-                if let Err(err) = self.kv_store.sync_instance(&existing.id, &data) {
+                let record = InstanceRecord::from(&existing);
+                if let Err(err) = self.kv_store.sync_instance(&existing.id, &record) {
                     error!("failed to sync existing instance to KvStore: {err:?}");
                 }
                 return Ok(existing);
@@ -1781,17 +1781,17 @@ impl ProxyState {
         let Some(info) = self.state.instances.get(instance_id) else {
             return Ok(());
         };
-        let data = InstanceData::from(info);
+        let record = InstanceRecord::from(info);
         self.kv_store
-            .sync_instance(instance_id, &data)
+            .sync_instance(instance_id, &record)
             .with_context(|| format!("failed to sync instance {instance_id} to KvStore"))
     }
 
     fn add_instance(&mut self, info: InstanceInfo) {
         self.state.top_n.remove(&info.app_id);
         // Sync to KvStore
-        let data = InstanceData::from(&info);
-        if let Err(err) = self.kv_store.sync_instance(&info.id, &data) {
+        let record = InstanceRecord::from(&info);
+        if let Err(err) = self.kv_store.sync_instance(&info.id, &record) {
             error!("failed to sync instance to KvStore: {err:?}");
         }
 

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1413,20 +1413,20 @@ impl ProxyState {
         // The selection cache holds a pre-gate snapshot. Drop it so the change
         // applies to the next connection rather than up to `cache_top_n` later.
         self.state.top_n.remove(&app_id);
-        // Not rolled back, but do not read that as "it still took effect
-        // locally". `reload_instances_from_kv_store` rebuilds every instance
-        // from the store, and any peer writing an unrelated `inst/` record
-        // triggers it -- so the next reload reads back the very record this
-        // write failed to update, and the gate reverts. A failed write survives
-        // in memory only until then: seconds, not until restart. Rolling back
-        // here would just reach the same end state sooner while losing the brief
+        // Not rolled back, but do not read that as "it took effect". The gate
+        // is in memory and nowhere else: it is gone on restart, and any reload
+        // that rebuilds instances from the store reads back the very record
+        // this write failed to update. How long it survives depends on when
+        // that next happens, which is not something to predict in an error
+        // message -- so the message says what is known instead. Rolling back
+        // here would reach the same end state sooner while throwing away the
         // window in which the operator's intent is at least locally in force.
         self.persist_instance_record(instance_id).with_context(|| {
             format!(
-                "instance {instance_id} is set to ready={ready} on this node \
-                 only and not durably: the write to the store failed, so it \
-                 will not reach the other gateways and will be undone here by \
-                 the next reload. Retry before relying on it"
+                "instance {instance_id} is set to ready={ready} in memory on \
+                 this node only: the write to the store failed, so the setting \
+                 is not durable and has not been shared. Retry before relying \
+                 on it"
             )
         })?;
         Ok(())

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1228,6 +1228,9 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
     Ok(())
 }
 
+/// WireGuard peers keyed by public key, valued by (last handshake, elapsed).
+pub(crate) type Handshakes = BTreeMap<String, (u64, Duration)>;
+
 impl ProxyState {
     fn valid_ip(&self, ip: Ipv4Addr) -> bool {
         self.config.wg.is_valid_client_ip(ip)
@@ -1456,14 +1459,16 @@ impl ProxyState {
         info.ready = Some(ready);
         let app_id = info.app_id.clone();
         info!("admin set ready={ready} for instance {instance_id} (prev: {prev})");
-        if !ready && self.count_ready_instances(&app_id) == 0 {
-            // Not an error -- an operator may well mean to drain an app
-            // entirely -- but silently refusing every connection to an app is
-            // the kind of thing someone should be told about once.
-            warn!(
-                "instance {instance_id} was the last ready instance of app {app_id}; \
-                 the app will refuse new connections until one is set ready again"
-            );
+        match self.drain_warning(instance_id, &app_id, prev, ready) {
+            Ok(Some(message)) => warn!("{message}"),
+            Ok(None) => {}
+            // The check needs a handshake read, which can fail on its own. That
+            // is not a reason to fail the gate -- it is already applied -- but
+            // it is a reason not to imply the app is still serving.
+            Err(err) => debug!(
+                "could not tell whether app {app_id} still has an eligible instance \
+                 after gating {instance_id}: {err:?}"
+            ),
         }
         // The selection cache holds a pre-gate snapshot. Drop it so the change
         // applies to the next connection rather than up to `cache_top_n` later.
@@ -1487,16 +1492,68 @@ impl ProxyState {
         Ok(())
     }
 
-    /// How many of an app's instances the operator has left open to traffic.
-    fn count_ready_instances(&self, app_id: &str) -> usize {
+    /// Whether the WireGuard tunnel to `instance` is fresh enough to route over.
+    fn handshake_is_fresh(&self, instance: &InstanceInfo, handshakes: &Handshakes) -> bool {
+        handshakes
+            .get(&instance.public_key)
+            .is_some_and(|(_, elapsed)| *elapsed < self.config.proxy.timeouts.handshake_stale)
+    }
+
+    /// Whether `instance` may receive a connection addressed to its app id.
+    ///
+    /// The one definition both selection paths and the drain warning ask.
+    /// They had already drifted apart: the warning looked only at the gate,
+    /// so an instance nobody gated but whose tunnel was dead counted as cover.
+    fn is_eligible(&self, instance: &InstanceInfo, handshakes: &Handshakes) -> bool {
+        instance.is_ready() && self.handshake_is_fresh(instance, handshakes)
+    }
+
+    /// The warning an operator should see after a gate change, if any.
+    ///
+    /// Returned rather than logged so both conditions are testable, because
+    /// both were wrong. It counted only the gate, so draining the last live
+    /// instance of an app whose others were dead-but-ungated said nothing --
+    /// the case the warning exists for. And it keyed on the resulting count
+    /// alone, so a second gate-off against an already-drained app warned
+    /// again, naming an instance that was never the last ready one; the retry
+    /// the failed-write message asks for is exactly that call.
+    fn drain_warning(
+        &self,
+        instance_id: &str,
+        app_id: &str,
+        prev: bool,
+        ready: bool,
+    ) -> Result<Option<String>> {
+        // Nothing was closed, so nothing can have been closed last.
+        if !prev || ready {
+            return Ok(None);
+        }
+        if self.count_eligible_instances(app_id)? > 0 {
+            return Ok(None);
+        }
+        // Not an error -- an operator may well mean to drain an app entirely --
+        // but silently refusing every connection to an app is the kind of thing
+        // someone should be told about once.
+        Ok(Some(format!(
+            "gating instance {instance_id} leaves app {app_id} with no instance eligible \
+             for load balancing; connections addressed to the app id will be refused \
+             until one becomes eligible again"
+        )))
+    }
+
+    /// How many of an app's instances can currently be given new traffic.
+    fn count_eligible_instances(&self, app_id: &str) -> Result<usize> {
         let Some(instances) = self.state.apps.get(app_id) else {
-            return 0;
+            return Ok(0);
         };
-        instances
+        let handshakes = self
+            .latest_handshakes(None)
+            .context("failed to read WireGuard handshakes")?;
+        Ok(instances
             .iter()
             .filter_map(|id| self.state.instances.get(id))
-            .filter(|info| info.is_ready())
-            .count()
+            .filter(|info| self.is_eligible(info, &handshakes))
+            .count())
     }
 
     /// Persist the current in-memory `InstanceInfo` snapshot to WaveKV.
@@ -1643,21 +1700,22 @@ impl ProxyState {
                 .iter()
                 .filter_map(|instance_id| {
                     let instance = self.state.instances.get(instance_id)?;
-                    // Operator gate. Only applied here, on the app-id path --
-                    // the instance-id lookup above returns before this point so
-                    // a gated instance stays directly reachable.
-                    if !instance.is_ready() {
+                    // Eligibility -- including the operator gate -- is only
+                    // applied here, on the app-id path: the instance-id lookup
+                    // above returns before this point, so a gated instance
+                    // stays directly reachable.
+                    if !self.is_eligible(instance, &handshakes) {
                         return None;
                     }
+                    // Re-read for the sort key; eligibility already proved it
+                    // is present and fresh.
                     let (_, elapsed) = handshakes.get(&instance.public_key)?;
-                    (*elapsed < self.config.proxy.timeouts.handshake_stale).then(|| {
-                        (
-                            instance.ip,
-                            *elapsed,
-                            instance.connections.clone(),
-                            instance.id.clone(),
-                        )
-                    })
+                    Some((
+                        instance.ip,
+                        *elapsed,
+                        instance.connections.clone(),
+                        instance.id.clone(),
+                    ))
                 })
                 .collect::<SmallVec<[_; 4]>>(),
         };
@@ -1692,19 +1750,12 @@ impl ProxyState {
         // Get latest handshakes to check instance health
         let handshakes = self.latest_handshakes(None).ok()?;
 
-        // Filter healthy instances and choose randomly among them
+        // Filter eligible instances and choose randomly among them
         let healthy_instances = app_instances.iter().filter(|instance_id| {
-            if let Some(instance) = self.state.instances.get(*instance_id) {
-                // Consider instance healthy if it had a recent handshake, and
-                // only if the operator has not gated it out of rotation.
-                instance.is_ready()
-                    && handshakes
-                        .get(&instance.public_key)
-                        .map(|(_, elapsed)| *elapsed < self.config.proxy.timeouts.handshake_stale)
-                        .unwrap_or(false)
-            } else {
-                false
-            }
+            self.state
+                .instances
+                .get(*instance_id)
+                .is_some_and(|instance| self.is_eligible(instance, &handshakes))
         });
 
         let selected = healthy_instances.choose(&mut rand::thread_rng())?;
@@ -1720,10 +1771,7 @@ impl ProxyState {
     /// Get latest handshakes
     ///
     /// Return a map of public key to (timestamp, elapsed)
-    pub(crate) fn latest_handshakes(
-        &self,
-        stale_timeout: Option<Duration>,
-    ) -> Result<BTreeMap<String, (u64, Duration)>> {
+    pub(crate) fn latest_handshakes(&self, stale_timeout: Option<Duration>) -> Result<Handshakes> {
         self.handshake_cache.latest(stale_timeout)
     }
 

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -752,6 +752,7 @@ fn build_state_from_kv_store(config: &Config, instances: LoadedInstances) -> Pro
             port_policy: data.port_policy,
             port_policy_hash: data.port_policy_hash,
             admin_port_policy: data.admin_port_policy,
+            admin_ready: data.admin_ready,
             connections: Default::default(),
         };
         state.allocated_addresses.insert(data.ip);
@@ -1114,6 +1115,7 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
             port_policy: data.port_policy.clone(),
             port_policy_hash: data.port_policy_hash.clone(),
             admin_port_policy: data.admin_port_policy.clone(),
+            admin_ready: data.admin_ready,
             connections: Default::default(),
         };
 
@@ -1143,6 +1145,22 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
                         state.state.top_n.remove(&existing.app_id);
                     }
                 }
+            }
+        }
+        // Drop any cached selection this record could invalidate. WaveKV is how
+        // an operator's traffic gate reaches the other nodes, and a cached
+        // `top_n` computed before it arrived would keep feeding the gated
+        // instance for up to `cache_top_n` -- on every node except the one that
+        // took the RPC.
+        let selection_is_stale = match &existing {
+            Some(existing) => existing.routing_inputs_differ(&new_info),
+            // A record this node has not seen before is a new candidate.
+            None => true,
+        };
+        if selection_is_stale {
+            state.state.top_n.remove(&data.app_id);
+            if let Some(existing) = &existing {
+                state.state.top_n.remove(&existing.app_id);
             }
         }
         state.state.allocated_addresses.insert(data.ip);
@@ -1205,10 +1223,20 @@ impl ProxyState {
         {
             bail!("WireGuard public key is already registered to another instance");
         }
+        // Both operator overrides live only in the instance record, so when the
+        // rebuild path below reconstructs the instance from scratch -- it does
+        // that when the recorded IP is no longer inside the configured range --
+        // they have to be carried across by hand. Otherwise the traffic gate
+        // falls open and the port-policy override silently reverts to whatever
+        // the instance reports about itself.
+        let mut carried_admin_ready = None;
+        let mut carried_admin_port_policy = None;
         if let Some(existing) = self.state.instances.get_mut(id) {
             if existing.app_id != app_id {
                 bail!("instance_id is already registered to a different app");
             }
+            carried_admin_ready = existing.admin_ready;
+            carried_admin_port_policy = existing.admin_port_policy.clone();
             let pubkey_changed = existing.public_key != public_key;
             if pubkey_changed {
                 info!("public key changed for instance {id}, new key: {public_key}");
@@ -1244,6 +1272,7 @@ impl ProxyState {
                     port_policy: existing.port_policy.clone(),
                     port_policy_hash: existing.port_policy_hash.clone(),
                     admin_port_policy: existing.admin_port_policy.clone(),
+                    admin_ready: existing.admin_ready,
                 };
                 if let Err(err) = self.kv_store.sync_instance(&existing.id, &data) {
                     error!("failed to sync existing instance to KvStore: {err:?}");
@@ -1264,7 +1293,8 @@ impl ProxyState {
             reg_time: SystemTime::now(),
             port_policy,
             port_policy_hash: compose_hash.to_string(),
-            admin_port_policy: None,
+            admin_port_policy: carried_admin_port_policy,
+            admin_ready: carried_admin_ready,
             connections: Default::default(),
         };
         self.add_instance(host_info.clone());
@@ -1293,7 +1323,11 @@ impl ProxyState {
             return;
         };
         info.port_policy = Some(policy);
-        self.persist_instance_record(instance_id);
+        // Pre-existing behaviour: the lazy fetch retries on its own schedule,
+        // so a failed write here is logged rather than surfaced.
+        if let Err(err) = self.persist_instance_record(instance_id) {
+            error!("{err:?}");
+        }
     }
 
     /// Snapshot view of an instance's port-policy state for inspection.
@@ -1323,7 +1357,11 @@ impl ProxyState {
             policy.ports.len(),
             prev.is_some(),
         );
-        self.persist_instance_record(instance_id);
+        // Pre-existing behaviour: a failed write is logged, not returned.
+        // Left alone here so this change stays about the traffic gate.
+        if let Err(err) = self.persist_instance_record(instance_id) {
+            error!("{err:?}");
+        }
         Ok(())
     }
 
@@ -1336,15 +1374,83 @@ impl ProxyState {
         let had_override = info.admin_port_policy.take().is_some();
         info!("admin cleared port_policy for instance {instance_id} (was set: {had_override})");
         if had_override {
-            self.persist_instance_record(instance_id);
+            if let Err(err) = self.persist_instance_record(instance_id) {
+                error!("{err:?}");
+            }
         }
         Ok(())
     }
 
+    /// Open or close the operator traffic gate for an instance.
+    ///
+    /// Closing it removes the instance from app-id load balancing but leaves it
+    /// running and still reachable by instance id, which is the point: an
+    /// operator investigating a misbehaving instance needs it out of rotation
+    /// and reachable at the same time.
+    ///
+    /// Existing connections are deliberately left alone. They are already
+    /// bridged, and tearing them down would turn "stop sending it new work"
+    /// into a second, louder outage.
+    ///
+    /// Errors if the instance is not registered.
+    pub(crate) fn set_admin_ready(&mut self, instance_id: &str, ready: bool) -> Result<()> {
+        let Some(info) = self.state.instances.get_mut(instance_id) else {
+            bail!("instance {instance_id} not found");
+        };
+        let prev = info.is_admin_ready();
+        info.admin_ready = Some(ready);
+        let app_id = info.app_id.clone();
+        info!("admin set ready={ready} for instance {instance_id} (prev: {prev})");
+        if !ready && self.count_ready_instances(&app_id) == 0 {
+            // Not an error -- an operator may well mean to drain an app
+            // entirely -- but silently refusing every connection to an app is
+            // the kind of thing someone should be told about once.
+            warn!(
+                "instance {instance_id} was the last ready instance of app {app_id}; \
+                 the app will refuse new connections until one is set ready again"
+            );
+        }
+        // The selection cache holds a pre-gate snapshot. Drop it so the change
+        // applies to the next connection rather than up to `cache_top_n` later.
+        self.state.top_n.remove(&app_id);
+        // Not rolled back, but do not read that as "it still took effect
+        // locally". `reload_instances_from_kv_store` rebuilds every instance
+        // from the store, reading the gate back out of `admin_ready/`, and any
+        // peer writing an unrelated `inst/` record triggers it. So a failed
+        // write survives in memory only until the next reload -- seconds, not
+        // until restart. Rolling back here would just reach the same end state
+        // sooner while losing the brief window in which the operator's intent
+        // is at least locally in force.
+        self.persist_instance_record(instance_id).with_context(|| {
+            format!(
+                "instance {instance_id} is set to ready={ready} on this node \
+                     only and not durably: the write to the store failed, so it \
+                     will not reach the other gateways and will be undone here by \
+                     the next reload. Retry before relying on it"
+            )
+        })?;
+        Ok(())
+    }
+
+    /// How many of an app's instances the operator has left open to traffic.
+    fn count_ready_instances(&self, app_id: &str) -> usize {
+        let Some(instances) = self.state.apps.get(app_id) else {
+            return 0;
+        };
+        instances
+            .iter()
+            .filter_map(|id| self.state.instances.get(id))
+            .filter(|info| info.is_admin_ready())
+            .count()
+    }
+
     /// Persist the current in-memory `InstanceInfo` snapshot to WaveKV.
-    fn persist_instance_record(&self, instance_id: &str) {
+    ///
+    /// Returns the store error rather than only logging it, so callers whose
+    /// API promises the change is durable can say otherwise when it is not.
+    fn persist_instance_record(&self, instance_id: &str) -> Result<()> {
         let Some(info) = self.state.instances.get(instance_id) else {
-            return;
+            return Ok(());
         };
         let data = InstanceData {
             app_id: info.app_id.clone(),
@@ -1354,10 +1460,11 @@ impl ProxyState {
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
             admin_port_policy: info.admin_port_policy.clone(),
+            admin_ready: info.admin_ready,
         };
-        if let Err(err) = self.kv_store.sync_instance(instance_id, &data) {
-            error!("failed to sync instance {instance_id} to KvStore: {err:?}");
-        }
+        self.kv_store
+            .sync_instance(instance_id, &data)
+            .with_context(|| format!("failed to sync instance {instance_id} to KvStore"))
     }
 
     fn add_instance(&mut self, info: InstanceInfo) {
@@ -1371,6 +1478,7 @@ impl ProxyState {
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
             admin_port_policy: info.admin_port_policy.clone(),
+            admin_ready: info.admin_ready,
         };
         if let Err(err) = self.kv_store.sync_instance(&info.id, &data) {
             error!("failed to sync instance to KvStore: {err:?}");
@@ -1498,6 +1606,12 @@ impl ProxyState {
                 .iter()
                 .filter_map(|instance_id| {
                     let instance = self.state.instances.get(instance_id)?;
+                    // Operator gate. Only applied here, on the app-id path --
+                    // the instance-id lookup above returns before this point so
+                    // a gated instance stays directly reachable.
+                    if !instance.is_admin_ready() {
+                        return None;
+                    }
                     let (_, elapsed) = handshakes.get(&instance.public_key)?;
                     (*elapsed < self.config.proxy.timeouts.handshake_stale).then(|| {
                         (
@@ -1544,11 +1658,13 @@ impl ProxyState {
         // Filter healthy instances and choose randomly among them
         let healthy_instances = app_instances.iter().filter(|instance_id| {
             if let Some(instance) = self.state.instances.get(*instance_id) {
-                // Consider instance healthy if it had a recent handshake
-                handshakes
-                    .get(&instance.public_key)
-                    .map(|(_, elapsed)| *elapsed < self.config.proxy.timeouts.handshake_stale)
-                    .unwrap_or(false)
+                // Consider instance healthy if it had a recent handshake, and
+                // only if the operator has not gated it out of rotation.
+                instance.is_admin_ready()
+                    && handshakes
+                        .get(&instance.public_key)
+                        .map(|(_, elapsed)| *elapsed < self.config.proxy.timeouts.handshake_stale)
+                        .unwrap_or(false)
             } else {
                 false
             }

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1415,18 +1415,18 @@ impl ProxyState {
         self.state.top_n.remove(&app_id);
         // Not rolled back, but do not read that as "it still took effect
         // locally". `reload_instances_from_kv_store` rebuilds every instance
-        // from the store, reading the gate back out of `admin_ready/`, and any
-        // peer writing an unrelated `inst/` record triggers it. So a failed
-        // write survives in memory only until the next reload -- seconds, not
-        // until restart. Rolling back here would just reach the same end state
-        // sooner while losing the brief window in which the operator's intent
-        // is at least locally in force.
+        // from the store, and any peer writing an unrelated `inst/` record
+        // triggers it -- so the next reload reads back the very record this
+        // write failed to update, and the gate reverts. A failed write survives
+        // in memory only until then: seconds, not until restart. Rolling back
+        // here would just reach the same end state sooner while losing the brief
+        // window in which the operator's intent is at least locally in force.
         self.persist_instance_record(instance_id).with_context(|| {
             format!(
                 "instance {instance_id} is set to ready={ready} on this node \
-                     only and not durably: the write to the store failed, so it \
-                     will not reach the other gateways and will be undone here by \
-                     the next reload. Retry before relying on it"
+                 only and not durably: the write to the store failed, so it \
+                 will not reach the other gateways and will be undone here by \
+                 the next reload. Retry before relying on it"
             )
         })?;
         Ok(())

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -752,7 +752,7 @@ fn build_state_from_kv_store(config: &Config, instances: LoadedInstances) -> Pro
             port_policy: data.port_policy,
             port_policy_hash: data.port_policy_hash,
             admin_port_policy: data.admin_port_policy,
-            admin_ready: data.admin_ready,
+            ready: data.ready,
             connections: Default::default(),
         };
         state.allocated_addresses.insert(data.ip);
@@ -1115,7 +1115,7 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
             port_policy: data.port_policy.clone(),
             port_policy_hash: data.port_policy_hash.clone(),
             admin_port_policy: data.admin_port_policy.clone(),
-            admin_ready: data.admin_ready,
+            ready: data.ready,
             connections: Default::default(),
         };
 
@@ -1229,13 +1229,13 @@ impl ProxyState {
         // they have to be carried across by hand. Otherwise the traffic gate
         // falls open and the port-policy override silently reverts to whatever
         // the instance reports about itself.
-        let mut carried_admin_ready = None;
+        let mut carried_ready = None;
         let mut carried_admin_port_policy = None;
         if let Some(existing) = self.state.instances.get_mut(id) {
             if existing.app_id != app_id {
                 bail!("instance_id is already registered to a different app");
             }
-            carried_admin_ready = existing.admin_ready;
+            carried_ready = existing.ready;
             carried_admin_port_policy = existing.admin_port_policy.clone();
             let pubkey_changed = existing.public_key != public_key;
             if pubkey_changed {
@@ -1272,7 +1272,7 @@ impl ProxyState {
                     port_policy: existing.port_policy.clone(),
                     port_policy_hash: existing.port_policy_hash.clone(),
                     admin_port_policy: existing.admin_port_policy.clone(),
-                    admin_ready: existing.admin_ready,
+                    ready: existing.ready,
                 };
                 if let Err(err) = self.kv_store.sync_instance(&existing.id, &data) {
                     error!("failed to sync existing instance to KvStore: {err:?}");
@@ -1294,7 +1294,7 @@ impl ProxyState {
             port_policy,
             port_policy_hash: compose_hash.to_string(),
             admin_port_policy: carried_admin_port_policy,
-            admin_ready: carried_admin_ready,
+            ready: carried_ready,
             connections: Default::default(),
         };
         self.add_instance(host_info.clone());
@@ -1393,12 +1393,12 @@ impl ProxyState {
     /// into a second, louder outage.
     ///
     /// Errors if the instance is not registered.
-    pub(crate) fn set_admin_ready(&mut self, instance_id: &str, ready: bool) -> Result<()> {
+    pub(crate) fn set_ready(&mut self, instance_id: &str, ready: bool) -> Result<()> {
         let Some(info) = self.state.instances.get_mut(instance_id) else {
             bail!("instance {instance_id} not found");
         };
-        let prev = info.is_admin_ready();
-        info.admin_ready = Some(ready);
+        let prev = info.is_ready();
+        info.ready = Some(ready);
         let app_id = info.app_id.clone();
         info!("admin set ready={ready} for instance {instance_id} (prev: {prev})");
         if !ready && self.count_ready_instances(&app_id) == 0 {
@@ -1440,7 +1440,7 @@ impl ProxyState {
         instances
             .iter()
             .filter_map(|id| self.state.instances.get(id))
-            .filter(|info| info.is_admin_ready())
+            .filter(|info| info.is_ready())
             .count()
     }
 
@@ -1460,7 +1460,7 @@ impl ProxyState {
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
             admin_port_policy: info.admin_port_policy.clone(),
-            admin_ready: info.admin_ready,
+            ready: info.ready,
         };
         self.kv_store
             .sync_instance(instance_id, &data)
@@ -1478,7 +1478,7 @@ impl ProxyState {
             port_policy: info.port_policy.clone(),
             port_policy_hash: info.port_policy_hash.clone(),
             admin_port_policy: info.admin_port_policy.clone(),
-            admin_ready: info.admin_ready,
+            ready: info.ready,
         };
         if let Err(err) = self.kv_store.sync_instance(&info.id, &data) {
             error!("failed to sync instance to KvStore: {err:?}");
@@ -1609,7 +1609,7 @@ impl ProxyState {
                     // Operator gate. Only applied here, on the app-id path --
                     // the instance-id lookup above returns before this point so
                     // a gated instance stays directly reachable.
-                    if !instance.is_admin_ready() {
+                    if !instance.is_ready() {
                         return None;
                     }
                     let (_, elapsed) = handshakes.get(&instance.public_key)?;
@@ -1660,7 +1660,7 @@ impl ProxyState {
             if let Some(instance) = self.state.instances.get(*instance_id) {
                 // Consider instance healthy if it had a recent handshake, and
                 // only if the operator has not gated it out of rotation.
-                instance.is_admin_ready()
+                instance.is_ready()
                     && handshakes
                         .get(&instance.public_key)
                         .map(|(_, elapsed)| *elapsed < self.config.proxy.timeouts.handshake_stale)

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -40,9 +40,9 @@ use crate::{
     cert_store::{CertResolver, CertStoreBuilder},
     config::{Config, TlsConfig},
     kv::{
-        fetch_peers_from_bootnode, import, AppIdValidator, CertData, HttpsClientConfig,
-        InstanceData, KvStore, LoadedInstances, NodeData, NodeStatus, PortPolicy,
-        WaveKvSyncService,
+        fetch_peers_from_bootnode, import, AdminOverrides, AdminPortPolicy, AppIdValidator,
+        CertData, HttpsClientConfig, InstanceData, InstanceGate, KvStore, LoadedInstances,
+        LoadedOverrides, NodeData, NodeStatus, PortPolicy, WaveKvSyncService,
     },
     models::{InstanceInfo, PortPolicyView, WgConf, WgPeer},
     proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo, AppAddressResolver},
@@ -119,6 +119,8 @@ pub(crate) struct ProxyState {
     /// Reason last logged for each KV instance record this node refuses, so a
     /// record that stays bad is reported once rather than on every reload.
     reported_rejections: BTreeMap<String, String>,
+    /// The same, for `admin/` records this node cannot decode.
+    reported_bad_overrides: BTreeMap<String, String>,
 }
 
 /// Options for creating a Proxy instance
@@ -285,7 +287,11 @@ impl ProxyInner {
             instances.undecodable.len(),
             nodes.len()
         );
-        let state = build_state_from_kv_store(&config, instances);
+        // Read-only: nothing may be written before the bootstrap below, so the
+        // move of any legacy overrides waits for the first reload.
+        let overrides = kv_store.load_all_instance_overrides();
+        let legacy_overrides = kv_store.legacy_instance_overrides();
+        let state = build_state_from_kv_store(&config, instances, &overrides, &legacy_overrides);
 
         // This node's own records are written *after* the bootstrap below, not
         // here. A local write allocates a sequence number, and after a
@@ -363,6 +369,7 @@ impl ProxyInner {
             handshake_cache: handshake_cache.clone(),
             admin_shutdown: None,
             reported_rejections: BTreeMap::new(),
+            reported_bad_overrides: BTreeMap::new(),
         });
         let auth_client = AuthClient::new(config.auth.clone());
         // Bootstrap WaveKV first if sync is enabled, so certbot can load certs from peers
@@ -738,7 +745,66 @@ fn report_new_rejections(
     *reported = current;
 }
 
-fn build_state_from_kv_store(config: &Config, instances: LoadedInstances) -> ProxyStateMut {
+/// The operator overrides in force for `instance_id`.
+///
+/// The `admin/` record wins whenever there is one, including when it says
+/// nothing is overridden. Only when there is none does the copy an older build
+/// left inside the instance record apply -- that is the same rule
+/// [`KvStore::migrate_legacy_instance_overrides`] writes by, so a reload before
+/// the move and one after it answer the same thing.
+///
+/// A record that will not decode is neither. Guessing "nothing is overridden"
+/// is what would return a quarantined instance to rotation, so the instance is
+/// held out of app-id selection until the record is readable again; it stays
+/// reachable by instance id throughout, as a gated instance always is.
+fn effective_overrides(
+    instance_id: &str,
+    current: &LoadedOverrides,
+    legacy: &BTreeMap<String, AdminOverrides>,
+) -> AdminOverrides {
+    if current.unreadable.contains_key(instance_id) {
+        return AdminOverrides {
+            port_policy: None,
+            ready: Some(false),
+        };
+    }
+    current
+        .decoded
+        .get(instance_id)
+        .or_else(|| legacy.get(instance_id))
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Report override records this node cannot read, once per transition.
+///
+/// Unreadable means the instance is held out of app-id rotation, so it is not a
+/// quiet condition -- but a record that stays bad would otherwise be reported on
+/// every reload, and reloads are driven by cluster activity.
+fn report_unreadable_overrides(proxy: &Proxy, loaded: &LoadedOverrides) {
+    let mut state = proxy.lock();
+    for (instance_id, reason) in &loaded.unreadable {
+        if state.reported_bad_overrides.get(instance_id) != Some(reason) {
+            error!(
+                "cannot read the operator overrides for instance {instance_id}, holding it \
+                 out of load balancing until they are readable again: {reason}"
+            );
+        }
+    }
+    for instance_id in state.reported_bad_overrides.keys() {
+        if !loaded.unreadable.contains_key(instance_id) {
+            info!("operator overrides for instance {instance_id} are readable again");
+        }
+    }
+    state.reported_bad_overrides = loaded.unreadable.clone();
+}
+
+fn build_state_from_kv_store(
+    config: &Config,
+    instances: LoadedInstances,
+    overrides: &LoadedOverrides,
+    legacy_overrides: &BTreeMap<String, AdminOverrides>,
+) -> ProxyStateMut {
     let mut state = ProxyStateMut::default();
 
     let accepted = import::accept_instances(&config.wg, instances);
@@ -746,6 +812,7 @@ fn build_state_from_kv_store(config: &Config, instances: LoadedInstances) -> Pro
 
     // Build instances
     for (instance_id, data) in accepted.instances {
+        let admin = effective_overrides(&instance_id, overrides, legacy_overrides);
         let info = InstanceInfo {
             id: instance_id.clone(),
             app_id: data.app_id.clone(),
@@ -756,8 +823,8 @@ fn build_state_from_kv_store(config: &Config, instances: LoadedInstances) -> Pro
                 .unwrap_or(UNIX_EPOCH),
             port_policy: data.port_policy,
             port_policy_hash: data.port_policy_hash,
-            admin_port_policy: data.admin_port_policy,
-            ready: data.ready,
+            admin_port_policy: admin.port_policy,
+            ready: admin.ready,
             connections: Default::default(),
         };
         state.allocated_addresses.insert(data.ip);
@@ -973,14 +1040,29 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
     let store_clone = kv_store.clone();
     // Register watcher first, then do initial load to avoid race condition
     let mut rx = store_clone.watch_instances();
+    // The operator overrides live under their own prefix, so a peer opening or
+    // closing a traffic gate does not touch `inst/` and would never wake the
+    // watcher above.
+    let mut overrides_rx = store_clone.watch_instance_overrides();
     reload_instances_from_kv_store(&proxy_clone, &store_clone)
         .context("Failed to initial load instances from KvStore")?;
     tokio::spawn(async move {
         loop {
-            if rx.changed().await.is_err() {
-                break;
-            }
-            info!("WaveKV: detected remote instance changes, reloading...");
+            let reason = tokio::select! {
+                changed = rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    "instance"
+                }
+                changed = overrides_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    "operator override"
+                }
+            };
+            info!("WaveKV: detected remote {reason} changes, reloading...");
             if let Err(err) = reload_instances_from_kv_store(&proxy_clone, &store_clone) {
                 error!("Failed to reload instances from KvStore: {err:?}");
             }
@@ -1118,6 +1200,19 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
 const LOCAL_REGISTRATION_GRACE: Duration = Duration::from_secs(60);
 
 fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> {
+    // Before the read, so an override an older node left in an instance record
+    // reaches its own key while that record is still the one carrying it.
+    let moved = store.migrate_legacy_instance_overrides();
+    if !moved.is_empty() {
+        info!(
+            "WaveKV: moved operator overrides for {} instance(s) out of the instance record: {}",
+            moved.len(),
+            moved.join(", ")
+        );
+    }
+    let overrides = store.load_all_instance_overrides();
+    report_unreadable_overrides(proxy, &overrides);
+    let legacy_overrides = store.legacy_instance_overrides();
     let accepted = import::accept_instances(&proxy.config.wg, store.load_all_instances());
     // An unreadable record is not a deletion. Its instance keeps whatever the
     // data plane already holds, so it must be exempt from the removal pass
@@ -1153,6 +1248,7 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
     }
 
     for (instance_id, data) in instances {
+        let admin = effective_overrides(&instance_id, &overrides, &legacy_overrides);
         let mut new_info = InstanceInfo {
             id: instance_id.clone(),
             app_id: data.app_id.clone(),
@@ -1163,8 +1259,8 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
                 .unwrap_or(UNIX_EPOCH),
             port_policy: data.port_policy.clone(),
             port_policy_hash: data.port_policy_hash.clone(),
-            admin_port_policy: data.admin_port_policy.clone(),
-            ready: data.ready,
+            admin_port_policy: admin.port_policy,
+            ready: admin.ready,
             connections: Default::default(),
         };
 
@@ -1416,8 +1512,8 @@ impl ProxyState {
             prev.is_some(),
         );
         // Pre-existing behaviour: a failed write is logged, not returned.
-        // Left alone here so this change stays about the traffic gate.
-        if let Err(err) = self.persist_instance_record(instance_id) {
+        // Left alone here so this change stays about where the record lives.
+        if let Err(err) = self.persist_instance_port_policy_override(instance_id) {
             error!("{err:?}");
         }
         Ok(())
@@ -1432,7 +1528,11 @@ impl ProxyState {
         let had_override = info.admin_port_policy.take().is_some();
         info!("admin cleared port_policy for instance {instance_id} (was set: {had_override})");
         if had_override {
-            if let Err(err) = self.persist_instance_record(instance_id) {
+            // Written, not deleted. An absent key means "no operator has
+            // decided anything here", which lets the legacy fallback apply --
+            // so deleting it would let a copy an older node left in the
+            // instance record put the override straight back.
+            if let Err(err) = self.persist_instance_port_policy_override(instance_id) {
                 error!("{err:?}");
             }
         }
@@ -1481,7 +1581,7 @@ impl ProxyState {
         // message -- so the message says what is known instead. Rolling back
         // here would reach the same end state sooner while throwing away the
         // window in which the operator's intent is at least locally in force.
-        self.persist_instance_record(instance_id).with_context(|| {
+        self.persist_instance_gate(instance_id).with_context(|| {
             format!(
                 "instance {instance_id} is set to ready={ready} in memory on \
                  this node only: the write to the store failed, so the setting \
@@ -1594,6 +1694,47 @@ impl ProxyState {
             .filter_map(|id| self.state.instances.get(id))
             .filter(|info| self.is_eligible(info, &handshakes))
             .count())
+    }
+
+    /// Persist the operator's traffic gate for `instance_id` to WaveKV.
+    ///
+    /// Separate from [`Self::persist_instance_record`], and from the port-policy
+    /// override beside it, because each is a separate key -- which is the point.
+    /// This one is written only from `Admin.SetInstanceReady`, so neither a
+    /// re-registration nor a peer's unsynced change to the other override can
+    /// overwrite it.
+    ///
+    /// Returns the store error rather than only logging it, so callers whose
+    /// API promises the change is durable can say otherwise when it is not.
+    fn persist_instance_gate(&self, instance_id: &str) -> Result<()> {
+        let Some(info) = self.state.instances.get(instance_id) else {
+            return Ok(());
+        };
+        let Some(ready) = info.ready else {
+            return Ok(());
+        };
+        self.kv_store
+            .sync_instance_gate(instance_id, &InstanceGate { ready })
+            .with_context(|| {
+                format!("failed to sync the gate for instance {instance_id} to KvStore")
+            })
+    }
+
+    /// Persist the operator's port-policy override for `instance_id` to WaveKV.
+    fn persist_instance_port_policy_override(&self, instance_id: &str) -> Result<()> {
+        let Some(info) = self.state.instances.get(instance_id) else {
+            return Ok(());
+        };
+        let data = AdminPortPolicy {
+            policy: info.admin_port_policy.clone(),
+        };
+        self.kv_store
+            .sync_instance_port_policy_override(instance_id, &data)
+            .with_context(|| {
+                format!(
+                    "failed to sync the port-policy override for instance {instance_id} to KvStore"
+                )
+            })
     }
 
     /// Persist the current in-memory `InstanceInfo` snapshot to WaveKV.

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -40,7 +40,7 @@ use crate::{
     cert_store::{CertResolver, CertStoreBuilder},
     config::{Config, TlsConfig},
     kv::{
-        fetch_peers_from_bootnode, import, AdminOverrides, AdminPortPolicy, AppIdValidator,
+        fetch_peers_from_bootnode, import, keys, AdminOverrides, AdminPortPolicy, AppIdValidator,
         CertData, HttpsClientConfig, InstanceData, InstanceGate, KvStore, LoadedInstances,
         LoadedOverrides, NodeData, NodeStatus, PortPolicy, WaveKvSyncService,
     },
@@ -768,12 +768,26 @@ fn effective_overrides(
             ready: Some(false),
         };
     }
-    current
-        .decoded
-        .get(instance_id)
-        .or_else(|| legacy.get(instance_id))
-        .cloned()
-        .unwrap_or_default()
+    // Per key, not per instance. They are separate keys, so one of them
+    // existing says nothing about the other: an operator who sets the gate
+    // through the new path on an instance whose port-policy override is still
+    // in the instance record would otherwise have the override dropped, which
+    // is the failure this whole split exists to remove.
+    let written = current.written_keys(instance_id);
+    let stored = current.decoded.get(instance_id);
+    let legacy = legacy.get(instance_id);
+    AdminOverrides {
+        ready: if written.contains(keys::ADMIN_READY) {
+            stored.and_then(|stored| stored.ready)
+        } else {
+            legacy.and_then(|legacy| legacy.ready)
+        },
+        port_policy: if written.contains(keys::ADMIN_PORT_POLICY) {
+            stored.and_then(|stored| stored.port_policy.clone())
+        } else {
+            legacy.and_then(|legacy| legacy.port_policy.clone())
+        },
+    }
 }
 
 /// Report override records this node cannot read, once per transition.

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1541,6 +1541,46 @@ impl ProxyState {
         )))
     }
 
+    /// Why an app-id selection came back empty.
+    ///
+    /// The proxy learns "no candidates" as an absence, and the layer that sees
+    /// the absence first is the port-policy filter -- which has not looked at a
+    /// port yet and cannot say why. Selection is where the reason exists, so
+    /// the reason is reconstructed here rather than guessed at downstream.
+    pub(crate) fn describe_empty_selection(&self, app_id: &str) -> String {
+        let Some(instance_ids) = self.state.apps.get(app_id) else {
+            return format!("app {app_id} has no registered instances");
+        };
+        let total = instance_ids.len();
+        // The random-selection fallback swallows this error, so it is a real
+        // way to arrive here with instances that are perfectly healthy.
+        let handshakes = match self.latest_handshakes(None) {
+            Ok(handshakes) => handshakes,
+            Err(err) => {
+                return format!(
+                    "could not read WireGuard handshakes, so none of app {app_id}'s \
+                     {total} instance(s) could be checked for liveness: {err:#}"
+                )
+            }
+        };
+        let mut gated = 0;
+        let mut stale = 0;
+        for instance in instance_ids
+            .iter()
+            .filter_map(|id| self.state.instances.get(id))
+        {
+            if !instance.is_ready() {
+                gated += 1;
+            } else if !self.handshake_is_fresh(instance, &handshakes) {
+                stale += 1;
+            }
+        }
+        format!(
+            "no instance of app {app_id} is currently routable: {total} registered, \
+             {gated} gated out by an operator, {stale} with no recent WireGuard handshake"
+        )
+    }
+
     /// How many of an app's instances can currently be given new traffic.
     fn count_eligible_instances(&self, app_id: &str) -> Result<usize> {
         let Some(instances) = self.state.apps.get(app_id) else {
@@ -1707,8 +1747,8 @@ impl ProxyState {
                     if !self.is_eligible(instance, &handshakes) {
                         return None;
                     }
-                    // Re-read for the sort key; eligibility already proved it
-                    // is present and fresh.
+                    // Re-read for the sort key. `is_eligible` already proved
+                    // it is present and fresh.
                     let (_, elapsed) = handshakes.get(&instance.public_key)?;
                     Some((
                         instance.ip,

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -46,7 +46,7 @@ use crate::{
     },
     models::{InstanceInfo, PortPolicyView, WgConf, WgPeer},
     proxy::{create_acceptor_with_cert_resolver, AddressGroup, AddressInfo, AppAddressResolver},
-    time::{decode_ts, encode_ts, now_secs},
+    time::{decode_ts, now_secs},
 };
 
 mod auth_client;
@@ -1272,20 +1272,17 @@ impl ProxyState {
         {
             bail!("WireGuard public key is already registered to another instance");
         }
-        // Both operator overrides live only in the instance record, so when the
-        // rebuild path below reconstructs the instance from scratch -- it does
-        // that when the recorded IP is no longer inside the configured range --
-        // they have to be carried across by hand. Otherwise the traffic gate
-        // falls open and the port-policy override silently reverts to whatever
-        // the instance reports about itself.
-        let mut carried_ready = None;
-        let mut carried_admin_port_policy = None;
+        // The rebuild path below reconstructs the instance from scratch -- it
+        // does that when the recorded IP is no longer inside the configured
+        // range -- and everything the registration does not re-state has to
+        // survive that. The operator overrides in particular live nowhere else:
+        // lose them and the traffic gate falls open while the port-policy
+        // override silently reverts to whatever the instance says about itself.
+        let mut previous: Option<InstanceInfo> = None;
         if let Some(existing) = self.state.instances.get_mut(id) {
             if existing.app_id != app_id {
                 bail!("instance_id is already registered to a different app");
             }
-            carried_ready = existing.ready;
-            carried_admin_port_policy = existing.admin_port_policy.clone();
             let pubkey_changed = existing.public_key != public_key;
             if pubkey_changed {
                 info!("public key changed for instance {id}, new key: {public_key}");
@@ -1313,16 +1310,7 @@ impl ProxyState {
             let existing = existing.clone();
             if self.valid_ip(existing.ip) {
                 // Sync existing instance to KvStore (might be from legacy state)
-                let data = InstanceData {
-                    app_id: existing.app_id.clone(),
-                    ip: existing.ip,
-                    public_key: existing.public_key.clone(),
-                    reg_time: encode_ts(existing.reg_time),
-                    port_policy: existing.port_policy.clone(),
-                    port_policy_hash: existing.port_policy_hash.clone(),
-                    admin_port_policy: existing.admin_port_policy.clone(),
-                    ready: existing.ready,
-                };
+                let data = InstanceData::from(&existing);
                 if let Err(err) = self.kv_store.sync_instance(&existing.id, &data) {
                     error!("failed to sync existing instance to KvStore: {err:?}");
                 }
@@ -1330,21 +1318,39 @@ impl ProxyState {
             }
             info!("ip {} is invalid, removing", existing.ip);
             self.state.allocated_addresses.remove(&existing.ip);
+            previous = Some(existing);
         }
         let ip = self
             .alloc_ip()
             .context("IP pool exhausted, no available addresses in client_ip_range")?;
-        let host_info = InstanceInfo {
-            id: id.to_string(),
-            app_id: app_id.to_string(),
-            ip,
-            public_key: public_key.to_string(),
-            reg_time: SystemTime::now(),
-            port_policy,
-            port_policy_hash: compose_hash.to_string(),
-            admin_port_policy: carried_admin_port_policy,
-            ready: carried_ready,
-            connections: Default::default(),
+        let host_info = match previous {
+            // Rebuilding a record that already existed. Start from it and
+            // overwrite only what this registration actually re-states, so a
+            // field added later is carried by default rather than by someone
+            // remembering to add a line here.
+            Some(existing) => InstanceInfo {
+                ip,
+                public_key: public_key.to_string(),
+                reg_time: SystemTime::now(),
+                port_policy,
+                port_policy_hash: compose_hash.to_string(),
+                connections: Default::default(),
+                ..existing
+            },
+            // First registration: no operator has had the chance to set
+            // anything, so every field is stated here and the compiler says so.
+            None => InstanceInfo {
+                id: id.to_string(),
+                app_id: app_id.to_string(),
+                ip,
+                public_key: public_key.to_string(),
+                reg_time: SystemTime::now(),
+                port_policy,
+                port_policy_hash: compose_hash.to_string(),
+                admin_port_policy: None,
+                ready: None,
+                connections: Default::default(),
+            },
         };
         self.add_instance(host_info.clone());
         Ok(host_info)
@@ -1501,16 +1507,7 @@ impl ProxyState {
         let Some(info) = self.state.instances.get(instance_id) else {
             return Ok(());
         };
-        let data = InstanceData {
-            app_id: info.app_id.clone(),
-            ip: info.ip,
-            public_key: info.public_key.clone(),
-            reg_time: encode_ts(info.reg_time),
-            port_policy: info.port_policy.clone(),
-            port_policy_hash: info.port_policy_hash.clone(),
-            admin_port_policy: info.admin_port_policy.clone(),
-            ready: info.ready,
-        };
+        let data = InstanceData::from(info);
         self.kv_store
             .sync_instance(instance_id, &data)
             .with_context(|| format!("failed to sync instance {instance_id} to KvStore"))
@@ -1519,16 +1516,7 @@ impl ProxyState {
     fn add_instance(&mut self, info: InstanceInfo) {
         self.state.top_n.remove(&info.app_id);
         // Sync to KvStore
-        let data = InstanceData {
-            app_id: info.app_id.clone(),
-            ip: info.ip,
-            public_key: info.public_key.clone(),
-            reg_time: encode_ts(info.reg_time),
-            port_policy: info.port_policy.clone(),
-            port_policy_hash: info.port_policy_hash.clone(),
-            admin_port_policy: info.admin_port_policy.clone(),
-            ready: info.ready,
-        };
+        let data = InstanceData::from(&info);
         if let Err(err) = self.kv_store.sync_instance(&info.id, &data) {
             error!("failed to sync instance to KvStore: {err:?}");
         }

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -269,7 +269,7 @@ impl ProxyInner {
                 config.sync.node_id,
                 vec![],
                 &config.sync.data_dir,
-                (!config.sync.wal_sync_interval.is_zero()).then_some(config.sync.wal_sync_interval),
+                (!config.sync.wal_sync_window.is_zero()).then_some(config.sync.wal_sync_window),
             )
             .context("failed to initialize WaveKV store")?,
         );
@@ -1143,11 +1143,16 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
     // at the window itself is enough to make it one: the store measures from
     // its last fsync, so a write is forced at the first tick that finds the
     // window elapsed, never more than one window after it landed.
-    let wal_sync_interval = proxy.config.sync.wal_sync_interval;
-    if !wal_sync_interval.is_zero() {
+    let wal_sync_window = proxy.config.sync.wal_sync_window;
+    if wal_sync_window.is_zero() {
+        // Not silence: no window is the strictest setting, and an operator who
+        // set zero expecting to turn the work off should find out here rather
+        // than from a latency graph.
+        info!("WaveKV: no WAL sync window, every write is forced before it returns");
+    } else {
         let kv_store_for_wal = kv_store.clone();
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(wal_sync_interval);
+            let mut ticker = tokio::time::interval(wal_sync_window);
             loop {
                 ticker.tick().await;
                 let kv = kv_store_for_wal.clone();
@@ -1164,7 +1169,7 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
                 }
             }
         });
-        info!("WaveKV: deferred WAL sync enabled (window: {wal_sync_interval:?})");
+        info!("WaveKV: deferred WAL sync enabled (window: {wal_sync_window:?})");
     }
 
     // Start periodic connection sync task

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1244,6 +1244,11 @@ fn reload_instances_from_kv_store(proxy: &Proxy, store: &KvStore) -> Result<()> 
     for instance_id in removed {
         info!("WaveKV: instance {instance_id} was deleted remotely, dropping it");
         state.forget_instance(&instance_id);
+        // The node that deleted it could only withdraw its own `conn/` and
+        // `handshake/` keys. Ours are ours to withdraw.
+        if let Err(err) = store.sync_forget_local_observations(&instance_id) {
+            warn!("failed to withdraw this node's observations of {instance_id}: {err:?}");
+        }
         wg_changed = true;
     }
 

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -26,7 +26,6 @@ use ra_tls::attestation::AppInfo;
 use rand::seq::IteratorRandom;
 use rinja::Template as _;
 use safe_write::safe_write_with_mode;
-use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
@@ -100,12 +99,17 @@ pub struct ProxyInner {
 const HANDSHAKE_CACHE_TTL: Duration = Duration::from_secs(30);
 const HANDSHAKE_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+/// The routing tables, rebuilt from WaveKV on every reload.
+///
+/// Held only in memory. It carried `Serialize`/`Deserialize` from the days
+/// before WaveKV, when it was written to a state file; nothing has serialized
+/// it since, and the derives kept every `#[serde]` attribute on the types it
+/// reaches looking load-bearing when none of them were.
+#[derive(Debug, Default)]
 pub(crate) struct ProxyStateMut {
     pub(crate) apps: BTreeMap<String, BTreeSet<String>>,
     pub(crate) instances: BTreeMap<String, InstanceInfo>,
     pub(crate) allocated_addresses: BTreeSet<Ipv4Addr>,
-    #[serde(skip)]
     pub(crate) top_n: BTreeMap<String, (AddressGroup, Instant)>,
 }
 

--- a/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config-2.snap
+++ b/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config-2.snap
@@ -15,5 +15,6 @@ InstanceInfo {
     port_policy: None,
     port_policy_hash: "",
     admin_port_policy: None,
+    admin_ready: None,
     connections: 0,
 }

--- a/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config-2.snap
+++ b/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config-2.snap
@@ -15,6 +15,6 @@ InstanceInfo {
     port_policy: None,
     port_policy_hash: "",
     admin_port_policy: None,
-    admin_ready: None,
+    ready: None,
     connections: 0,
 }

--- a/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config.snap
+++ b/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config.snap
@@ -15,5 +15,6 @@ InstanceInfo {
     port_policy: None,
     port_policy_hash: "",
     admin_port_policy: None,
+    admin_ready: None,
     connections: 0,
 }

--- a/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config.snap
+++ b/dstack/gateway/src/main_service/snapshots/dstack_gateway__main_service__tests__config.snap
@@ -15,6 +15,6 @@ InstanceInfo {
     port_policy: None,
     port_policy_hash: "",
     admin_port_policy: None,
-    admin_ready: None,
+    ready: None,
     connections: 0,
 }

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -643,6 +643,30 @@ async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
     );
 }
 
+/// Whether this node's `conn/` record for the fixture instance is live.
+///
+/// Reads the raw entry because `KvStore` exposes no conn accessor, and uses the
+/// store's own node id rather than the config's so the key matches whatever
+/// `sync_connections` wrote -- the two agree today, and this keeps the
+/// assertions honest if they ever stop agreeing.
+fn conn_is_live(state: &TestState) -> bool {
+    let key = crate::kv::keys::conn("gone-app-0", state.kv_store.my_node_id());
+    state
+        .kv_store
+        .ephemeral()
+        .read()
+        .get(&key)
+        .is_some_and(|entry| !entry.is_deleted())
+}
+
+/// Whether this node's `handshake/` observation for the fixture instance is live.
+fn handshake_is_live(state: &TestState) -> bool {
+    state
+        .kv_store
+        .get_instance_handshakes("gone-app-0")
+        .contains_key(&state.kv_store.my_node_id())
+}
+
 /// Removing an instance must take its gate with it, or a later instance
 /// reusing the id would inherit a quarantine nobody asked for.
 #[tokio::test]
@@ -656,13 +680,28 @@ async fn removing_an_instance_removes_its_gate() {
             state.kv_store.load_all_instances().decoded["gone-app-0"].admin_ready,
             Some(false)
         );
+        // Seed the two ephemeral records as well, or the assertions below pass
+        // whether or not the deletes are issued.
+        state.kv_store.sync_connections("gone-app-0", 3).unwrap();
+        state
+            .kv_store
+            .sync_instance_handshake("gone-app-0", 1)
+            .unwrap();
+        // Assert they are live first. Without this the post-delete assertions
+        // go quietly vacuous again the moment the seeds stop landing on the
+        // keys they are checked against -- which is the failure this test
+        // exists to rule out.
+        assert!(conn_is_live(&state), "seeded conn/ record should be live");
+        assert!(
+            handshake_is_live(&state),
+            "seeded handshake/ record should be live"
+        );
         proxy.remove_instance("gone-app-0").unwrap();
     }
     // The gate lives in the instance record, so removing the instance takes it
     // with it. The deletes are issued unconditionally so a failure in one
     // cannot strand the others, which is only worth anything if they are all
     // actually issued.
-    let node = state.config.sync.node_id;
     let key = crate::kv::keys::inst("gone-app-0");
     let live = state
         .kv_store
@@ -671,10 +710,11 @@ async fn removing_an_instance_removes_its_gate() {
         .get(&key)
         .is_some_and(|entry| !entry.is_deleted());
     assert!(!live, "{key} should be gone");
-    assert!(!state
-        .kv_store
-        .get_instance_handshakes("gone-app-0")
-        .contains_key(&node));
+    assert!(
+        !handshake_is_live(&state),
+        "handshake/ record should be gone"
+    );
+    assert!(!conn_is_live(&state), "conn/ record should be gone");
 }
 
 /// Selection handing over an empty group means every instance was ruled out

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -491,7 +491,7 @@ async fn gating_an_instance_removes_it_from_rotation_but_keeps_it_directly_reach
         3
     );
 
-    proxy.set_admin_ready("gated-app-1", false).unwrap();
+    proxy.set_ready("gated-app-1", false).unwrap();
 
     let after = selected_ids(&proxy.select_top_n_hosts("gated-app").unwrap());
     assert_eq!(after, vec!["gated-app-0", "gated-app-2"]);
@@ -513,7 +513,7 @@ async fn gating_an_instance_invalidates_the_selection_cache() {
     proxy.select_top_n_hosts("cache-app").unwrap();
     assert_eq!(proxy.state.top_n.len(), 1, "selection should be cached");
 
-    proxy.set_admin_ready("cache-app-0", false).unwrap();
+    proxy.set_ready("cache-app-0", false).unwrap();
     assert!(
         proxy.state.top_n.is_empty(),
         "closing the gate must drop the cached selection"
@@ -533,15 +533,15 @@ async fn gating_every_instance_refuses_traffic_instead_of_failing_open() {
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "drained-app", 2);
 
-    proxy.set_admin_ready("drained-app-0", false).unwrap();
-    proxy.set_admin_ready("drained-app-1", false).unwrap();
+    proxy.set_ready("drained-app-0", false).unwrap();
+    proxy.set_ready("drained-app-1", false).unwrap();
 
     assert!(
         proxy.select_top_n_hosts("drained-app").unwrap().is_empty(),
         "an operator draining every instance must be obeyed, not overridden"
     );
 
-    proxy.set_admin_ready("drained-app-1", true).unwrap();
+    proxy.set_ready("drained-app-1", true).unwrap();
     assert_eq!(
         selected_ids(&proxy.select_top_n_hosts("drained-app").unwrap()),
         vec!["drained-app-1"]
@@ -556,7 +556,7 @@ async fn the_gate_survives_re_registration() {
     let state = create_test_state().await;
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "reboot-app", 2);
-    proxy.set_admin_ready("reboot-app-0", false).unwrap();
+    proxy.set_ready("reboot-app-0", false).unwrap();
 
     // Same instance id, same key: a reboot re-running registration.
     proxy
@@ -583,7 +583,7 @@ async fn the_random_selection_path_honours_the_gate() {
     let state = create_test_state_with(|config| config.proxy.connect_top_n = 0).await;
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "random-app", 2);
-    proxy.set_admin_ready("random-app-0", false).unwrap();
+    proxy.set_ready("random-app-0", false).unwrap();
 
     for _ in 0..16 {
         assert_eq!(
@@ -622,7 +622,7 @@ async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
             port_policy: existing.port_policy.clone(),
             port_policy_hash: existing.port_policy_hash.clone(),
             admin_port_policy: None,
-            admin_ready: Some(false),
+            ready: Some(false),
         }
     };
     state.kv_store.sync_instance("peer-app-0", &gated).unwrap();
@@ -675,9 +675,9 @@ async fn removing_an_instance_removes_its_gate() {
     {
         let mut proxy = state.lock();
         register_ready_instances(&mut proxy, "gone-app", 2);
-        proxy.set_admin_ready("gone-app-0", false).unwrap();
+        proxy.set_ready("gone-app-0", false).unwrap();
         assert_eq!(
-            state.kv_store.load_all_instances().decoded["gone-app-0"].admin_ready,
+            state.kv_store.load_all_instances().decoded["gone-app-0"].ready,
             Some(false)
         );
         // Seed the two ephemeral records as well, or the assertions below pass
@@ -727,7 +727,7 @@ async fn an_empty_candidate_group_is_not_blamed_on_the_port_policy() {
     {
         let mut proxy = state.lock();
         register_ready_instances(&mut proxy, "drain-all", 1);
-        proxy.set_admin_ready("drain-all-0", false).unwrap();
+        proxy.set_ready("drain-all-0", false).unwrap();
     }
     let mut proxy = state.lock();
     let empty = proxy.select_top_n_hosts("drain-all").unwrap();
@@ -748,7 +748,7 @@ async fn an_empty_candidate_group_is_not_blamed_on_the_port_policy() {
 async fn gating_an_unregistered_instance_is_an_error() {
     let state = create_test_state().await;
     let mut proxy = state.lock();
-    assert!(proxy.set_admin_ready("never-registered", false).is_err());
+    assert!(proxy.set_ready("never-registered", false).is_err());
 }
 
 /// Write a record straight into the KV store, bypassing registration, the way
@@ -776,7 +776,7 @@ fn sync_from_peer_at(
                 port_policy: None,
                 port_policy_hash: String::new(),
                 admin_port_policy: None,
-                admin_ready: None,
+                ready: None,
             },
         )
         .unwrap();

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -23,6 +23,10 @@ impl std::ops::Deref for TestState {
 }
 
 async fn create_test_state() -> TestState {
+    create_test_state_with(|_| {}).await
+}
+
+async fn create_test_state_with(tweak: impl FnOnce(&mut Config)) -> TestState {
     let figment = load_config_figment(None);
     let mut config = figment.focus("core").extract::<Config>().unwrap();
     let temp_dir = TempDir::new().expect("failed to create temp dir");
@@ -34,6 +38,7 @@ async fn create_test_state() -> TestState {
         .join("wg.conf")
         .to_string_lossy()
         .into_owned();
+    tweak(&mut config);
     let options = ProxyOptions {
         config,
         my_app_id: None,
@@ -446,6 +451,266 @@ async fn gateway_top_n_batch_007_cache_health_and_invalidation() {
     }
 }
 
+/// Register `count` instances of `app` and mark every handshake fresh, so the
+/// only thing that can keep an instance out of a selection is the gate.
+fn register_ready_instances(proxy: &mut ProxyState, app: &str, count: usize) {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let mut handshakes = BTreeMap::new();
+    for index in 0..count {
+        let id = format!("{app}-{index}");
+        let key = test_pubkey(&format!("{app}-key-{index}"));
+        proxy
+            .new_client_by_id(&id, app, &key, "", Some(policy(false, &[])))
+            .unwrap();
+        handshakes.insert(key, now);
+    }
+    proxy.handshake_cache.set_for_test(handshakes);
+}
+
+fn selected_ids(group: &AddressGroup) -> Vec<String> {
+    group
+        .iter()
+        .map(|row| row.instance_id.clone())
+        .collect::<Vec<_>>()
+}
+
+/// The gate exists so an operator can pull a misbehaving instance out of the
+/// rotation *and still reach it*. Dropping it from app-id selection while
+/// leaving instance-id routing untouched is the whole feature.
+#[tokio::test]
+async fn gating_an_instance_removes_it_from_rotation_but_keeps_it_directly_reachable() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "gated-app", 3);
+
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("gated-app").unwrap()).len(),
+        3
+    );
+
+    proxy.set_admin_ready("gated-app-1", false).unwrap();
+
+    let after = selected_ids(&proxy.select_top_n_hosts("gated-app").unwrap());
+    assert_eq!(after, vec!["gated-app-0", "gated-app-2"]);
+
+    // ... but addressing it directly still resolves, which is what makes
+    // debugging a quarantined instance possible.
+    let direct = proxy.select_top_n_hosts("gated-app-1").unwrap();
+    assert_eq!(selected_ids(&direct), vec!["gated-app-1"]);
+}
+
+/// The selection cache holds a pre-gate snapshot for up to `cache_top_n`.
+/// An emergency cut-off that takes 30s to apply is not an emergency cut-off.
+#[tokio::test]
+async fn gating_an_instance_invalidates_the_selection_cache() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "cache-app", 2);
+
+    proxy.select_top_n_hosts("cache-app").unwrap();
+    assert_eq!(proxy.state.top_n.len(), 1, "selection should be cached");
+
+    proxy.set_admin_ready("cache-app-0", false).unwrap();
+    assert!(
+        proxy.state.top_n.is_empty(),
+        "closing the gate must drop the cached selection"
+    );
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("cache-app").unwrap()),
+        vec!["cache-app-1"]
+    );
+}
+
+/// Health checks are inference and may be wrong, so they fail open. The
+/// operator gate is an instruction, so it does not: gating every instance
+/// means the app refuses new connections rather than quietly serving them.
+#[tokio::test]
+async fn gating_every_instance_refuses_traffic_instead_of_failing_open() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "drained-app", 2);
+
+    proxy.set_admin_ready("drained-app-0", false).unwrap();
+    proxy.set_admin_ready("drained-app-1", false).unwrap();
+
+    assert!(
+        proxy.select_top_n_hosts("drained-app").unwrap().is_empty(),
+        "an operator draining every instance must be obeyed, not overridden"
+    );
+
+    proxy.set_admin_ready("drained-app-1", true).unwrap();
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("drained-app").unwrap()),
+        vec!["drained-app-1"]
+    );
+}
+
+/// Instance ids are derived from attestation and survive reboots, so a
+/// re-registration is usually the same box coming back. It must not rejoin the
+/// rotation on its own.
+#[tokio::test]
+async fn the_gate_survives_re_registration() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "reboot-app", 2);
+    proxy.set_admin_ready("reboot-app-0", false).unwrap();
+
+    // Same instance id, same key: a reboot re-running registration.
+    proxy
+        .new_client_by_id(
+            "reboot-app-0",
+            "reboot-app",
+            &test_pubkey("reboot-app-key-0"),
+            "",
+            Some(policy(false, &[])),
+        )
+        .unwrap();
+
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("reboot-app").unwrap()),
+        vec!["reboot-app-1"],
+        "a rebooted instance must stay out of rotation until an operator says otherwise"
+    );
+}
+
+/// `connect_top_n = 0` takes the random-selection path, which carries its own
+/// copy of the filter.
+#[tokio::test]
+async fn the_random_selection_path_honours_the_gate() {
+    let state = create_test_state_with(|config| config.proxy.connect_top_n = 0).await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "random-app", 2);
+    proxy.set_admin_ready("random-app-0", false).unwrap();
+
+    for _ in 0..16 {
+        assert_eq!(
+            selected_ids(&proxy.select_top_n_hosts("random-app").unwrap()),
+            vec!["random-app-1"]
+        );
+    }
+}
+
+/// The gate reaches other gateways through WaveKV, not through the RPC. A node
+/// that learns about it on a reload has to drop the selection it cached before
+/// the change, or it keeps feeding the gated instance for up to `cache_top_n`.
+#[tokio::test]
+async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
+    let state = create_test_state().await;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "peer-app", 2);
+        proxy.select_top_n_hosts("peer-app").unwrap();
+        assert_eq!(proxy.state.top_n.len(), 1, "selection should be cached");
+    }
+
+    // A peer gated peer-app-0 and the record reached us through sync.
+    let gated = {
+        let proxy = state.lock();
+        let existing = proxy.state.instances["peer-app-0"].clone();
+        InstanceData {
+            app_id: existing.app_id.clone(),
+            ip: existing.ip,
+            public_key: existing.public_key.clone(),
+            reg_time: now,
+            port_policy: existing.port_policy.clone(),
+            port_policy_hash: existing.port_policy_hash.clone(),
+            admin_port_policy: None,
+            admin_ready: Some(false),
+        }
+    };
+    state.kv_store.sync_instance("peer-app-0", &gated).unwrap();
+    reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
+
+    let mut proxy = state.lock();
+    assert!(
+        proxy.state.top_n.is_empty(),
+        "a gate arriving through KV must drop the cached selection"
+    );
+    proxy.handshake_cache.set_for_test(BTreeMap::from([
+        (test_pubkey("peer-app-key-0"), now),
+        (test_pubkey("peer-app-key-1"), now),
+    ]));
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("peer-app").unwrap()),
+        vec!["peer-app-1"]
+    );
+}
+
+/// Removing an instance must take its gate with it, or a later instance
+/// reusing the id would inherit a quarantine nobody asked for.
+#[tokio::test]
+async fn removing_an_instance_removes_its_gate() {
+    let state = create_test_state().await;
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "gone-app", 2);
+        proxy.set_admin_ready("gone-app-0", false).unwrap();
+        assert_eq!(
+            state.kv_store.load_all_instances().decoded["gone-app-0"].admin_ready,
+            Some(false)
+        );
+        proxy.remove_instance("gone-app-0").unwrap();
+    }
+    // The gate lives in the instance record, so removing the instance takes it
+    // with it. The deletes are issued unconditionally so a failure in one
+    // cannot strand the others, which is only worth anything if they are all
+    // actually issued.
+    let node = state.config.sync.node_id;
+    let key = crate::kv::keys::inst("gone-app-0");
+    let live = state
+        .kv_store
+        .persistent()
+        .read()
+        .get(&key)
+        .is_some_and(|entry| !entry.is_deleted());
+    assert!(!live, "{key} should be gone");
+    assert!(!state
+        .kv_store
+        .get_instance_handshakes("gone-app-0")
+        .contains_key(&node));
+}
+
+/// Selection handing over an empty group means every instance was ruled out
+/// before the port policy ever looked -- an operator drained the app, or none
+/// passed the handshake filter. Blaming the port policy sends whoever reads the
+/// log at the wrong subsystem.
+#[tokio::test]
+async fn an_empty_candidate_group_is_not_blamed_on_the_port_policy() {
+    let state = create_test_state().await;
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "drain-all", 1);
+        proxy.set_admin_ready("drain-all-0", false).unwrap();
+    }
+    let mut proxy = state.lock();
+    let empty = proxy.select_top_n_hosts("drain-all").unwrap();
+    assert!(empty.is_empty());
+    drop(proxy);
+
+    let err =
+        crate::proxy::port_policy::filter_allowed_addresses(&state.proxy, empty, "drain-all", 443)
+            .unwrap_err()
+            .to_string();
+    assert!(
+        err.contains("no instance") && !err.contains("port policy"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn gating_an_unregistered_instance_is_an_error() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    assert!(proxy.set_admin_ready("never-registered", false).is_err());
+}
+
 /// Write a record straight into the KV store, bypassing registration, the way
 /// a peer's sync round would.
 fn sync_from_peer(state: &TestState, instance_id: &str, ip: &str, public_key: &str) {
@@ -471,6 +736,7 @@ fn sync_from_peer_at(
                 port_policy: None,
                 port_policy_hash: String::new(),
                 admin_port_policy: None,
+                admin_ready: None,
             },
         )
         .unwrap();

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -775,6 +775,81 @@ async fn setting_the_gate_does_not_discard_a_peers_port_policy_override() {
     );
 }
 
+/// The two overrides have a key each, so one of them existing says nothing
+/// about the other. Falling back to the instance record per instance rather
+/// than per key means an operator who gates an instance mid-upgrade drops the
+/// port-policy override that has not been moved across yet -- silently
+/// widening the ports the app serves, which is the failure the split exists to
+/// remove.
+///
+/// The reload path hides this: it migrates before it reads, so the key it would
+/// have fallen back for already exists by then. Startup does not -- nothing may
+/// be written before the WaveKV bootstrap -- so the merge itself has to be
+/// right, which is what this asserts.
+#[test]
+fn one_override_key_existing_does_not_answer_for_the_other() {
+    let mut current = LoadedOverrides::default();
+    // A peer gated the instance through the new key. Only that key exists.
+    current.decoded.insert(
+        "half-moved".to_string(),
+        AdminOverrides {
+            ready: Some(false),
+            port_policy: None,
+        },
+    );
+    current.present.insert(
+        "half-moved".to_string(),
+        BTreeSet::from([crate::kv::keys::ADMIN_READY.to_string()]),
+    );
+    // The port-policy override is still where the previous build left it.
+    let legacy = BTreeMap::from([(
+        "half-moved".to_string(),
+        AdminOverrides {
+            ready: Some(true),
+            port_policy: Some(policy(true, &[8443])),
+        },
+    )]);
+
+    let effective = effective_overrides("half-moved", &current, &legacy);
+    assert_eq!(
+        effective.ready,
+        Some(false),
+        "the gate key exists, so it answers -- not the stale copy"
+    );
+    assert_eq!(
+        effective.port_policy,
+        Some(policy(true, &[8443])),
+        "the port-policy key does not exist, so the instance record still answers"
+    );
+}
+
+/// The other half of the same rule: a key that exists and says "cleared" is an
+/// answer. Reading the stale copy there would undo the clear.
+#[test]
+fn a_cleared_override_is_an_answer_not_an_absence() {
+    let mut current = LoadedOverrides::default();
+    current
+        .decoded
+        .insert("cleared".to_string(), AdminOverrides::default());
+    current.present.insert(
+        "cleared".to_string(),
+        BTreeSet::from([crate::kv::keys::ADMIN_PORT_POLICY.to_string()]),
+    );
+    let legacy = BTreeMap::from([(
+        "cleared".to_string(),
+        AdminOverrides {
+            ready: None,
+            port_policy: Some(policy(true, &[8443])),
+        },
+    )]);
+
+    assert_eq!(
+        effective_overrides("cleared", &current, &legacy).port_policy,
+        None,
+        "the operator cleared it; the instance record must not put it back"
+    );
+}
+
 /// The instance record as the build before the override key wrote it.
 #[derive(serde::Serialize)]
 struct LegacyRecord {

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -735,9 +735,9 @@ async fn an_override_left_in_the_instance_record_still_reaches_the_data_plane() 
     assert_eq!(migrated.ready, Some(false));
     assert_eq!(migrated.admin_port_policy, Some(policy(true, &[8443])));
     assert_eq!(
-        state.kv_store.load_all_instance_overrides().decoded["legacy-app-0"].ready,
+        state.kv_store.instance_gate("legacy-app-0").unwrap(),
         Some(false),
-        "and the reload should have moved them to their own key"
+        "and the reload should have moved them to their own keys"
     );
 }
 
@@ -755,22 +755,20 @@ async fn setting_the_gate_does_not_discard_a_peers_port_policy_override() {
     // A peer's override, in the store but not yet in this node's memory.
     state
         .kv_store
-        .sync_instance_port_policy_override(
-            "split-app-0",
-            &AdminPortPolicy {
-                policy: Some(policy(true, &[8443])),
-            },
-        )
+        .set_instance_port_policy_override("split-app-0", Some(policy(true, &[8443])))
         .unwrap();
     state.lock().set_ready("split-app-0", false).unwrap();
 
-    let loaded = state.kv_store.load_all_instance_overrides();
     assert_eq!(
-        loaded.decoded["split-app-0"],
-        AdminOverrides {
-            port_policy: Some(policy(true, &[8443])),
-            ready: Some(false),
-        },
+        state.kv_store.instance_gate("split-app-0").unwrap(),
+        Some(false)
+    );
+    assert_eq!(
+        state
+            .kv_store
+            .instance_port_policy_override("split-app-0")
+            .unwrap(),
+        Some(crate::kv::PortPolicyOverride::Set(policy(true, &[8443]))),
         "the gate write must not have taken the port-policy override with it"
     );
 }
@@ -786,38 +784,29 @@ async fn setting_the_gate_does_not_discard_a_peers_port_policy_override() {
 /// have fallen back for already exists by then. Startup does not -- nothing may
 /// be written before the WaveKV bootstrap -- so the merge itself has to be
 /// right, which is what this asserts.
-#[test]
-fn one_override_key_existing_does_not_answer_for_the_other() {
-    let mut current = LoadedOverrides::default();
+#[tokio::test]
+async fn one_override_key_existing_does_not_answer_for_the_other() {
+    let state = create_test_state().await;
     // A peer gated the instance through the new key. Only that key exists.
-    current.decoded.insert(
-        "half-moved".to_string(),
-        AdminOverrides {
-            ready: Some(false),
-            port_policy: None,
-        },
-    );
-    current.present.insert(
-        "half-moved".to_string(),
-        BTreeSet::from([crate::kv::keys::ADMIN_READY.to_string()]),
-    );
+    state
+        .kv_store
+        .set_instance_gate("half-moved", false)
+        .unwrap();
     // The port-policy override is still where the previous build left it.
-    let legacy = BTreeMap::from([(
-        "half-moved".to_string(),
-        AdminOverrides {
-            ready: Some(true),
-            port_policy: Some(policy(true, &[8443])),
-        },
-    )]);
+    let legacy = LegacyOverrides {
+        ready: Some(true),
+        admin_port_policy: Some(policy(true, &[8443])),
+    };
 
-    let effective = effective_overrides("half-moved", &current, &legacy);
+    let (port_policy, ready) =
+        effective_overrides(&state.kv_store, "half-moved", Some(&legacy)).unwrap();
     assert_eq!(
-        effective.ready,
+        ready,
         Some(false),
         "the gate key exists, so it answers -- not the stale copy"
     );
     assert_eq!(
-        effective.port_policy,
+        port_policy,
         Some(policy(true, &[8443])),
         "the port-policy key does not exist, so the instance record still answers"
     );
@@ -825,27 +814,21 @@ fn one_override_key_existing_does_not_answer_for_the_other() {
 
 /// The other half of the same rule: a key that exists and says "cleared" is an
 /// answer. Reading the stale copy there would undo the clear.
-#[test]
-fn a_cleared_override_is_an_answer_not_an_absence() {
-    let mut current = LoadedOverrides::default();
-    current
-        .decoded
-        .insert("cleared".to_string(), AdminOverrides::default());
-    current.present.insert(
-        "cleared".to_string(),
-        BTreeSet::from([crate::kv::keys::ADMIN_PORT_POLICY.to_string()]),
-    );
-    let legacy = BTreeMap::from([(
-        "cleared".to_string(),
-        AdminOverrides {
-            ready: None,
-            port_policy: Some(policy(true, &[8443])),
-        },
-    )]);
+#[tokio::test]
+async fn a_cleared_override_is_an_answer_not_an_absence() {
+    let state = create_test_state().await;
+    state
+        .kv_store
+        .set_instance_port_policy_override("cleared", None)
+        .unwrap();
+    let legacy = LegacyOverrides {
+        ready: None,
+        admin_port_policy: Some(policy(true, &[8443])),
+    };
 
+    let (port_policy, _) = effective_overrides(&state.kv_store, "cleared", Some(&legacy)).unwrap();
     assert_eq!(
-        effective_overrides("cleared", &current, &legacy).port_policy,
-        None,
+        port_policy, None,
         "the operator cleared it; the instance record must not put it back"
     );
 }
@@ -985,7 +968,7 @@ async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
     // A peer gated peer-app-0 and the override record reached us through sync.
     state
         .kv_store
-        .sync_instance_gate("peer-app-0", &InstanceGate { ready: false })
+        .set_instance_gate("peer-app-0", false)
         .unwrap();
     reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
 

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -525,6 +525,75 @@ async fn gating_an_instance_invalidates_the_selection_cache() {
     );
 }
 
+/// Mark `instance_id`'s tunnel as long dead while leaving the others alone.
+fn expire_handshake(proxy: &mut ProxyState, instance_id: &str) {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let key = proxy.state.instances[instance_id].public_key.clone();
+    let mut handshakes = proxy
+        .latest_handshakes(None)
+        .unwrap()
+        .into_iter()
+        .map(|(pk, (ts, _))| (pk, ts))
+        .collect::<BTreeMap<_, _>>();
+    handshakes.insert(key, now.saturating_sub(3600));
+    proxy.handshake_cache.set_for_test(handshakes);
+}
+
+/// The warning exists to tell an operator they just took the app offline. An
+/// instance nobody gated but whose tunnel is dead is not cover: selection will
+/// not route to it either. Counting it as cover silences the warning in the one
+/// case it is for.
+#[tokio::test]
+async fn draining_the_last_live_instance_warns_even_with_ungated_dead_ones() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "half-dead", 2);
+    expire_handshake(&mut proxy, "half-dead-1");
+
+    // Nobody gated -1, so a gate-only count sees cover in it.
+    assert!(proxy.state.instances["half-dead-1"].is_ready());
+    assert_eq!(proxy.count_eligible_instances("half-dead").unwrap(), 1);
+
+    proxy.set_ready("half-dead-0", false).unwrap();
+    let warning = proxy
+        .drain_warning("half-dead-0", "half-dead", true, false)
+        .unwrap();
+    assert!(
+        warning.is_some_and(|message| message.contains("no instance eligible")),
+        "draining onto a dead instance must still warn"
+    );
+}
+
+/// The message on a failed gate write asks the operator to retry. Warning on
+/// the resulting count alone makes that retry claim the instance was the last
+/// ready one -- a second time, about an instance that was already gated.
+#[tokio::test]
+async fn re_gating_an_already_gated_instance_does_not_warn_again() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "twice", 1);
+
+    proxy.set_ready("twice-0", false).unwrap();
+    assert!(
+        proxy
+            .drain_warning("twice-0", "twice", true, false)
+            .unwrap()
+            .is_some(),
+        "closing the last gate is worth saying once"
+    );
+
+    assert!(
+        proxy
+            .drain_warning("twice-0", "twice", false, false)
+            .unwrap()
+            .is_none(),
+        "an instance that was already gated was not the last ready one"
+    );
+}
+
 /// Health checks are inference and may be wrong, so they fail open. The
 /// operator gate is an instruction, so it does not: gating every instance
 /// means the app refuses new connections rather than quietly serving them.

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -646,6 +646,148 @@ async fn the_gate_survives_re_registration() {
     );
 }
 
+/// The re-registration above is local, so the node applying it already holds
+/// the gate. The case that used to lose it is a peer: the gate rode in the
+/// instance record, every node rewrites that record in full from its own
+/// memory on every registration, and `gateway_checker` re-registers every 180s
+/// -- so a node the gate had not reached yet published a record without it and
+/// won on last-write. The record it publishes now cannot carry the gate at all.
+#[tokio::test]
+async fn a_re_registration_by_a_node_that_never_saw_the_gate_cannot_drop_it() {
+    let state = create_test_state().await;
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "race-app", 2);
+        proxy.set_ready("race-app-0", false).unwrap();
+    }
+
+    // What that peer would publish: the whole instance record, rebuilt from a
+    // memory copy holding no gate, with a newer reg_time so it wins.
+    {
+        let mut proxy = state.lock();
+        let unaware = InstanceInfo {
+            ready: None,
+            admin_port_policy: None,
+            reg_time: SystemTime::now(),
+            ..proxy.state.instances["race-app-0"].clone()
+        };
+        state
+            .kv_store
+            .sync_instance("race-app-0", &InstanceData::from(&unaware))
+            .unwrap();
+        // ... and this node forgets it too, so only the store can answer.
+        proxy.state.instances.get_mut("race-app-0").unwrap().ready = None;
+    }
+    reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
+
+    let mut proxy = state.lock();
+    assert_eq!(
+        proxy.state.instances["race-app-0"].ready,
+        Some(false),
+        "the gate has its own key; a re-registration must not be able to reach it"
+    );
+    assert_eq!(
+        selected_ids(&proxy.select_top_n_hosts("race-app").unwrap()),
+        vec!["race-app-1"]
+    );
+}
+
+/// The data plane, not just the store: an override an older build left inside
+/// the instance record has to be in force from the first load, before anything
+/// has had a chance to move it.
+#[tokio::test]
+async fn an_override_left_in_the_instance_record_still_reaches_the_data_plane() {
+    let state = create_test_state().await;
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "legacy-app", 2);
+    }
+    // Rewrite the record the way the previous build wrote it: the operator
+    // fields inside, and no `admin/` record anywhere.
+    {
+        let proxy = state.lock();
+        let existing = proxy.state.instances["legacy-app-0"].clone();
+        let legacy = LegacyRecord {
+            app_id: existing.app_id,
+            ip: existing.ip,
+            public_key: existing.public_key,
+            reg_time: encode_ts(existing.reg_time),
+            port_policy: existing.port_policy,
+            port_policy_hash: existing.port_policy_hash,
+            admin_port_policy: Some(policy(true, &[8443])),
+            ready: Some(false),
+        };
+        state
+            .kv_store
+            .persistent()
+            .write()
+            .put(
+                crate::kv::keys::inst("legacy-app-0"),
+                crate::kv::encode(&legacy).unwrap(),
+            )
+            .unwrap();
+    }
+
+    reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
+
+    let proxy = state.lock();
+    let migrated = &proxy.state.instances["legacy-app-0"];
+    assert_eq!(migrated.ready, Some(false));
+    assert_eq!(migrated.admin_port_policy, Some(policy(true, &[8443])));
+    assert_eq!(
+        state.kv_store.load_all_instance_overrides().decoded["legacy-app-0"].ready,
+        Some(false),
+        "and the reload should have moved them to their own key"
+    );
+}
+
+/// The service-level counterpart of the KV test: an operator setting the gate
+/// here must not discard a port-policy override a peer set and this node has
+/// not applied yet. Two overrides in one record made that a whole-value
+/// conflict; two keys make them independent.
+#[tokio::test]
+async fn setting_the_gate_does_not_discard_a_peers_port_policy_override() {
+    let state = create_test_state().await;
+    {
+        let mut proxy = state.lock();
+        register_ready_instances(&mut proxy, "split-app", 2);
+    }
+    // A peer's override, in the store but not yet in this node's memory.
+    state
+        .kv_store
+        .sync_instance_port_policy_override(
+            "split-app-0",
+            &AdminPortPolicy {
+                policy: Some(policy(true, &[8443])),
+            },
+        )
+        .unwrap();
+    state.lock().set_ready("split-app-0", false).unwrap();
+
+    let loaded = state.kv_store.load_all_instance_overrides();
+    assert_eq!(
+        loaded.decoded["split-app-0"],
+        AdminOverrides {
+            port_policy: Some(policy(true, &[8443])),
+            ready: Some(false),
+        },
+        "the gate write must not have taken the port-policy override with it"
+    );
+}
+
+/// The instance record as the build before the override key wrote it.
+#[derive(serde::Serialize)]
+struct LegacyRecord {
+    app_id: String,
+    ip: std::net::Ipv4Addr,
+    public_key: String,
+    reg_time: u64,
+    port_policy: Option<crate::kv::PortPolicy>,
+    port_policy_hash: String,
+    admin_port_policy: Option<crate::kv::PortPolicy>,
+    ready: Option<bool>,
+}
+
 /// The test above takes the early-return branch of `new_client_by_id`, where
 /// the in-memory record is reused untouched -- so it says nothing about the
 /// rebuild branch, which reconstructs the record. Dropping the operator
@@ -704,16 +846,16 @@ async fn both_operator_overrides_survive_the_ip_rebuild_path() {
     );
 }
 
-/// `persist_instance_record` was changed to return a `Result` for exactly one
-/// caller: `set_ready`, whose API tells an operator the gate is in force.
-/// Swallowing that error left the whole suite green, so nothing pinned the one
-/// behaviour the signature change existed for.
+/// `persist_instance_overrides` returns a `Result` for exactly one caller:
+/// `set_ready`, whose API tells an operator the gate is in force. Swallowing
+/// that error left the whole suite green, so nothing pinned the one behaviour
+/// the signature exists for.
 #[tokio::test]
 async fn a_gate_that_could_not_be_stored_is_reported_as_such() {
     let state = create_test_state().await;
     state
         .kv_store
-        .fail_writes_for_test(crate::kv::FailWrite::INST);
+        .fail_writes_for_test(crate::kv::FailWrite::ADMIN);
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "durable-app", 1);
 
@@ -765,22 +907,11 @@ async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
         assert_eq!(proxy.state.top_n.len(), 1, "selection should be cached");
     }
 
-    // A peer gated peer-app-0 and the record reached us through sync.
-    let gated = {
-        let proxy = state.lock();
-        let existing = proxy.state.instances["peer-app-0"].clone();
-        InstanceData {
-            app_id: existing.app_id.clone(),
-            ip: existing.ip,
-            public_key: existing.public_key.clone(),
-            reg_time: now,
-            port_policy: existing.port_policy.clone(),
-            port_policy_hash: existing.port_policy_hash.clone(),
-            admin_port_policy: None,
-            ready: Some(false),
-        }
-    };
-    state.kv_store.sync_instance("peer-app-0", &gated).unwrap();
+    // A peer gated peer-app-0 and the override record reached us through sync.
+    state
+        .kv_store
+        .sync_instance_gate("peer-app-0", &InstanceGate { ready: false })
+        .unwrap();
     reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
 
     let mut proxy = state.lock();
@@ -832,7 +963,7 @@ async fn removing_an_instance_removes_its_gate() {
         register_ready_instances(&mut proxy, "gone-app", 2);
         proxy.set_ready("gone-app-0", false).unwrap();
         assert_eq!(
-            state.kv_store.load_all_instances().decoded["gone-app-0"].ready,
+            state.kv_store.load_all_instance_overrides().decoded["gone-app-0"].ready,
             Some(false)
         );
         // Seed the two ephemeral records as well, or the assertions below pass
@@ -853,18 +984,23 @@ async fn removing_an_instance_removes_its_gate() {
         );
         proxy.remove_instance("gone-app-0").unwrap();
     }
-    // The gate lives in the instance record, so removing the instance takes it
-    // with it. The deletes are issued unconditionally so a failure in one
-    // cannot strand the others, which is only worth anything if they are all
-    // actually issued.
-    let key = crate::kv::keys::inst("gone-app-0");
-    let live = state
-        .kv_store
-        .persistent()
-        .read()
-        .get(&key)
-        .is_some_and(|entry| !entry.is_deleted());
-    assert!(!live, "{key} should be gone");
+    // The gate has its own key now, so it needs its own tombstone -- an id
+    // recycled after the delete would otherwise inherit it. The deletes are
+    // issued unconditionally so a failure in one cannot strand the others,
+    // which is only worth anything if they are all actually issued.
+    for key in [
+        crate::kv::keys::inst("gone-app-0"),
+        crate::kv::keys::admin_ready("gone-app-0"),
+        crate::kv::keys::admin_port_policy("gone-app-0"),
+    ] {
+        let live = state
+            .kv_store
+            .persistent()
+            .read()
+            .get(&key)
+            .is_some_and(|entry| !entry.is_deleted());
+        assert!(!live, "{key} should be gone");
+    }
     assert!(
         !handshake_is_live(&state),
         "handshake/ record should be gone"
@@ -936,8 +1072,6 @@ fn sync_from_peer_at(
                 reg_time,
                 port_policy: None,
                 port_policy_hash: String::new(),
-                admin_port_policy: None,
-                ready: None,
             },
         )
         .unwrap();

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -673,7 +673,7 @@ async fn a_re_registration_by_a_node_that_never_saw_the_gate_cannot_drop_it() {
         };
         state
             .kv_store
-            .sync_instance("race-app-0", &InstanceData::from(&unaware))
+            .sync_instance("race-app-0", &InstanceRecord::from(&unaware))
             .unwrap();
         // ... and this node forgets it too, so only the store can answer.
         proxy.state.instances.get_mut("race-app-0").unwrap().ready = None;
@@ -913,7 +913,7 @@ async fn a_gate_that_could_not_be_stored_is_reported_as_such() {
     let state = create_test_state().await;
     state
         .kv_store
-        .fail_writes_for_test(&[crate::kv::InstanceRecord::Gate]);
+        .fail_writes_for_test(&[crate::kv::InstanceKey::Gate]);
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "durable-app", 1);
 
@@ -1125,7 +1125,7 @@ fn sync_from_peer_at(
         .kv_store
         .sync_instance(
             instance_id,
-            &InstanceData {
+            &InstanceRecord {
                 app_id: "peer-app".to_string(),
                 ip: ip.parse().unwrap(),
                 public_key: public_key.to_string(),

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -875,14 +875,15 @@ async fn removing_an_instance_removes_its_gate() {
 /// Selection handing over an empty group means every instance was ruled out
 /// before the port policy ever looked -- an operator drained the app, or none
 /// passed the handshake filter. Blaming the port policy sends whoever reads the
-/// log at the wrong subsystem.
+/// log at the wrong subsystem, and the port it names was never examined.
 #[tokio::test]
-async fn an_empty_candidate_group_is_not_blamed_on_the_port_policy() {
+async fn an_empty_candidate_group_names_the_reason_selection_had() {
     let state = create_test_state().await;
     {
         let mut proxy = state.lock();
-        register_ready_instances(&mut proxy, "drain-all", 1);
+        register_ready_instances(&mut proxy, "drain-all", 2);
         proxy.set_ready("drain-all-0", false).unwrap();
+        expire_handshake(&mut proxy, "drain-all-1");
     }
     let mut proxy = state.lock();
     let empty = proxy.select_top_n_hosts("drain-all").unwrap();
@@ -893,9 +894,14 @@ async fn an_empty_candidate_group_is_not_blamed_on_the_port_policy() {
         crate::proxy::port_policy::filter_allowed_addresses(&state.proxy, empty, "drain-all", 443)
             .unwrap_err()
             .to_string();
+    assert!(!err.contains("port"), "the port was never checked: {err}");
     assert!(
-        err.contains("no instance") && !err.contains("port policy"),
-        "unexpected error: {err}"
+        err.contains("1 gated out by an operator"),
+        "the gated instance should be accounted for: {err}"
+    );
+    assert!(
+        err.contains("1 with no recent WireGuard handshake"),
+        "the dead instance should be accounted for: {err}"
     );
 }
 

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::config::{load_config_figment, Config, MutualConfig};
 use crate::kv::PortFlags;
 use crate::proxy::port_policy::is_port_allowed;
+use crate::time::encode_ts;
 use base64::Engine as _;
 use std::sync::atomic::Ordering;
 use tempfile::TempDir;
@@ -578,14 +579,13 @@ async fn the_gate_survives_re_registration() {
 
 /// The test above takes the early-return branch of `new_client_by_id`, where
 /// the in-memory record is reused untouched -- so it says nothing about the
-/// `carried_ready` / `carried_admin_port_policy` locals, which only exist
-/// for the *other* branch. Replacing both with `None` left the whole suite
-/// green, which is why this test exists.
+/// rebuild branch, which reconstructs the record. Dropping the operator
+/// overrides there left the whole suite green, which is why this test exists.
 ///
 /// That branch runs when the recorded IP is no longer inside
 /// `wg.client_ip_range` -- an operator renumbering the range, or a record
 /// restored from a differently-configured gateway. The instance is rebuilt from
-/// scratch, and anything held only in the record has to be carried by hand.
+/// the previous one, and anything held only in the record has to survive that.
 #[tokio::test]
 async fn both_operator_overrides_survive_the_ip_rebuild_path() {
     let state = create_test_state().await;

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -576,6 +576,92 @@ async fn the_gate_survives_re_registration() {
     );
 }
 
+/// The test above takes the early-return branch of `new_client_by_id`, where
+/// the in-memory record is reused untouched -- so it says nothing about the
+/// `carried_ready` / `carried_admin_port_policy` locals, which only exist
+/// for the *other* branch. Replacing both with `None` left the whole suite
+/// green, which is why this test exists.
+///
+/// That branch runs when the recorded IP is no longer inside
+/// `wg.client_ip_range` -- an operator renumbering the range, or a record
+/// restored from a differently-configured gateway. The instance is rebuilt from
+/// scratch, and anything held only in the record has to be carried by hand.
+#[tokio::test]
+async fn both_operator_overrides_survive_the_ip_rebuild_path() {
+    let state = create_test_state().await;
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "rebuild-app", 2);
+    proxy.set_ready("rebuild-app-0", false).unwrap();
+    proxy
+        .set_admin_port_policy("rebuild-app-0", policy(true, &[8443]))
+        .unwrap();
+
+    // Put the recorded IP outside the configured range, so re-registering takes
+    // the rebuild branch instead of the early return.
+    let stale_ip: Ipv4Addr = "192.0.2.7".parse().unwrap();
+    assert!(
+        !proxy.valid_ip(stale_ip),
+        "the test IP must be out of range"
+    );
+    let old_ip = proxy.state.instances["rebuild-app-0"].ip;
+    proxy.state.instances.get_mut("rebuild-app-0").unwrap().ip = stale_ip;
+    proxy.state.allocated_addresses.remove(&old_ip);
+    proxy.state.allocated_addresses.insert(stale_ip);
+
+    proxy
+        .new_client_by_id(
+            "rebuild-app-0",
+            "rebuild-app",
+            &test_pubkey("rebuild-app-key-0"),
+            "",
+            Some(policy(false, &[])),
+        )
+        .unwrap();
+
+    let rebuilt = proxy.state.instances["rebuild-app-0"].clone();
+    assert!(
+        proxy.valid_ip(rebuilt.ip),
+        "the rebuild path should have reallocated an in-range IP"
+    );
+    assert_eq!(
+        rebuilt.ready,
+        Some(false),
+        "the operator's traffic gate was dropped by the rebuild"
+    );
+    assert_eq!(
+        rebuilt.admin_port_policy,
+        Some(policy(true, &[8443])),
+        "the operator's port-policy override was dropped by the rebuild"
+    );
+}
+
+/// `persist_instance_record` was changed to return a `Result` for exactly one
+/// caller: `set_ready`, whose API tells an operator the gate is in force.
+/// Swallowing that error left the whole suite green, so nothing pinned the one
+/// behaviour the signature change existed for.
+#[tokio::test]
+async fn a_gate_that_could_not_be_stored_is_reported_as_such() {
+    let state = create_test_state().await;
+    state
+        .kv_store
+        .fail_writes_for_test(crate::kv::FailWrite::INST);
+    let mut proxy = state.lock();
+    register_ready_instances(&mut proxy, "durable-app", 1);
+
+    let err = proxy
+        .set_ready("durable-app-0", false)
+        .expect_err("a failed store write must not be reported as success");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("not durable"),
+        "the operator has to be told the setting did not stick: {message}"
+    );
+
+    // Still in force locally, deliberately: the operator's intent applies to
+    // the next connection even though it is not durable.
+    assert_eq!(proxy.state.instances["durable-app-0"].ready, Some(false));
+}
+
 /// `connect_top_n = 0` takes the random-selection path, which carries its own
 /// copy of the filter.
 #[tokio::test]

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -855,7 +855,7 @@ async fn a_gate_that_could_not_be_stored_is_reported_as_such() {
     let state = create_test_state().await;
     state
         .kv_store
-        .fail_writes_for_test(crate::kv::FailWrite::ADMIN);
+        .fail_writes_for_test(&[crate::kv::InstanceRecord::Gate]);
     let mut proxy = state.lock();
     register_ready_instances(&mut proxy, "durable-app", 1);
 

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -929,83 +929,85 @@ async fn a_gate_arriving_through_kv_invalidates_the_cached_selection() {
     );
 }
 
-/// Whether this node's `conn/` record for the fixture instance is live.
+/// Every live key in either store whose name contains `instance_id`.
 ///
-/// Reads the raw entry because `KvStore` exposes no conn accessor, and uses the
-/// store's own node id rather than the config's so the key matches whatever
-/// `sync_connections` wrote -- the two agree today, and this keeps the
-/// assertions honest if they ever stop agreeing.
-fn conn_is_live(state: &TestState) -> bool {
-    let key = crate::kv::keys::conn("gone-app-0", state.kv_store.my_node_id());
-    state
+/// Scanned rather than listed, so a per-instance key added later without a
+/// matching delete shows up here instead of leaking quietly.
+fn live_keys_naming(state: &TestState, instance_id: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    for (key, entry) in state
+        .kv_store
+        .persistent()
+        .read()
+        .iter_all_including_tombstones()
+    {
+        if key.contains(instance_id) && !entry.is_deleted() {
+            found.push(key.clone());
+        }
+    }
+    for (key, entry) in state
         .kv_store
         .ephemeral()
         .read()
-        .get(&key)
-        .is_some_and(|entry| !entry.is_deleted())
+        .iter_all_including_tombstones()
+    {
+        if key.contains(instance_id) && !entry.is_deleted() {
+            found.push(key.clone());
+        }
+    }
+    found.sort();
+    found
 }
 
-/// Whether this node's `handshake/` observation for the fixture instance is live.
-fn handshake_is_live(state: &TestState) -> bool {
-    state
-        .kv_store
-        .get_instance_handshakes("gone-app-0")
-        .contains_key(&state.kv_store.my_node_id())
-}
-
-/// Removing an instance must take its gate with it, or a later instance
-/// reusing the id would inherit a quarantine nobody asked for.
+/// Nothing that names a CVM may outlive it. The gate especially: instance ids
+/// are recycled, so one left behind would quarantine whatever registers under
+/// the id next.
+///
+/// The deletes are issued unconditionally so a failure in one cannot strand the
+/// others, which is only worth anything if they are all actually issued.
 #[tokio::test]
-async fn removing_an_instance_removes_its_gate() {
+async fn removing_an_instance_leaves_nothing_behind_that_names_it() {
     let state = create_test_state().await;
     {
         let mut proxy = state.lock();
         register_ready_instances(&mut proxy, "gone-app", 2);
         proxy.set_ready("gone-app-0", false).unwrap();
-        assert_eq!(
-            state.kv_store.load_all_instance_overrides().decoded["gone-app-0"].ready,
-            Some(false)
-        );
-        // Seed the two ephemeral records as well, or the assertions below pass
+        proxy
+            .set_admin_port_policy("gone-app-0", policy(true, &[8443]))
+            .unwrap();
+        // Seed the two ephemeral records as well, or the assertion below passes
         // whether or not the deletes are issued.
         state.kv_store.sync_connections("gone-app-0", 3).unwrap();
         state
             .kv_store
             .sync_instance_handshake("gone-app-0", 1)
             .unwrap();
-        // Assert they are live first. Without this the post-delete assertions
-        // go quietly vacuous again the moment the seeds stop landing on the
-        // keys they are checked against -- which is the failure this test
-        // exists to rule out.
-        assert!(conn_is_live(&state), "seeded conn/ record should be live");
-        assert!(
-            handshake_is_live(&state),
-            "seeded handshake/ record should be live"
-        );
-        proxy.remove_instance("gone-app-0").unwrap();
     }
-    // The gate has its own key now, so it needs its own tombstone -- an id
-    // recycled after the delete would otherwise inherit it. The deletes are
-    // issued unconditionally so a failure in one cannot strand the others,
-    // which is only worth anything if they are all actually issued.
-    for key in [
-        crate::kv::keys::inst("gone-app-0"),
-        crate::kv::keys::admin_ready("gone-app-0"),
-        crate::kv::keys::admin_port_policy("gone-app-0"),
-    ] {
-        let live = state
-            .kv_store
-            .persistent()
-            .read()
-            .get(&key)
-            .is_some_and(|entry| !entry.is_deleted());
-        assert!(!live, "{key} should be gone");
-    }
-    assert!(
-        !handshake_is_live(&state),
-        "handshake/ record should be gone"
+
+    let node = state.kv_store.my_node_id();
+    let before = live_keys_naming(&state, "gone-app-0");
+    assert_eq!(
+        before,
+        vec![
+            "admin/gone-app-0/port_policy".to_string(),
+            "admin/gone-app-0/ready".to_string(),
+            format!("conn/gone-app-0/{node}"),
+            format!("handshake/gone-app-0/{node}"),
+            "inst/gone-app-0".to_string(),
+        ],
+        "the fixture must seed every per-instance key, or the assertion below \
+         is vacuous"
     );
-    assert!(!conn_is_live(&state), "conn/ record should be gone");
+
+    state.lock().remove_instance("gone-app-0").unwrap();
+
+    assert!(
+        live_keys_naming(&state, "gone-app-0").is_empty(),
+        "left behind: {:?}",
+        live_keys_naming(&state, "gone-app-0")
+    );
+    // The sibling is untouched: a delete is per instance, not per app.
+    assert!(!live_keys_naming(&state, "gone-app-1").is_empty());
 }
 
 /// Selection handing over an empty group means every instance was ruled out
@@ -1157,6 +1159,59 @@ async fn an_instance_deleted_on_another_node_stops_being_routable_here() {
         .state
         .allocated_addresses
         .contains(&"10.0.0.40".parse().unwrap()));
+}
+
+/// Whether this node's ephemeral observations of `instance_id` are live.
+fn observations_are_live(state: &TestState, instance_id: &str) -> (bool, bool) {
+    let node = state.kv_store.my_node_id();
+    let store = state.kv_store.ephemeral().read();
+    let live = |key: String| store.get(&key).is_some_and(|entry| !entry.is_deleted());
+    (
+        live(crate::kv::keys::conn(instance_id, node)),
+        live(crate::kv::keys::handshake(instance_id, node)),
+    )
+}
+
+/// A delete can only withdraw the deleting node's own `conn/` and `handshake/`
+/// keys -- those are the only ones it owns. Every other node has to withdraw
+/// its own when it learns of the deletion, or its observation of a CVM that no
+/// longer exists is never collected: nothing else iterates those prefixes, and
+/// the recycle loop cannot see an instance it has already dropped from memory.
+#[tokio::test]
+async fn learning_of_a_remote_deletion_withdraws_this_nodes_observations() {
+    let state = create_test_state().await;
+    sync_from_peer(
+        &state,
+        "peer-instance",
+        "10.0.0.40",
+        &test_pubkey("peer-key"),
+    );
+    reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
+    // This node has been watching it, as every node in the cluster does.
+    state.kv_store.sync_connections("peer-instance", 4).unwrap();
+    state
+        .kv_store
+        .sync_instance_handshake("peer-instance", 1)
+        .unwrap();
+    assert_eq!(observations_are_live(&state, "peer-instance"), (true, true));
+
+    // The tombstone arrives through sync: the peer withdrew its own keys, not
+    // ours. Written directly rather than through `sync_delete_instance`, which
+    // is what the *deleting* node calls.
+    state
+        .kv_store
+        .persistent()
+        .write()
+        .delete(crate::kv::keys::inst("peer-instance"))
+        .unwrap();
+    reload_instances_from_kv_store(&state.proxy, &state.kv_store).unwrap();
+
+    assert!(!state.lock().state.instances.contains_key("peer-instance"));
+    assert_eq!(
+        observations_are_live(&state, "peer-instance"),
+        (false, false),
+        "this node's observations must not outlive the instance they describe"
+    );
 }
 
 #[tokio::test]

--- a/dstack/gateway/src/main_service/tests.rs
+++ b/dstack/gateway/src/main_service/tests.rs
@@ -799,7 +799,7 @@ async fn one_override_key_existing_does_not_answer_for_the_other() {
     };
 
     let (port_policy, ready) =
-        effective_overrides(&state.kv_store, "half-moved", Some(&legacy)).unwrap();
+        read_overrides(&state.kv_store, "half-moved", Some(&legacy)).unwrap();
     assert_eq!(
         ready,
         Some(false),
@@ -826,7 +826,7 @@ async fn a_cleared_override_is_an_answer_not_an_absence() {
         admin_port_policy: Some(policy(true, &[8443])),
     };
 
-    let (port_policy, _) = effective_overrides(&state.kv_store, "cleared", Some(&legacy)).unwrap();
+    let (port_policy, _) = read_overrides(&state.kv_store, "cleared", Some(&legacy)).unwrap();
     assert_eq!(
         port_policy, None,
         "the operator cleared it; the instance record must not put it back"

--- a/dstack/gateway/src/metrics.rs
+++ b/dstack/gateway/src/metrics.rs
@@ -358,7 +358,7 @@ pub(crate) fn render(snapshot: &Snapshot) -> String {
     counter(
         &mut out,
         "dstack_gateway_kv_wal_sync_failures_total",
-        "Attempts to force the WaveKV write-ahead log to disk that failed. While this is rising, writes accepted in the last wal_sync_interval are not durable.",
+        "Attempts to force the WaveKV write-ahead log to disk that failed. While this is rising, writes accepted in the last wal_sync_window are not durable.",
         "",
         KV_WAL_SYNC_FAILURES.load(Ordering::Relaxed),
     );

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -25,13 +25,14 @@ mod filters {
 /// record, what an operator decided under `admin/`, and this node's live
 /// connection count.
 ///
-/// Not a stored shape, which is the difference from [`crate::kv::InstanceData`]
-/// -- that one is the `inst/` record and nothing else. Assembling three sources
-/// into one type here is what lets the proxy answer a routing question without
-/// touching the store; keeping them apart is what stops a registration, which
-/// writes the `inst/` record in full, from carrying an operator's decision back
-/// out with it. `From<&InstanceInfo> for InstanceData` is that narrowing, and
-/// the compiler is what checks it drops exactly the right fields.
+/// Not a stored shape, which is the difference from
+/// [`crate::kv::InstanceRecord`] -- that one is the `inst/` record and nothing
+/// else. Assembling three sources into one type here is what lets the proxy
+/// answer a routing question without touching the store; keeping them apart is
+/// what stops a registration, which writes the `inst/` record in full, from
+/// carrying an operator's decision back out with it.
+/// `From<&InstanceInfo> for InstanceRecord` is that narrowing, and the compiler
+/// is what checks it drops exactly the right fields.
 #[derive(Clone, Debug)]
 pub struct InstanceInfo {
     pub id: String,

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -41,6 +41,14 @@ pub struct InstanceInfo {
     /// when set; survives app upgrades.
     #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
+    /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
+    /// touched it. See [`InstanceInfo::is_admin_ready`].
+    ///
+    /// Persisted under its own `admin_ready/` key rather than inside the
+    /// shared instance record, so that a node which does not know about the
+    /// gate cannot drop it when it rewrites that record.
+    #[serde(default)]
+    pub admin_ready: Option<bool>,
     #[serde(skip)]
     pub connections: Arc<AtomicU64>,
 }
@@ -48,6 +56,35 @@ pub struct InstanceInfo {
 impl InstanceInfo {
     pub fn num_connections(&self) -> u64 {
         self.connections.load(Ordering::Relaxed)
+    }
+
+    /// Whether an operator has left this instance eligible for traffic.
+    ///
+    /// Defaults to ready, so the gate is invisible until someone explicitly
+    /// closes it -- an instance that predates this field, or one nobody has
+    /// touched, keeps serving exactly as before.
+    ///
+    /// This only gates *multi-target* selection, i.e. connections addressed to
+    /// the app id. Routing to the instance id directly ignores it on purpose:
+    /// the point of taking an instance out of rotation is to investigate it
+    /// while it is still running, which needs the instance to stay reachable.
+    pub fn is_admin_ready(&self) -> bool {
+        self.admin_ready.unwrap_or(true)
+    }
+
+    /// Whether replacing `self` with `other` could invalidate a cached
+    /// selection.
+    ///
+    /// `ip` is copied straight into the cached `AddressInfo`; `app_id` decides
+    /// which cache entry the instance belongs to; `public_key` is the key the
+    /// handshake freshness filter looks up; `admin_ready` gates eligibility.
+    /// A change to any of them means a cached `top_n` was computed against a
+    /// record that no longer exists.
+    pub fn routing_inputs_differ(&self, other: &Self) -> bool {
+        self.ip != other.ip
+            || self.app_id != other.app_id
+            || self.public_key != other.public_key
+            || self.admin_ready != other.admin_ready
     }
 }
 

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -42,13 +42,13 @@ pub struct InstanceInfo {
     #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
     /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
-    /// touched it. See [`InstanceInfo::is_admin_ready`].
+    /// touched it. See [`InstanceInfo::is_ready`].
     ///
     /// Persisted as a field of the instance record; see
-    /// [`crate::kv::InstanceData::admin_ready`] for why it does not get a key
+    /// [`crate::kv::InstanceData::ready`] for why it does not get a key
     /// of its own.
     #[serde(default)]
-    pub admin_ready: Option<bool>,
+    pub ready: Option<bool>,
     #[serde(skip)]
     pub connections: Arc<AtomicU64>,
 }
@@ -68,8 +68,8 @@ impl InstanceInfo {
     /// the app id. Routing to the instance id directly ignores it on purpose:
     /// the point of taking an instance out of rotation is to investigate it
     /// while it is still running, which needs the instance to stay reachable.
-    pub fn is_admin_ready(&self) -> bool {
-        self.admin_ready.unwrap_or(true)
+    pub fn is_ready(&self) -> bool {
+        self.ready.unwrap_or(true)
     }
 
     /// Whether replacing `self` with `other` could invalidate a cached
@@ -77,14 +77,14 @@ impl InstanceInfo {
     ///
     /// `ip` is copied straight into the cached `AddressInfo`; `app_id` decides
     /// which cache entry the instance belongs to; `public_key` is the key the
-    /// handshake freshness filter looks up; `admin_ready` gates eligibility.
+    /// handshake freshness filter looks up; `ready` gates eligibility.
     /// A change to any of them means a cached `top_n` was computed against a
     /// record that no longer exists.
     pub fn routing_inputs_differ(&self, other: &Self) -> bool {
         self.ip != other.ip
             || self.app_id != other.app_id
             || self.public_key != other.public_key
-            || self.admin_ready != other.admin_ready
+            || self.ready != other.ready
     }
 }
 

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -41,14 +41,14 @@ pub struct InstanceInfo {
     /// when set; survives app upgrades.
     ///
     /// Persisted under `admin/<instance_id>/port_policy`, not in the instance
-    /// record -- see [`crate::kv::AdminOverrides`].
+    /// record -- see [`crate::kv::PortPolicyOverride`].
     #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
     /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
     /// touched it. See [`InstanceInfo::is_ready`].
     ///
     /// Persisted under `admin/<instance_id>/ready`, not in the instance record
-    /// -- see [`crate::kv::AdminOverrides`].
+    /// -- see [`crate::kv::KvStore::instance_gate`].
     #[serde(default)]
     pub ready: Option<bool>,
     #[serde(skip)]

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -4,7 +4,6 @@
 
 use dstack_gateway_rpc::{AcmeInfoResponse, ProxyAccelStatus, StatusResponse};
 use rinja::Template;
-use serde::{Deserialize, Serialize};
 use std::{
     net::Ipv4Addr,
     sync::{
@@ -22,7 +21,18 @@ mod filters {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// One instance as the data plane sees it: what the CVM reported in its `inst/`
+/// record, what an operator decided under `admin/`, and this node's live
+/// connection count.
+///
+/// Not a stored shape, which is the difference from [`crate::kv::InstanceData`]
+/// -- that one is the `inst/` record and nothing else. Assembling three sources
+/// into one type here is what lets the proxy answer a routing question without
+/// touching the store; keeping them apart is what stops a registration, which
+/// writes the `inst/` record in full, from carrying an operator's decision back
+/// out with it. `From<&InstanceInfo> for InstanceData` is that narrowing, and
+/// the compiler is what checks it drops exactly the right fields.
+#[derive(Clone, Debug)]
 pub struct InstanceInfo {
     pub id: String,
     pub app_id: String,
@@ -31,27 +41,22 @@ pub struct InstanceInfo {
     pub reg_time: SystemTime,
     /// Port policy. `None` means the CVM didn't report any (legacy);
     /// gateway will lazily populate via Info() on first proxied connection.
-    #[serde(default)]
     pub port_policy: Option<PortPolicy>,
     /// Hex-encoded compose_hash that `port_policy` was learned against. The
     /// cache is invalidated when a new registration presents a different hash.
-    #[serde(default)]
     pub port_policy_hash: String,
     /// Operator-set override (Admin RPC). Takes precedence over `port_policy`
     /// when set; survives app upgrades.
     ///
     /// Persisted under `admin/<instance_id>/port_policy`, not in the instance
     /// record -- see [`crate::kv::PortPolicyOverride`].
-    #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
     /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
     /// touched it. See [`InstanceInfo::is_ready`].
     ///
     /// Persisted under `admin/<instance_id>/ready`, not in the instance record
     /// -- see [`crate::kv::KvStore::instance_gate`].
-    #[serde(default)]
     pub ready: Option<bool>,
-    #[serde(skip)]
     pub connections: Arc<AtomicU64>,
 }
 

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -39,14 +39,16 @@ pub struct InstanceInfo {
     pub port_policy_hash: String,
     /// Operator-set override (Admin RPC). Takes precedence over `port_policy`
     /// when set; survives app upgrades.
+    ///
+    /// Persisted under `admin/<instance_id>/port_policy`, not in the instance
+    /// record -- see [`crate::kv::AdminOverrides`].
     #[serde(default)]
     pub admin_port_policy: Option<PortPolicy>,
     /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
     /// touched it. See [`InstanceInfo::is_ready`].
     ///
-    /// Persisted as a field of the instance record; see
-    /// [`crate::kv::InstanceData::ready`] for why it does not get a key
-    /// of its own.
+    /// Persisted under `admin/<instance_id>/ready`, not in the instance record
+    /// -- see [`crate::kv::AdminOverrides`].
     #[serde(default)]
     pub ready: Option<bool>,
     #[serde(skip)]

--- a/dstack/gateway/src/models.rs
+++ b/dstack/gateway/src/models.rs
@@ -44,9 +44,9 @@ pub struct InstanceInfo {
     /// Operator-set traffic gate (Admin RPC). `None` means no operator ever
     /// touched it. See [`InstanceInfo::is_admin_ready`].
     ///
-    /// Persisted under its own `admin_ready/` key rather than inside the
-    /// shared instance record, so that a node which does not know about the
-    /// gate cannot drop it when it rewrites that record.
+    /// Persisted as a field of the instance record; see
+    /// [`crate::kv::InstanceData::admin_ready`] for why it does not get a key
+    /// of its own.
     #[serde(default)]
     pub admin_ready: Option<bool>,
     #[serde(skip)]

--- a/dstack/gateway/src/proxy/port_policy.rs
+++ b/dstack/gateway/src/proxy/port_policy.rs
@@ -100,6 +100,13 @@ pub(crate) fn filter_allowed_addresses(
     port: u16,
 ) -> Result<AddressGroup> {
     let total = addresses.len();
+    // Nothing was offered, so nothing was denied here. Selection already ruled
+    // every instance out -- an operator gated them, or none passed the
+    // handshake-freshness filter -- and claiming the port policy rejected them
+    // would send whoever reads this log at the wrong subsystem entirely.
+    if total == 0 {
+        bail!("no instance of app {app_id} is eligible to serve port {port}");
+    }
     let allowed: AddressGroup = addresses
         .into_iter()
         .filter(|a| match is_port_allowed(state, &a.instance_id, port) {

--- a/dstack/gateway/src/proxy/port_policy.rs
+++ b/dstack/gateway/src/proxy/port_policy.rs
@@ -100,12 +100,12 @@ pub(crate) fn filter_allowed_addresses(
     port: u16,
 ) -> Result<AddressGroup> {
     let total = addresses.len();
-    // Nothing was offered, so nothing was denied here. Selection already ruled
-    // every instance out -- an operator gated them, or none passed the
-    // handshake-freshness filter -- and claiming the port policy rejected them
-    // would send whoever reads this log at the wrong subsystem entirely.
+    // Nothing was offered, so nothing was denied here -- and `port` has not
+    // been looked at yet, so naming it would send whoever reads this log at
+    // the wrong subsystem entirely. Selection knows why it came back empty;
+    // ask it instead of guessing.
     if total == 0 {
-        bail!("no instance of app {app_id} is eligible to serve port {port}");
+        bail!("{}", state.lock().describe_empty_selection(app_id));
     }
     let allowed: AddressGroup = addresses
         .into_iter()

--- a/dstack/gateway/templates/dashboard.html
+++ b/dstack/gateway/templates/dashboard.html
@@ -182,6 +182,11 @@ SPDX-License-Identifier: Apache-2.0
             color: #f44336;
         }
 
+        .traffic-gated {
+            color: #f44336;
+            font-weight: bold;
+        }
+
         .status-controls {
             display: flex;
             gap: 5px;
@@ -609,6 +614,7 @@ SPDX-License-Identifier: Apache-2.0
             <th>IP</th>
             <th>Last Seen</th>
             <th>Connections</th>
+            <th>Traffic</th>
         </tr>
         {% for host in status.hosts %}
         <tr>
@@ -617,6 +623,11 @@ SPDX-License-Identifier: Apache-2.0
             <td>{{ host.ip }}</td>
             <td class="timestamp">{{ host.latest_handshake }}</td>
             <td>{{ host.num_connections }}</td>
+            {% if host.admin_ready.unwrap_or(true) %}
+            <td>in rotation</td>
+            {% else %}
+            <td class="traffic-gated" title="Removed from app-id load balancing by an operator. Still reachable by instance id.">gated off</td>
+            {% endif %}
         </tr>
         {% endfor %}
     </table>

--- a/dstack/gateway/templates/dashboard.html
+++ b/dstack/gateway/templates/dashboard.html
@@ -623,7 +623,7 @@ SPDX-License-Identifier: Apache-2.0
             <td>{{ host.ip }}</td>
             <td class="timestamp">{{ host.latest_handshake }}</td>
             <td>{{ host.num_connections }}</td>
-            {% if host.admin_ready.unwrap_or(true) %}
+            {% if host.ready.unwrap_or(true) %}
             <td>in rotation</td>
             {% else %}
             <td class="traffic-gated" title="Removed from app-id load balancing by an operator. Still reachable by instance id.">gated off</td>


### PR DESCRIPTION
## Problem

A CVM registers with the gateway from `dstack-util setup`, during boot, before
`app-compose.service` has even started the containers. From that moment the
instance is in `state.apps[app_id]` and eligible for traffic. The only filter
`select_top_n_hosts` applies is WireGuard handshake freshness
(`handshake_stale`, default 30m), which says the tunnel is up and nothing about
whether the application can serve a request.

That leaves an operator with no way to stop traffic to one instance of a
multi-instance app. Today the options are to shut the CVM down or to remove its
instance record — both of which destroy the thing you were trying to look at.
There is no way to say "stop sending this one new work, but leave it running so
I can find out what is wrong with it".

## Fix

Add a per-instance operator traffic gate, set through `Admin.SetInstanceReady`.

- **It only gates multi-target selection.** The gate is applied on the app-id
  path in `select_top_n_hosts` and `random_select_a_host`. Both functions
  already return early for a direct instance-id lookup, before any filtering,
  so `<instance_id>.<base_domain>` keeps resolving to a gated instance. That is
  the point: an instance pulled from rotation has to stay reachable to be
  investigated.

- **It does not fail open.** A health check is inference and may be wrong, so
  it should fail open; an operator instruction is not, so this one does not.
  Gating every instance of an app makes the app refuse new connections rather
  than quietly overriding the operator.

- **It survives re-registration.** Instance ids are derived from attestation
  and are stable across reboots, so a quarantined instance that reboots must
  not rejoin the rotation on its own.

- **It is carried in the instance record.** Every writer rewrites the whole
  record from its own in-memory copy, so a copy without the gate drops it. That
  happens two ways: a build predating the field reads the record fine (msgpack
  named maps) and just does not write the field back — one rolled-back node is
  enough, no cluster needed — and a node on the *current* build that has not
  seen the gate yet can clobber it via the lazy port-policy fetch, which
  rewrites the record on the first proxied connection. A separate key would
  survive both.

  It is still not worth one. `port_policy` and `admin_port_policy` ride in the
  same record, are rewritten by the same code, and are lost the same two ways,
  so guarding one field of three buys inconsistency rather than safety. The
  cost does differ and that is worth stating: a lost `port_policy` is
  re-fetched and a lost `admin_port_policy` falls back to what the instance
  reports, whereas a lost gate silently returns an instance to rotation.
  Re-issuing the gate rewrites the record and fixes it.

  Keeping it in `inst/` also means it reaches other nodes through the watcher
  that already exists, is removed with the instance, and cannot go corrupt
  independently of the record it describes.

  `InstanceData` is a msgpack named map, so a reader skips fields it does not
  know — widening it later stays a no-op for older nodes, which
  `an_instance_record_with_an_unknown_field_still_decodes` pins.

  If the record itself becomes unreadable, the instance is exempt from the
  removal pass and keeps what the data plane already holds, so the last known
  operator intent survives. Setting the gate again rewrites the whole record
  from memory, which repairs the unreadable one on the way past.

- **It takes effect immediately.** Setting the gate drops the app's `top_n`
  entry, which otherwise pins a pre-gate selection for up to `cache_top_n`
  (30s). An emergency cut-off that takes 30 seconds to apply is not one.

- **Existing connections are left alone.** They are already bridged; tearing
  them down would turn "stop sending it new work" into a second, louder
  outage.

Closing the last open instance of an app logs a warning once — draining an app
entirely is a legitimate thing to want, but silently refusing every connection
to it is worth saying out loud.

`Option<bool>` throughout, with `None` (nobody ever touched it) reading as
ready, so existing deployments and records are unaffected. `HostInfo` gains an
`optional bool admin_ready` and the dashboard grows a `Traffic` column, so an
instance left gated after an investigation is visible rather than forgotten.

## Verification

`cargo test -p dstack-gateway --all-features`: 180 passed, 0 failed.
`cargo fmt --all --check` and `cargo clippy -p dstack-gateway --all-targets -- -D warnings` are clean.

New tests cover the behaviours above individually, in
`main_service/tests.rs` unless noted:

- `gating_an_instance_removes_it_from_rotation_but_keeps_it_directly_reachable`
- `gating_an_instance_invalidates_the_selection_cache`
- `gating_every_instance_refuses_traffic_instead_of_failing_open`
- `the_gate_survives_re_registration`
- `the_random_selection_path_honours_the_gate` (the `connect_top_n = 0` path
  carries its own copy of the filter)
- `gating_an_unregistered_instance_is_an_error`
- `a_gate_arriving_through_kv_invalidates_the_cached_selection`
- `removing_an_instance_removes_its_gate`
- `an_empty_candidate_group_is_not_blamed_on_the_port_policy`
- `an_instance_record_with_an_unknown_field_still_decodes` (`kv/mod.rs`) — the
  gate rides in the instance record, so its forward compatibility is the
  record's: a build that adds a field must not make the record unreadable to
  one that does not know it.

## Notes

- This is the operator half of the traffic gate. A follow-up PR adds
  `healthy`, polled by the gateway from a new `Worker.Health` RPC on the guest
  agent, and the two compose: an instance takes traffic when it is both healthy
  and not gated.
- `admin_port_policy` is carried across the instance-rebuild path here too. It
  had the same hole and the fix is one line, and leaving two operator overrides
  behaving differently under a comment that argues for one of them would have
  been worse than fixing both.
- A failed write to the store is reported rather than swallowed, and the error
  says how far it got: the change is in force on this node only, is not
  durable, and will be undone by the next reload — not "until restart", since
  any peer writing an unrelated `inst/` record triggers a reload that reads the
  gate back out of the store.





