### PR TITLE
fix(gateway): keep KV record fields the writing build does not declare

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wavekv 1.0.0",
- "wavekv 2.0.0",
+ "wavekv 2.1.0",
  "x509-parser",
 ]
 
@@ -8406,9 +8406,9 @@ dependencies = [
 
 [[package]]
 name = "wavekv"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c12ef936041e6aea20bacac4ff79b7c93adc57b232e9d381ecd8e2b1c5f4753"
+checksum = "99f5f24dfab68f43806c0a15c3b87d9cde250dfc876cae3ec34642427becf336"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -1904,7 +1904,9 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rinja",
+ "rmp",
  "rmp-serde",
+ "rmpv",
  "rocket",
  "rustls",
  "safe-write",
@@ -2584,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3478,7 +3480,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3808,7 +3810,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4924,7 +4926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5610,7 +5612,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5649,9 +5651,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6124,6 +6126,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
+
+[[package]]
 name = "rocket"
 version = "0.6.0-dev"
 source = "git+https://github.com/rwf2/Rocket?branch=master#3a54d079aef060a8f732bd04ea54b0581a604087"
@@ -6303,7 +6314,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6371,7 +6382,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7542,7 +7553,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8497,7 +8508,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -176,6 +176,10 @@ serde_with = "3.14.0"
 semver = "1.0.28"
 serde_jcs = "0.2.0"
 rmp-serde = "1.3.1"
+# The msgpack marker table, shared with rmp-serde rather than hand-copied.
+rmp = "0.8.15"
+# Test-only: a full msgpack decoder to differential-test the KV field walker.
+rmpv = "1.3.1"
 serde_json = { version = "1.0.140", default-features = false }
 serde_ini = "0.2.0"
 toml = "0.8.20"

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -121,7 +121,7 @@ serde-duration = { path = "serde-duration" }
 dstack-mr = { path = "dstack-mr" }
 dstack-verifier = { path = "verifier", default-features = false }
 size-parser = { path = "size-parser" }
-wavekv = "2.0"
+wavekv = "2.1"
 
 # Core dependencies
 anyhow = { version = "1.0.97", default-features = false }

--- a/dstack/gateway/Cargo.toml
+++ b/dstack/gateway/Cargo.toml
@@ -60,6 +60,7 @@ tdx-attest.workspace = true
 flate2.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 rmp-serde.workspace = true
+rmp.workspace = true
 or-panic.workspace = true
 base64.workspace = true
 dstack-api-auth.workspace = true
@@ -73,6 +74,7 @@ socket2.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+rmpv.workspace = true
 tempfile.workspace = true
 wavekv-v1 = { package = "wavekv", version = "=1.0.0" }
 # `test-util` gives the idle-watchdog tests a paused clock, so they assert on

--- a/dstack/gateway/gateway.toml
+++ b/dstack/gateway/gateway.toml
@@ -175,6 +175,21 @@ bootnode = ""
 data_dir = "/dstack-gateway/data"
 # Interval for periodic persistence of WaveKV data (e.g., "5s", "1m", "1h")
 persist_interval = "5m"
+# How long a KV write may sit in the page cache before the write-ahead log is
+# forced to disk.
+#
+# An fsync costs about 100us on an NVMe host and milliseconds on the virtio disk
+# a CVM gets, and it runs under the store lock, so paying one per write bounds
+# how fast this gateway can accept registrations and stalls its readers while it
+# does. Deferring it bounds what losing the *machine* costs — writes made in the
+# last window — and changes nothing about losing the process: a panic, an OOM
+# kill or a restart loses nothing either way, because the bytes are already with
+# the kernel.
+#
+# A cluster recovers the window from its peers on restart. A single-node gateway
+# does not, which is the case for setting this to "0s" — force every write
+# before it returns, as releases before WaveKV 2.1 always did.
+wal_sync_interval = "5s"
 # Enable periodic sync of instance connections to KV store
 sync_connections_enabled = true
 # Interval for syncing instance connections to KV store

--- a/dstack/gateway/src/config.rs
+++ b/dstack/gateway/src/config.rs
@@ -543,6 +543,10 @@ pub struct SyncConfig {
     /// Interval for periodic WAL persistence (default: 10s)
     #[serde(with = "serde_duration")]
     pub persist_interval: Duration,
+    /// How long a KV write may sit in the page cache before the write-ahead log
+    /// is forced to disk. Zero forces every write before it returns.
+    #[serde(with = "serde_duration")]
+    pub wal_sync_interval: Duration,
     /// Enable periodic sync of instance connections to KV store
     pub sync_connections_enabled: bool,
     /// Interval for syncing instance connections to KV store

--- a/dstack/gateway/src/distributed_certbot.rs
+++ b/dstack/gateway/src/distributed_certbot.rs
@@ -807,15 +807,16 @@ mod tests {
 
     fn test_certbot(data_dir: &std::path::Path) -> DistributedCertBot {
         let kv_store =
-            Arc::new(KvStore::new(1, vec![], data_dir).expect("failed to create kv store"));
+            Arc::new(KvStore::new(1, vec![], data_dir, None).expect("failed to create kv store"));
         DistributedCertBot::new(kv_store, Arc::new(CertResolver::new()), None)
     }
 
     #[test]
     fn lock_writes_wake_the_persistent_push_path() {
         let data_dir = tempfile::tempdir().expect("failed to create temp dir");
-        let kv_store =
-            Arc::new(KvStore::new(1, vec![], data_dir.path()).expect("failed to create kv store"));
+        let kv_store = Arc::new(
+            KvStore::new(1, vec![], data_dir.path(), None).expect("failed to create kv store"),
+        );
         let notifier = Arc::new(CountingNotifier::default());
         let certbot = DistributedCertBot::new(
             kv_store,

--- a/dstack/gateway/src/kv/compat.rs
+++ b/dstack/gateway/src/kv/compat.rs
@@ -27,15 +27,23 @@
 //! the declaration, so it stays cleared instead of being resurrected from the
 //! stored copy. Aliases count as declared, so `#[serde(alias)]` is safe here too.
 //!
-//! # Records, not snapshots
+//! # The caller says whether a write updates or replaces
 //!
-//! Only long-lived records carry fields forward — see [`is_long_lived_record`].
-//! A snapshot key (a certificate, an attestation, a lock) is a complete new fact
-//! on every write, and carrying a field across those writes would attribute the
-//! previous snapshot's value to the new one. An older gateway renewing a
-//! certificate would then publish, say, a stale chain alongside the key it just
-//! issued: worse than the field being absent, because absent is a case the newer
-//! reader already has to handle.
+//! [`UnknownFields::Keep`] is for a write that updates a record which outlives
+//! it — an instance, a node, a credential, a config. [`UnknownFields::Drop`] is
+//! for one that states a complete new fact: a certificate, an attestation, a
+//! lock, a counter. Carrying a field across one of those would attribute the
+//! previous fact's value to the new one — an older gateway renewing a
+//! certificate would publish a stale chain beside the key it just issued, and
+//! one writing an attestation would hang a stale field off a quote about a
+//! different public key. That is worse than the field being absent, because
+//! absent is a case the newer reader already handles — older gateways exist —
+//! while stale is one it will silently trust.
+//!
+//! The choice is a parameter rather than a table of key prefixes because the
+//! code performing the write is the code that knows which of the two it is
+//! doing, and because a parameter cannot be forgotten: a new write does not
+//! compile until it says.
 //!
 //! # Top-level only
 //!
@@ -56,21 +64,16 @@ use serde::de::{self, Deserializer, Visitor};
 use std::fmt;
 use tracing::debug;
 
-use super::keys;
-
-/// Whether writes to `key` preserve fields this binary does not declare.
-///
-/// True for records with an identity that outlives any single write — an
-/// instance, a node, a DNS credential, a domain or the certbot config — where a
-/// write updates a record that already existed. False for snapshots, counters
-/// and locks, where each write replaces the whole fact and a carried-over field
-/// would describe the write before it.
-pub fn is_long_lived_record(key: &str) -> bool {
-    key.starts_with(keys::INST_PREFIX)
-        || key.starts_with(keys::NODE_INFO_PREFIX)
-        || key.starts_with(keys::DNS_CRED_PREFIX)
-        || key == keys::GLOBAL_CERTBOT_CONFIG
-        || (key.starts_with(keys::CERT_PREFIX) && key.ends_with("/config"))
+/// What a write means for the fields it does not carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownFields {
+    /// The write updates a record that outlives it, so anything in the stored
+    /// copy that this binary does not declare belongs to a newer peer and is
+    /// carried through.
+    Keep,
+    /// The write states a complete new fact, so nothing from the previous one
+    /// may follow it.
+    Drop,
 }
 
 /// Append the fields of `stored` that `T` does not declare to `encoded`.
@@ -82,12 +85,10 @@ pub fn is_long_lived_record(key: &str) -> bool {
 /// never a precondition for the write.
 pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
     key: &str,
+    declared: &[&str],
     stored: &[u8],
     encoded: Vec<u8>,
 ) -> Vec<u8> {
-    let Some(declared) = declared_fields::<T>() else {
-        return encoded;
-    };
     let Some((_, stored_fields)) = split_map(stored) else {
         return encoded;
     };
@@ -152,7 +153,7 @@ pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
 /// across a variant change would mix them), and a type using
 /// `#[serde(flatten)]`, which reads as a map and already preserves what it does
 /// not know.
-fn declared_fields<T: serde::de::DeserializeOwned>() -> Option<&'static [&'static str]> {
+pub fn declared_fields<T: serde::de::DeserializeOwned>() -> Option<&'static [&'static str]> {
     let mut fields = None;
     let _ = T::deserialize(FieldProbe { out: &mut fields });
     fields
@@ -398,7 +399,12 @@ mod tests {
         record.ip = "10.0.0.2".into();
         let encoded = rmp_serde::to_vec_named(&record).unwrap();
 
-        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        let written = carry_unknown_fields::<Old>(
+            "inst/app",
+            declared_fields::<Old>().unwrap(),
+            &stored,
+            encoded,
+        );
         let seen_by_new: New = rmp_serde::from_slice(&written).unwrap();
         assert_eq!(
             seen_by_new.ip, "10.0.0.2",
@@ -426,7 +432,12 @@ mod tests {
         record.note = None;
         let encoded = rmp_serde::to_vec_named(&record).unwrap();
 
-        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        let written = carry_unknown_fields::<Old>(
+            "inst/app",
+            declared_fields::<Old>().unwrap(),
+            &stored,
+            encoded,
+        );
         let seen_by_new: New = rmp_serde::from_slice(&written).unwrap();
         assert_eq!(seen_by_new.note, None, "the clear must stick");
         assert_eq!(
@@ -449,20 +460,20 @@ mod tests {
             b"not msgpack at all".to_vec(),
             Vec::new(),
         ] {
-            let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded.clone());
+            let written = carry_unknown_fields::<Old>(
+                "inst/app",
+                declared_fields::<Old>().unwrap(),
+                &stored,
+                encoded.clone(),
+            );
             assert_eq!(
                 written, encoded,
                 "stored {stored:?} must not change the write"
             );
         }
 
-        // The same holds when it is the value being written that is a scalar.
-        let scalar = rmp_serde::to_vec_named(&7u64).unwrap();
-        let stored = stored_by_a_newer_build();
-        assert_eq!(
-            carry_unknown_fields::<u64>("conn/app/1", &stored, scalar.clone()),
-            scalar
-        );
+        // A scalar value type never gets as far as the merge.
+        assert!(declared_fields::<u64>().is_none());
     }
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -517,7 +528,8 @@ mod tests {
         })
         .unwrap();
 
-        let written = carry_unknown_fields::<Strict>("inst/app", &stored, encoded.clone());
+        let written =
+            carry_unknown_fields::<Strict>("inst/app", &["app_id", "ip"], &stored, encoded.clone());
         assert_eq!(
             written, encoded,
             "the write must stay decodable by its writer"
@@ -538,35 +550,26 @@ mod tests {
             Route53 { access_key: String },
         }
 
-        let stored_map = rmp_serde::to_vec_named(&BTreeMap::from([
-            ("keep".to_string(), 1u8),
-            ("drop".to_string(), 2u8),
-        ]))
-        .unwrap();
-        assert!(
-            matches!(stored_map[0], 0x80..=0x8f),
-            "the fixture must be a map on the wire for this test to mean anything"
-        );
+        // Both are maps on the wire, which is all the byte walker can see.
+        for bytes in [
+            rmp_serde::to_vec_named(&BTreeMap::from([("k".to_string(), 1u8)])).unwrap(),
+            rmp_serde::to_vec_named(&Tagless::Cloudflare {
+                api_token: "secret".into(),
+            })
+            .unwrap(),
+        ] {
+            assert!(
+                matches!(bytes[0], 0x80..=0x8f),
+                "the fixture must be a map on the wire for this test to mean anything"
+            );
+        }
 
-        let encoded =
-            rmp_serde::to_vec_named(&BTreeMap::from([("keep".to_string(), 1u8)])).unwrap();
-        assert_eq!(
-            carry_unknown_fields::<BTreeMap<String, u8>>("inst/app", &stored_map, encoded.clone()),
-            encoded,
+        assert!(
+            declared_fields::<BTreeMap<String, u8>>().is_none(),
             "a removed map entry must stay removed"
         );
-
-        let stored_enum = rmp_serde::to_vec_named(&Tagless::Cloudflare {
-            api_token: "secret".into(),
-        })
-        .unwrap();
-        let encoded = rmp_serde::to_vec_named(&Tagless::Route53 {
-            access_key: "key".into(),
-        })
-        .unwrap();
-        assert_eq!(
-            carry_unknown_fields::<Tagless>("dns_cred/x", &stored_enum, encoded.clone()),
-            encoded,
+        assert!(
+            declared_fields::<Tagless>().is_none(),
             "one variant's fields must not follow a change of variant"
         );
     }
@@ -591,40 +594,6 @@ mod tests {
         );
     }
 
-    /// Records keep unknown fields; snapshots must not, or an older gateway
-    /// would describe the certificate it just issued with the previous one's
-    /// fields.
-    #[test]
-    fn only_long_lived_records_carry_unknown_fields() {
-        for key in [
-            keys::inst("app"),
-            keys::node_info(1),
-            keys::dns_cred("cred"),
-            keys::zt_domain_config("a.example"),
-            keys::GLOBAL_CERTBOT_CONFIG.to_string(),
-        ] {
-            assert!(is_long_lived_record(&key), "{key} is a record");
-        }
-
-        for key in [
-            keys::cert_data("a.example"),
-            keys::cert_lock("a.example"),
-            keys::cert_attestation_latest("a.example"),
-            keys::cert_attestation_history("a.example", 1),
-            keys::node_status(1),
-            keys::conn("app", 1),
-            keys::handshake("app", 1),
-            keys::last_seen_node(1, 2),
-            keys::peer_addr(1),
-            keys::DNS_CRED_DEFAULT.to_string(),
-            keys::GLOBAL_ACME_CREDENTIALS.to_string(),
-            keys::GLOBAL_ACME_ATTESTATION.to_string(),
-            keys::GLOBAL_ACME_ROTATION_LOCK.to_string(),
-        ] {
-            assert!(!is_long_lived_record(&key), "{key} is a snapshot");
-        }
-    }
-
     /// A map with more than 15 entries needs a wider header than the one it
     /// started with, so the rewrite has to widen it rather than patch the
     /// original byte.
@@ -635,7 +604,12 @@ mod tests {
         assert_eq!(stored[0], 0x8f, "15 fields still fit a fixmap");
 
         let encoded = rmp_serde::to_vec_named(&Old::default()).unwrap();
-        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        let written = carry_unknown_fields::<Old>(
+            "inst/app",
+            declared_fields::<Old>().unwrap(),
+            &stored,
+            encoded,
+        );
         assert_eq!(written[0], 0xde, "17 fields need a map16 header");
         assert_eq!(split_map(&written).unwrap().1.len(), 15 + 2);
     }

--- a/dstack/gateway/src/kv/compat.rs
+++ b/dstack/gateway/src/kv/compat.rs
@@ -27,23 +27,23 @@
 //! the declaration, so it stays cleared instead of being resurrected from the
 //! stored copy. Aliases count as declared, so `#[serde(alias)]` is safe here too.
 //!
-//! # The caller says whether a write updates or replaces
+//! # The caller says whether the write is an update
 //!
-//! [`UnknownFields::Keep`] is for a write that updates a record which outlives
-//! it — an instance, a node, a credential, a config. [`UnknownFields::Drop`] is
-//! for one that states a complete new fact: a certificate, an attestation, a
-//! lock, a counter. Carrying a field across one of those would attribute the
-//! previous fact's value to the new one — an older gateway renewing a
-//! certificate would publish a stale chain beside the key it just issued, and
-//! one writing an attestation would hang a stale field off a quote about a
-//! different public key. That is worse than the field being absent, because
-//! absent is a case the newer reader already handles — older gateways exist —
-//! while stale is one it will silently trust.
+//! A write that updates a record outliving it — an instance, a node, a
+//! credential, a config — keeps the fields it does not declare. A write that
+//! states a complete new fact does not: a certificate, an attestation, a lock,
+//! a counter. Carrying a field across one of those would attribute the previous
+//! fact's value to the new one — an older gateway renewing a certificate would
+//! publish a stale chain beside the key it just issued, and one writing an
+//! attestation would hang a stale field off a quote about a different public
+//! key. That is worse than the field being absent, because absent is a case the
+//! newer reader already handles — older gateways exist — while stale is one it
+//! will silently trust.
 //!
-//! The choice is a parameter rather than a table of key prefixes because the
-//! code performing the write is the code that knows which of the two it is
-//! doing, and because a parameter cannot be forgotten: a new write does not
-//! compile until it says.
+//! It is a parameter rather than a table of key prefixes because the code
+//! performing the write is the code that knows which of the two it is doing,
+//! and because a parameter cannot be forgotten: a new write does not compile
+//! until it says.
 //!
 //! # Top-level only
 //!
@@ -63,18 +63,6 @@ use rmp::Marker;
 use serde::de::{self, Deserializer, Visitor};
 use std::fmt;
 use tracing::debug;
-
-/// What a write means for the fields it does not carry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnknownFields {
-    /// The write updates a record that outlives it, so anything in the stored
-    /// copy that this binary does not declare belongs to a newer peer and is
-    /// carried through.
-    Keep,
-    /// The write states a complete new fact, so nothing from the previous one
-    /// may follow it.
-    Drop,
-}
 
 /// Append the fields of `stored` that `T` does not declare to `encoded`.
 ///

--- a/dstack/gateway/src/kv/compat.rs
+++ b/dstack/gateway/src/kv/compat.rs
@@ -77,8 +77,9 @@ pub fn is_long_lived_record(key: &str) -> bool {
 ///
 /// Returns `encoded` untouched — today's behavior — whenever the merge cannot be
 /// made safely: `T` is not a plain struct, either side is not a string-keyed
-/// map, or either side does not parse cleanly. Preserving unknown fields is an
-/// improvement on the write path, never a precondition for the write.
+/// map, either side does not parse cleanly, or the merged bytes do not read
+/// back as `T`. Preserving unknown fields is an improvement on the write path,
+/// never a precondition for the write.
 pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
     key: &str,
     stored: &[u8],
@@ -114,6 +115,18 @@ pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
     for field in &carried {
         out.extend_from_slice(field.raw);
     }
+
+    // Never write a record this binary cannot read back. The field list says
+    // which names `T` knows, not what it tolerates next to them: a
+    // `deny_unknown_fields` type, or a stored record that repeats a key, would
+    // otherwise turn a healthy write into a record its own writer can no longer
+    // decode. Dropping a newer peer's field is the lesser failure — it is the
+    // one this module exists to reduce, not one it may introduce.
+    if let Err(err) = super::decode::<T>(&out) {
+        debug!("declining to carry unknown fields for key {key}: {err:#}");
+        return encoded;
+    }
+
     debug!(
         "carried {} unknown field(s) forward for key {key}: {:?}",
         carried.len(),
@@ -472,6 +485,81 @@ mod tests {
         assert_eq!(declared_fields::<u64>(), None);
         assert_eq!(declared_fields::<Vec<u8>>(), None);
         assert_eq!(declared_fields::<Option<Old>>(), None);
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct Strict {
+        app_id: String,
+        ip: String,
+    }
+
+    /// The declared field list says which names `T` knows, not what it tolerates
+    /// beside them. Carrying a field into a `deny_unknown_fields` type would
+    /// leave a record its own writer can no longer decode — strictly worse than
+    /// the field being dropped, which is the failure this module already
+    /// accepts everywhere else.
+    #[test]
+    fn a_merge_that_would_not_read_back_is_abandoned() {
+        let stored = stored_by_a_newer_build();
+        let encoded = rmp_serde::to_vec_named(&Strict {
+            app_id: "app".into(),
+            ip: "10.0.0.2".into(),
+        })
+        .unwrap();
+
+        let written = carry_unknown_fields::<Strict>("inst/app", &stored, encoded.clone());
+        assert_eq!(
+            written, encoded,
+            "the write must stay decodable by its writer"
+        );
+        rmp_serde::from_slice::<Strict>(&written).expect("writer reads its own record");
+    }
+
+    /// A `BTreeMap` value and an externally tagged enum both encode as maps, so
+    /// the byte walker alone cannot tell them apart from a struct: carrying a
+    /// "missing" key into a map would resurrect an entry that was deliberately
+    /// removed, and into an enum it would graft one variant's fields onto
+    /// another. The declared-field probe is what refuses them.
+    #[test]
+    fn map_shaped_values_that_are_not_structs_are_refused() {
+        #[derive(Debug, Serialize, Deserialize)]
+        enum Tagless {
+            Cloudflare { api_token: String },
+            Route53 { access_key: String },
+        }
+
+        let stored_map = rmp_serde::to_vec_named(&BTreeMap::from([
+            ("keep".to_string(), 1u8),
+            ("drop".to_string(), 2u8),
+        ]))
+        .unwrap();
+        assert!(
+            matches!(stored_map[0], 0x80..=0x8f),
+            "the fixture must be a map on the wire for this test to mean anything"
+        );
+
+        let encoded =
+            rmp_serde::to_vec_named(&BTreeMap::from([("keep".to_string(), 1u8)])).unwrap();
+        assert_eq!(
+            carry_unknown_fields::<BTreeMap<String, u8>>("inst/app", &stored_map, encoded.clone()),
+            encoded,
+            "a removed map entry must stay removed"
+        );
+
+        let stored_enum = rmp_serde::to_vec_named(&Tagless::Cloudflare {
+            api_token: "secret".into(),
+        })
+        .unwrap();
+        let encoded = rmp_serde::to_vec_named(&Tagless::Route53 {
+            access_key: "key".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            carry_unknown_fields::<Tagless>("dns_cred/x", &stored_enum, encoded.clone()),
+            encoded,
+            "one variant's fields must not follow a change of variant"
+        );
     }
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/dstack/gateway/src/kv/compat.rs
+++ b/dstack/gateway/src/kv/compat.rs
@@ -1,0 +1,676 @@
+// SPDX-FileCopyrightText: © 2024-2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Keeps a rolling upgrade from erasing fields the writer has never heard of.
+//!
+//! KV values are msgpack maps keyed by field name, so a gateway running an older
+//! build already *reads* a newer record without tripping over the fields it does
+//! not know. The write path is where the data is lost: `encode` serializes the
+//! struct as this binary declares it, so the moment an older node rewrites a
+//! record — a re-registration, an admin call, a lazily-filled port policy — the
+//! newer fields are gone for the whole cluster, and the node that wrote them has
+//! no way to tell.
+//!
+//! That makes "values may gain fields freely" true only while every node is on
+//! the same build, which is exactly when it does not matter. This module makes it
+//! true during the upgrade window: before a record is written, the fields present
+//! in the stored copy that this binary does not declare are appended to the
+//! outgoing encoding verbatim.
+//!
+//! # What counts as unknown
+//!
+//! Unknown is decided against the field list `T` *declares*, obtained from the
+//! derived `Deserialize` impl, not against the keys the new encoding happens to
+//! contain. The difference matters: a `#[serde(skip_serializing_if)]` field that
+//! this binary deliberately cleared is absent from the encoding but present in
+//! the declaration, so it stays cleared instead of being resurrected from the
+//! stored copy. Aliases count as declared, so `#[serde(alias)]` is safe here too.
+//!
+//! # Records, not snapshots
+//!
+//! Only long-lived records carry fields forward — see [`is_long_lived_record`].
+//! A snapshot key (a certificate, an attestation, a lock) is a complete new fact
+//! on every write, and carrying a field across those writes would attribute the
+//! previous snapshot's value to the new one. An older gateway renewing a
+//! certificate would then publish, say, a stale chain alongside the key it just
+//! issued: worse than the field being absent, because absent is a case the newer
+//! reader already has to handle.
+//!
+//! # Top-level only
+//!
+//! Only the root map is merged. Below it, nothing distinguishes a struct encoded
+//! as a map from a `BTreeMap` field: recursing would resurrect map entries that
+//! were deliberately removed. So a value type gains new fields **at its root**;
+//! a nested type that has to grow needs its own preservation (a
+//! `#[serde(flatten)]` catch-all), and this module declines the merge for such a
+//! type rather than half-doing it.
+//!
+//! A field this binary stops declaring is carried forever, since it is
+//! indistinguishable from a field a newer peer wrote. Retiring one for real
+//! needs an explicit list of names to drop on write; until something needs to be
+//! retired, that list would have no entries to hold.
+
+use rmp::Marker;
+use serde::de::{self, Deserializer, Visitor};
+use std::fmt;
+use tracing::debug;
+
+use super::keys;
+
+/// Whether writes to `key` preserve fields this binary does not declare.
+///
+/// True for records with an identity that outlives any single write — an
+/// instance, a node, a DNS credential, a domain or the certbot config — where a
+/// write updates a record that already existed. False for snapshots, counters
+/// and locks, where each write replaces the whole fact and a carried-over field
+/// would describe the write before it.
+pub fn is_long_lived_record(key: &str) -> bool {
+    key.starts_with(keys::INST_PREFIX)
+        || key.starts_with(keys::NODE_INFO_PREFIX)
+        || key.starts_with(keys::DNS_CRED_PREFIX)
+        || key == keys::GLOBAL_CERTBOT_CONFIG
+        || (key.starts_with(keys::CERT_PREFIX) && key.ends_with("/config"))
+}
+
+/// Append the fields of `stored` that `T` does not declare to `encoded`.
+///
+/// Returns `encoded` untouched — today's behavior — whenever the merge cannot be
+/// made safely: `T` is not a plain struct, either side is not a string-keyed
+/// map, or either side does not parse cleanly. Preserving unknown fields is an
+/// improvement on the write path, never a precondition for the write.
+pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
+    key: &str,
+    stored: &[u8],
+    encoded: Vec<u8>,
+) -> Vec<u8> {
+    let Some(declared) = declared_fields::<T>() else {
+        return encoded;
+    };
+    let Some((_, stored_fields)) = split_map(stored) else {
+        return encoded;
+    };
+    let Some((header_len, encoded_fields)) = split_map(&encoded) else {
+        return encoded;
+    };
+
+    let carried: Vec<&Field> = stored_fields
+        .iter()
+        .filter(|field| {
+            !declared.contains(&field.name)
+                && !encoded_fields.iter().any(|out| out.name == field.name)
+        })
+        .collect();
+    if carried.is_empty() {
+        return encoded;
+    }
+
+    let extra: usize = carried.iter().map(|field| field.raw.len()).sum();
+    let mut out = Vec::with_capacity(encoded.len() + extra + MAX_MAP_HEADER_LEN);
+    if write_map_header(&mut out, encoded_fields.len() + carried.len()).is_none() {
+        return encoded;
+    }
+    out.extend_from_slice(&encoded[header_len..]);
+    for field in &carried {
+        out.extend_from_slice(field.raw);
+    }
+    debug!(
+        "carried {} unknown field(s) forward for key {key}: {:?}",
+        carried.len(),
+        carried.iter().map(|field| field.name).collect::<Vec<_>>(),
+    );
+    out
+}
+
+/// The field names `T` declares, or `None` if `T` does not deserialize from a
+/// plain struct.
+///
+/// `None` is the answer for every shape the merge must stay away from: a scalar,
+/// an internally tagged enum (whose variants have disjoint fields, so merging
+/// across a variant change would mix them), and a type using
+/// `#[serde(flatten)]`, which reads as a map and already preserves what it does
+/// not know.
+fn declared_fields<T: serde::de::DeserializeOwned>() -> Option<&'static [&'static str]> {
+    let mut fields = None;
+    let _ = T::deserialize(FieldProbe { out: &mut fields });
+    fields
+}
+
+/// A deserializer that answers nothing.
+///
+/// Its only purpose is the field list the derived `Deserialize` impl passes to
+/// `deserialize_struct`; every other entry point refuses, which ends the
+/// deserialization immediately.
+struct FieldProbe<'a> {
+    out: &'a mut Option<&'static [&'static str]>,
+}
+
+#[derive(Debug)]
+struct ProbeDone;
+
+impl fmt::Display for ProbeDone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("field probe")
+    }
+}
+
+impl std::error::Error for ProbeDone {}
+
+impl de::Error for ProbeDone {
+    fn custom<T: fmt::Display>(_msg: T) -> Self {
+        // Deliberately drops the message: the probe always fails, and formatting
+        // a string for an error nobody reads would allocate on every write.
+        ProbeDone
+    }
+}
+
+impl<'de> Deserializer<'de> for FieldProbe<'_> {
+    type Error = ProbeDone;
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        *self.out = Some(fields);
+        Err(ProbeDone)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(ProbeDone)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf
+        option unit unit_struct seq tuple tuple_struct map enum identifier ignored_any
+    }
+}
+
+/// A `map32` header is the longest msgpack map header.
+const MAX_MAP_HEADER_LEN: usize = 5;
+
+/// One top-level `key -> value` pair, borrowed from the buffer it was parsed
+/// from so that carrying it forward copies the original bytes rather than
+/// re-encoding a decoded value.
+struct Field<'a> {
+    name: &'a str,
+    /// Key and value bytes, contiguous and verbatim.
+    raw: &'a [u8],
+}
+
+/// Split a msgpack map into its header length and its top-level fields.
+///
+/// Returns `None` unless the buffer is exactly one map whose keys are all
+/// strings. A scalar, an array (the positional struct encoding older releases
+/// wrote), an enum encoded as a string, or trailing bytes all decline rather
+/// than get reinterpreted.
+fn split_map(buf: &[u8]) -> Option<(usize, Vec<Field<'_>>)> {
+    let (header_len, count) = match Marker::from_u8(*buf.first()?) {
+        Marker::FixMap(n) => (1, n as usize),
+        Marker::Map16 => (3, read_uint(buf, 1, 2)?),
+        Marker::Map32 => (5, read_uint(buf, 1, 4)?),
+        _ => return None,
+    };
+    let mut pos = header_len;
+    let mut fields = Vec::with_capacity(count.min(32));
+    for _ in 0..count {
+        let key_start = pos;
+        let key_end = skip_value(buf, pos)?;
+        let name = read_str(buf, key_start, key_end)?;
+        pos = skip_value(buf, key_end)?;
+        fields.push(Field {
+            name,
+            raw: buf.get(key_start..pos)?,
+        });
+    }
+    // Trailing bytes mean this is not the value we think it is.
+    (pos == buf.len()).then_some((header_len, fields))
+}
+
+/// The offset just past the msgpack value starting at `pos`, or `None` if the
+/// input is malformed, truncated, or claims more elements than it has bytes for.
+///
+/// Iterative rather than recursive: the stored bytes come off the wire, and a
+/// deeply nested value must not be able to exhaust the stack. `pending` stays
+/// bounded by the remaining byte count because every element costs at least the
+/// one byte of its own marker.
+fn skip_value(buf: &[u8], mut pos: usize) -> Option<usize> {
+    let mut pending: usize = 1;
+    while pending > 0 {
+        pending -= 1;
+        let marker = Marker::from_u8(*buf.get(pos)?);
+        pos = pos.checked_add(1)?;
+        let (payload, children) = match marker {
+            Marker::FixPos(_) | Marker::FixNeg(_) | Marker::Null | Marker::True | Marker::False => {
+                (0, 0)
+            }
+            Marker::U8 | Marker::I8 => (1, 0),
+            Marker::U16 | Marker::I16 => (2, 0),
+            Marker::U32 | Marker::I32 | Marker::F32 => (4, 0),
+            Marker::U64 | Marker::I64 | Marker::F64 => (8, 0),
+            Marker::FixStr(len) => (len as usize, 0),
+            Marker::Str8 | Marker::Bin8 => (1 + read_uint(buf, pos, 1)?, 0),
+            Marker::Str16 | Marker::Bin16 => (2 + read_uint(buf, pos, 2)?, 0),
+            Marker::Str32 | Marker::Bin32 => (4 + read_uint(buf, pos, 4)?, 0),
+            // One type byte, then the payload.
+            Marker::FixExt1 => (1 + 1, 0),
+            Marker::FixExt2 => (1 + 2, 0),
+            Marker::FixExt4 => (1 + 4, 0),
+            Marker::FixExt8 => (1 + 8, 0),
+            Marker::FixExt16 => (1 + 16, 0),
+            Marker::Ext8 => (1 + 1 + read_uint(buf, pos, 1)?, 0),
+            Marker::Ext16 => (2 + 1 + read_uint(buf, pos, 2)?, 0),
+            Marker::Ext32 => (4 + 1 + read_uint(buf, pos, 4)?, 0),
+            Marker::FixArray(len) => (0, len as usize),
+            Marker::Array16 => (2, read_uint(buf, pos, 2)?),
+            Marker::Array32 => (4, read_uint(buf, pos, 4)?),
+            Marker::FixMap(len) => (0, (len as usize).checked_mul(2)?),
+            Marker::Map16 => (2, read_uint(buf, pos, 2)?.checked_mul(2)?),
+            Marker::Map32 => (4, read_uint(buf, pos, 4)?.checked_mul(2)?),
+            // Never used by the spec, and rejected by rmp-serde on read.
+            Marker::Reserved => return None,
+        };
+        pos = pos.checked_add(payload)?;
+        if pos > buf.len() {
+            return None;
+        }
+        pending = pending.checked_add(children)?;
+        if pending > buf.len() - pos {
+            return None;
+        }
+    }
+    Some(pos)
+}
+
+/// A big-endian unsigned integer of `size` bytes at `pos`.
+fn read_uint(buf: &[u8], pos: usize, size: usize) -> Option<usize> {
+    let bytes = buf.get(pos..pos.checked_add(size)?)?;
+    bytes.iter().try_fold(0usize, |acc, byte| {
+        acc.checked_mul(256)?.checked_add(*byte as usize)
+    })
+}
+
+/// The contents of the msgpack string spanning `start..end`.
+fn read_str(buf: &[u8], start: usize, end: usize) -> Option<&str> {
+    let body = match Marker::from_u8(*buf.get(start)?) {
+        Marker::FixStr(_) => start + 1,
+        Marker::Str8 => start + 2,
+        Marker::Str16 => start + 3,
+        Marker::Str32 => start + 5,
+        _ => return None,
+    };
+    std::str::from_utf8(buf.get(body..end)?).ok()
+}
+
+fn write_map_header(out: &mut Vec<u8>, count: usize) -> Option<()> {
+    match count {
+        0..=15 => out.push(0x80 | count as u8),
+        16..=0xffff => {
+            out.push(0xde);
+            out.extend_from_slice(&(count as u16).to_be_bytes());
+        }
+        _ => {
+            out.push(0xdf);
+            out.extend_from_slice(&u32::try_from(count).ok()?.to_be_bytes());
+        }
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{Rng, SeedableRng};
+    use serde::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
+
+    /// A record as an older build declares it.
+    #[derive(Debug, Default, Serialize, Deserialize)]
+    struct Old {
+        app_id: String,
+        ip: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    }
+
+    /// The same record after a later release added fields to it.
+    #[derive(Debug, Default, Serialize, Deserialize)]
+    struct New {
+        app_id: String,
+        ip: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+        #[serde(default)]
+        admin_port_policy: Option<u32>,
+        #[serde(default)]
+        labels: BTreeMap<String, String>,
+    }
+
+    fn stored_by_a_newer_build() -> Vec<u8> {
+        rmp_serde::to_vec_named(&New {
+            app_id: "app".into(),
+            ip: "10.0.0.1".into(),
+            note: Some("keep".into()),
+            admin_port_policy: Some(7),
+            labels: BTreeMap::from([("tier".to_string(), "edge".to_string())]),
+        })
+        .unwrap()
+    }
+
+    /// The point of the module: an older gateway rewriting a record must not
+    /// silently delete what a newer peer put there.
+    #[test]
+    fn a_field_only_a_newer_build_knows_survives_an_older_writer() {
+        let stored = stored_by_a_newer_build();
+
+        let mut record: Old = rmp_serde::from_slice(&stored).unwrap();
+        record.ip = "10.0.0.2".into();
+        let encoded = rmp_serde::to_vec_named(&record).unwrap();
+
+        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        let seen_by_new: New = rmp_serde::from_slice(&written).unwrap();
+        assert_eq!(
+            seen_by_new.ip, "10.0.0.2",
+            "the writer's own change applies"
+        );
+        assert_eq!(seen_by_new.admin_port_policy, Some(7));
+        assert_eq!(seen_by_new.labels["tier"], "edge");
+        // And the result is still a record the writer itself can read back.
+        assert_eq!(
+            rmp_serde::from_slice::<Old>(&written).unwrap().ip,
+            "10.0.0.2"
+        );
+    }
+
+    /// Deciding "unknown" from the keys missing in the new encoding rather than
+    /// from what the type declares would undo a deliberate clear: `note` is
+    /// skipped when it is `None`, so it is absent from the encoding for the same
+    /// reason a field from the future is.
+    #[test]
+    fn a_field_this_build_declares_is_not_resurrected() {
+        let stored = stored_by_a_newer_build();
+
+        let mut record: Old = rmp_serde::from_slice(&stored).unwrap();
+        assert_eq!(record.note.as_deref(), Some("keep"));
+        record.note = None;
+        let encoded = rmp_serde::to_vec_named(&record).unwrap();
+
+        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        let seen_by_new: New = rmp_serde::from_slice(&written).unwrap();
+        assert_eq!(seen_by_new.note, None, "the clear must stick");
+        assert_eq!(
+            seen_by_new.admin_port_policy,
+            Some(7),
+            "unknowns still carried"
+        );
+    }
+
+    /// Anything that is not a string-keyed map is left exactly as encoded: a
+    /// scalar, and the positional array encoding that older releases wrote
+    /// before values became named maps.
+    #[test]
+    fn a_value_that_is_not_a_string_keyed_map_is_left_alone() {
+        let encoded = rmp_serde::to_vec_named(&Old::default()).unwrap();
+        for stored in [
+            rmp_serde::to_vec_named(&42u64).unwrap(),
+            rmp_serde::to_vec_named(&"up").unwrap(),
+            rmp_serde::to_vec(&New::default()).unwrap(),
+            b"not msgpack at all".to_vec(),
+            Vec::new(),
+        ] {
+            let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded.clone());
+            assert_eq!(
+                written, encoded,
+                "stored {stored:?} must not change the write"
+            );
+        }
+
+        // The same holds when it is the value being written that is a scalar.
+        let scalar = rmp_serde::to_vec_named(&7u64).unwrap();
+        let stored = stored_by_a_newer_build();
+        assert_eq!(
+            carry_unknown_fields::<u64>("conn/app/1", &stored, scalar.clone()),
+            scalar
+        );
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Flattened {
+        a: u8,
+        #[serde(flatten)]
+        rest: BTreeMap<String, u8>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum Tagged {
+        Cloudflare { api_token: String },
+        Route53 { access_key: String },
+    }
+
+    /// The probe must refuse every shape whose fields it cannot enumerate.
+    /// An internally tagged enum is the dangerous one: its variants have
+    /// disjoint fields, so merging across a variant change would graft one
+    /// variant's secrets onto another.
+    #[test]
+    fn a_type_the_probe_cannot_enumerate_declines_the_merge() {
+        assert_eq!(
+            declared_fields::<Old>(),
+            Some(&["app_id", "ip", "note"][..])
+        );
+        assert_eq!(declared_fields::<Flattened>(), None);
+        assert_eq!(declared_fields::<Tagged>(), None);
+        assert_eq!(declared_fields::<u64>(), None);
+        assert_eq!(declared_fields::<Vec<u8>>(), None);
+        assert_eq!(declared_fields::<Option<Old>>(), None);
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Renamed {
+        #[serde(rename = "app")]
+        app_id: String,
+        #[serde(alias = "old_ip")]
+        ip: String,
+    }
+
+    /// A renamed field is declared under its wire name, and an alias counts as
+    /// declared too — otherwise a record written under the alias would be
+    /// carried forward next to the canonical key and then fail to decode as a
+    /// duplicate field.
+    #[test]
+    fn renames_and_aliases_count_as_declared() {
+        assert_eq!(
+            declared_fields::<Renamed>(),
+            Some(&["app", "ip", "old_ip"][..])
+        );
+    }
+
+    /// Records keep unknown fields; snapshots must not, or an older gateway
+    /// would describe the certificate it just issued with the previous one's
+    /// fields.
+    #[test]
+    fn only_long_lived_records_carry_unknown_fields() {
+        for key in [
+            keys::inst("app"),
+            keys::node_info(1),
+            keys::dns_cred("cred"),
+            keys::zt_domain_config("a.example"),
+            keys::GLOBAL_CERTBOT_CONFIG.to_string(),
+        ] {
+            assert!(is_long_lived_record(&key), "{key} is a record");
+        }
+
+        for key in [
+            keys::cert_data("a.example"),
+            keys::cert_lock("a.example"),
+            keys::cert_attestation_latest("a.example"),
+            keys::cert_attestation_history("a.example", 1),
+            keys::node_status(1),
+            keys::conn("app", 1),
+            keys::handshake("app", 1),
+            keys::last_seen_node(1, 2),
+            keys::peer_addr(1),
+            keys::DNS_CRED_DEFAULT.to_string(),
+            keys::GLOBAL_ACME_CREDENTIALS.to_string(),
+            keys::GLOBAL_ACME_ATTESTATION.to_string(),
+            keys::GLOBAL_ACME_ROTATION_LOCK.to_string(),
+        ] {
+            assert!(!is_long_lived_record(&key), "{key} is a snapshot");
+        }
+    }
+
+    /// A map with more than 15 entries needs a wider header than the one it
+    /// started with, so the rewrite has to widen it rather than patch the
+    /// original byte.
+    #[test]
+    fn the_map_header_widens_when_the_field_count_outgrows_it() {
+        let wide: BTreeMap<String, u8> = (0..15).map(|i| (format!("f{i}"), i as u8)).collect();
+        let stored = rmp_serde::to_vec_named(&wide).unwrap();
+        assert_eq!(stored[0], 0x8f, "15 fields still fit a fixmap");
+
+        let encoded = rmp_serde::to_vec_named(&Old::default()).unwrap();
+        let written = carry_unknown_fields::<Old>("inst/app", &stored, encoded);
+        assert_eq!(written[0], 0xde, "17 fields need a map16 header");
+        assert_eq!(split_map(&written).unwrap().1.len(), 15 + 2);
+    }
+
+    // ---- differential tests against a full msgpack decoder ----
+
+    fn random_value(rng: &mut impl Rng, depth: u32) -> rmpv::Value {
+        let leaves = 9;
+        let arms = if depth == 0 { leaves } else { leaves + 3 };
+        match rng.gen_range(0..arms) {
+            0 => rmpv::Value::Nil,
+            1 => rmpv::Value::Boolean(rng.gen()),
+            2 => rmpv::Value::from(rng.gen::<u64>()),
+            3 => rmpv::Value::from(rng.gen::<i64>()),
+            4 => rmpv::Value::from(rng.gen::<f32>()),
+            5 => rmpv::Value::from(rng.gen::<f64>()),
+            // Long enough to reach the str16/str32 and bin16/bin32 headers.
+            6 => rmpv::Value::from("x".repeat(rng.gen_range(0..70_000))),
+            7 => rmpv::Value::Binary(vec![7; rng.gen_range(0..70_000)]),
+            8 => rmpv::Value::Ext(rng.gen(), vec![9; rng.gen_range(0..20)]),
+            9 => rmpv::Value::Array(
+                (0..rng.gen_range(0..18))
+                    .map(|_| random_value(rng, depth - 1))
+                    .collect(),
+            ),
+            10 => rmpv::Value::Map(
+                (0..rng.gen_range(0..18))
+                    .map(|_| (random_value(rng, depth - 1), random_value(rng, depth - 1)))
+                    .collect(),
+            ),
+            _ => rmpv::Value::from(rng.gen_range(-32i8..0)),
+        }
+    }
+
+    /// The skipper walks the format by hand, so it is only trustworthy if it
+    /// lands on exactly the same byte a real decoder does — for every header
+    /// width, not just the compact ones a struct usually produces.
+    #[test]
+    fn skipping_a_value_lands_where_a_real_decoder_lands() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+        for case in 0..2_000 {
+            let value = random_value(&mut rng, 4);
+            let mut buf = Vec::new();
+            rmpv::encode::write_value(&mut buf, &value).unwrap();
+            assert_eq!(skip_value(&buf, 0), Some(buf.len()), "case {case}");
+        }
+    }
+
+    /// The stored bytes arrive over the network, so corruption is the expected
+    /// input, not the exceptional one. Whatever the skipper accepts, a real
+    /// decoder must accept identically; whatever it rejects must be genuinely
+    /// undecodable.
+    #[test]
+    fn corrupted_encodings_are_judged_the_same_way_a_real_decoder_judges_them() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(23);
+        let mut accepted = 0u32;
+        for _ in 0..50_000 {
+            let value = random_value(&mut rng, 3);
+            let mut buf = Vec::new();
+            rmpv::encode::write_value(&mut buf, &value).unwrap();
+            if buf.is_empty() || buf.len() > 4096 {
+                continue;
+            }
+            for _ in 0..rng.gen_range(1..4) {
+                let at = rng.gen_range(0..buf.len());
+                buf[at] ^= 1 << rng.gen_range(0..8);
+            }
+            if rng.gen_range(0..3) == 0 {
+                buf.truncate(rng.gen_range(0..buf.len()));
+            }
+
+            let mine = skip_value(&buf, 0);
+            let mut cursor = &buf[..];
+            let theirs = rmpv::decode::read_value(&mut cursor)
+                .ok()
+                .map(|_| buf.len() - cursor.len());
+            match (mine, theirs) {
+                (Some(mine), Some(theirs)) => {
+                    accepted += 1;
+                    assert_eq!(mine, theirs, "length disagreement on {buf:?}");
+                }
+                (Some(mine), None) => panic!("accepted {mine} bytes rmpv rejects: {buf:?}"),
+                (None, Some(_)) => {
+                    assert!(buf.contains(&0xc1), "rejected what rmpv accepts: {buf:?}")
+                }
+                (None, None) => {}
+            }
+        }
+        assert!(
+            accepted > 1_000,
+            "corpus degenerate: only {accepted} accepted"
+        );
+    }
+
+    /// Nothing about the stored bytes is guaranteed, so no input may read past
+    /// the buffer, panic, or claim more than it was given.
+    #[test]
+    fn arbitrary_bytes_are_never_over_read() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(11);
+        for _ in 0..100_000 {
+            let buf: Vec<u8> = (0..rng.gen_range(0..40)).map(|_| rng.gen()).collect();
+            if let Some(end) = skip_value(&buf, 0) {
+                assert!(end <= buf.len());
+            }
+            if let Some((_, fields)) = split_map(&buf) {
+                for field in fields {
+                    assert!(field.raw.len() <= buf.len());
+                }
+            }
+        }
+    }
+
+    /// A nested value deep enough to exhaust a recursive walker must still be
+    /// handled, since a peer's record is not bounded by what this node writes.
+    #[test]
+    fn deep_nesting_does_not_exhaust_the_stack() {
+        let deep: Vec<u8> = std::iter::repeat_n(0x91, 200_000).chain([0xc0]).collect();
+        assert_eq!(skip_value(&deep, 0), Some(deep.len()));
+    }
+
+    /// A header that claims more entries than the buffer could possibly hold is
+    /// the cheap way to make a parser allocate or spin.
+    #[test]
+    fn a_header_claiming_more_than_the_buffer_holds_is_refused() {
+        assert_eq!(skip_value(&[0xdf, 0xff, 0xff, 0xff, 0xff], 0), None);
+        assert_eq!(skip_value(&[0xdd, 0xff, 0xff, 0xff, 0xff], 0), None);
+        assert_eq!(skip_value(&[0xdb, 0xff, 0xff, 0xff, 0xff], 0), None);
+        assert_eq!(
+            skip_value(&[0xc1], 0),
+            None,
+            "the reserved marker is not a value"
+        );
+        assert!(split_map(&[0xdf, 0xff, 0xff, 0xff, 0xff]).is_none());
+    }
+}

--- a/dstack/gateway/src/kv/compat.rs
+++ b/dstack/gateway/src/kv/compat.rs
@@ -91,6 +91,15 @@ pub fn carry_unknown_fields<T: serde::de::DeserializeOwned>(
     let Some((_, stored_fields)) = split_map(stored) else {
         return encoded;
     };
+    // The steady state is a single-version cluster, where the stored record
+    // holds nothing this binary has not heard of. Settle that before parsing
+    // the outgoing encoding, so the common write pays for one walk, not two.
+    if stored_fields
+        .iter()
+        .all(|field| declared.contains(&field.name))
+    {
+        return encoded;
+    }
     let Some((header_len, encoded_fields)) = split_map(&encoded) else {
         return encoded;
     };

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -43,7 +43,6 @@ mod https_client;
 pub mod import;
 mod sync_service;
 
-pub use compat::UnknownFields;
 #[cfg(test)]
 pub(crate) use https_client::HttpsClient;
 pub use https_client::{AppIdValidator, HttpsClientConfig};
@@ -502,7 +501,7 @@ trait GetPutCodec {
         &mut self,
         key: String,
         value: &T,
-        unknown: compat::UnknownFields,
+        update: bool,
     ) -> Result<()>;
     fn iter_decoded<T: for<'de> serde::Deserialize<'de>>(
         &self,
@@ -554,29 +553,26 @@ impl GetPutCodec for NodeState {
 
     /// Write a value.
     ///
-    /// `unknown` says what becomes of the fields the stored record holds and
-    /// this binary does not declare: [`compat::UnknownFields::Keep`] for a
-    /// write that updates a record, `Drop` for one that states a complete new
-    /// fact. See [`compat`] for why that is the caller's call, and why keeping
-    /// them is not the same as keeping every field the encoding happens to be
-    /// missing.
+    /// `update` is true when the write modifies a record that outlives it, and
+    /// false when it states a complete new fact. An update keeps the fields the
+    /// stored record holds and this binary does not declare; a replacement does
+    /// not, because they describe the fact being replaced. See [`compat`] for
+    /// why that is the caller's call, and why keeping a field is not the same
+    /// as keeping every field the encoding happens to be missing.
     fn put_encoded<T: serde::Serialize + serde::de::DeserializeOwned>(
         &mut self,
         key: String,
         value: &T,
-        unknown: compat::UnknownFields,
+        update: bool,
     ) -> Result<()> {
         let encoded = encode(value)?;
-        let bytes = match (unknown, compat::declared_fields::<T>()) {
-            (compat::UnknownFields::Keep, Some(declared)) => {
-                match self.get(&key).and_then(|entry| entry.value) {
-                    Some(stored) => {
-                        compat::carry_unknown_fields::<T>(&key, declared, &stored, encoded)
-                    }
-                    None => encoded,
-                }
-            }
-            _ => encoded,
+        let declared = update.then(compat::declared_fields::<T>).flatten();
+        let bytes = match declared {
+            Some(declared) => match self.get(&key).and_then(|entry| entry.value) {
+                Some(stored) => compat::carry_unknown_fields::<T>(&key, declared, &stored, encoded),
+                None => encoded,
+            },
+            None => encoded,
         };
         self.put(key.clone(), bytes)
             .with_context(|| format!("failed to put key {key}"))?;
@@ -767,7 +763,7 @@ impl KvStore {
     pub fn sync_instance(&self, instance_id: &str, data: &InstanceData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::inst(instance_id), data, UnknownFields::Keep)
+            .put_encoded(keys::inst(instance_id), data, true)
     }
 
     /// Sync instance deletion to other nodes
@@ -817,7 +813,7 @@ impl KvStore {
     pub fn sync_node(&self, node_id: NodeId, data: &NodeData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::node_info(node_id), data, UnknownFields::Keep)
+            .put_encoded(keys::node_info(node_id), data, true)
     }
 
     /// Load all nodes from sync store
@@ -865,11 +861,9 @@ impl KvStore {
 
     /// Set node status (stored separately from NodeData)
     pub fn set_node_status(&self, node_id: NodeId, status: NodeStatus) -> Result<()> {
-        self.persistent.write().put_encoded(
-            keys::node_status(node_id),
-            &status,
-            UnknownFields::Drop,
-        )?;
+        self.persistent
+            .write()
+            .put_encoded(keys::node_status(node_id), &status, false)?;
         Ok(())
     }
 
@@ -926,7 +920,7 @@ impl KvStore {
         self.ephemeral.write().put_encoded(
             keys::conn(instance_id, self.my_node_id),
             &count,
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -938,7 +932,7 @@ impl KvStore {
         self.ephemeral.write().put_encoded(
             keys::handshake(instance_id, self.my_node_id),
             &timestamp,
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -981,7 +975,7 @@ impl KvStore {
         self.ephemeral.write().put_encoded(
             keys::last_seen_node(node_id, self.my_node_id),
             &timestamp,
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -1101,11 +1095,9 @@ impl KvStore {
 
         // Store URL in persistent KvStore. Owned, because the value has to be a
         // type a reader can name: `&str` borrows from the buffer it decodes.
-        self.persistent.write().put_encoded(
-            keys::peer_addr(node_id),
-            &url.to_string(),
-            UnknownFields::Drop,
-        )?;
+        self.persistent
+            .write()
+            .put_encoded(keys::peer_addr(node_id), &url.to_string(), false)?;
 
         let _ = self.add_peer(node_id);
         Ok(())
@@ -1125,11 +1117,7 @@ impl KvStore {
     pub fn update_peer_last_seen(&self, peer_id: NodeId) {
         let ts = now_secs();
         let key = keys::last_seen_node(peer_id, self.my_node_id);
-        if let Err(e) = self
-            .ephemeral
-            .write()
-            .put_encoded(key, &ts, UnknownFields::Drop)
-        {
+        if let Err(e) = self.ephemeral.write().put_encoded(key, &ts, false) {
             warn!("failed to update peer {peer_id} last_seen: {e}");
         }
     }
@@ -1163,7 +1151,7 @@ impl KvStore {
     pub fn save_dns_credential(&self, cred: &DnsCredential) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::dns_cred(&cred.id), cred, UnknownFields::Keep)?;
+            .put_encoded(keys::dns_cred(&cred.id), cred, true)?;
         Ok(())
     }
 
@@ -1194,7 +1182,7 @@ impl KvStore {
         self.persistent.write().put_encoded(
             keys::DNS_CRED_DEFAULT.to_string(),
             &cred_id.to_string(),
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -1227,7 +1215,7 @@ impl KvStore {
         self.persistent.write().put_encoded(
             keys::GLOBAL_CERTBOT_CONFIG.to_string(),
             config,
-            UnknownFields::Keep,
+            true,
         )?;
         Ok(())
     }
@@ -1259,7 +1247,7 @@ impl KvStore {
         self.persistent.write().put_encoded(
             keys::zt_domain_config(&config.domain),
             config,
-            UnknownFields::Keep,
+            true,
         )?;
         Ok(())
     }
@@ -1354,7 +1342,7 @@ impl KvStore {
     pub fn save_cert_data(&self, domain: &str, data: &CertData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::cert_data(domain), data, UnknownFields::Drop)?;
+            .put_encoded(keys::cert_data(domain), data, false)?;
         Ok(())
     }
 
@@ -1402,7 +1390,7 @@ impl KvStore {
         self.persistent.write().put_encoded(
             keys::GLOBAL_ACME_CREDENTIALS.to_string(),
             creds,
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -1423,7 +1411,7 @@ impl KvStore {
         self.persistent.write().put_encoded(
             keys::GLOBAL_ACME_ATTESTATION.to_string(),
             attestation,
-            UnknownFields::Drop,
+            false,
         )?;
         Ok(())
     }
@@ -1454,7 +1442,7 @@ impl KvStore {
         };
         self.persistent
             .write()
-            .put_encoded(keys::cert_lock(domain), &lock, UnknownFields::Drop)
+            .put_encoded(keys::cert_lock(domain), &lock, false)
             .is_ok()
     }
 
@@ -1491,11 +1479,7 @@ impl KvStore {
         };
         self.persistent
             .write()
-            .put_encoded(
-                keys::GLOBAL_ACME_ROTATION_LOCK.to_string(),
-                &lock,
-                UnknownFields::Drop,
-            )
+            .put_encoded(keys::GLOBAL_ACME_ROTATION_LOCK.to_string(), &lock, false)
             .ok()?;
         Some(lock)
     }
@@ -1548,14 +1532,10 @@ impl KvStore {
         state.put_encoded(
             keys::cert_attestation_history(domain, attestation.generated_at),
             attestation,
-            UnknownFields::Drop,
+            false,
         )?;
         // Update latest
-        state.put_encoded(
-            keys::cert_attestation_latest(domain),
-            attestation,
-            UnknownFields::Drop,
-        )?;
+        state.put_encoded(keys::cert_attestation_latest(domain), attestation, false)?;
         Ok(())
     }
 
@@ -1703,7 +1683,7 @@ mod acme_credentials_tests {
                     started_at: u64::MAX,
                     started_by: 2,
                 },
-                UnknownFields::Drop,
+                false,
             )
             .expect("lock write should succeed");
 
@@ -1720,7 +1700,7 @@ mod acme_credentials_tests {
                     started_at: u64::MAX,
                     started_by: 2,
                 },
-                UnknownFields::Drop,
+                false,
             )
             .expect("certificate lock write should succeed");
         assert!(
@@ -2221,15 +2201,11 @@ mod corruption_tests {
 
         kv.ephemeral
             .write()
-            .put_encoded(
-                keys::handshake("cvm", 2),
-                &(now.saturating_sub(30)),
-                UnknownFields::Drop,
-            )
+            .put_encoded(keys::handshake("cvm", 2), &(now.saturating_sub(30)), false)
             .unwrap();
         kv.ephemeral
             .write()
-            .put_encoded(keys::handshake("cvm", 3), &u64::MAX, UnknownFields::Drop)
+            .put_encoded(keys::handshake("cvm", 3), &u64::MAX, false)
             .unwrap();
         // A peer with a broken clock must not keep a dead CVM alive forever.
         let latest = kv
@@ -2240,7 +2216,7 @@ mod corruption_tests {
 
         kv.ephemeral
             .write()
-            .put_encoded(keys::last_seen_node(7, 3), &u64::MAX, UnknownFields::Drop)
+            .put_encoded(keys::last_seen_node(7, 3), &u64::MAX, false)
             .unwrap();
         assert_eq!(kv.get_node_latest_last_seen(7), None);
         assert!(kv.get_node_last_seen_by_all(7).is_empty());
@@ -2253,7 +2229,7 @@ mod corruption_tests {
             .put_encoded(
                 keys::handshake("cvm", 4),
                 &(now + MAX_CLOCK_DRIFT_SECS / 2),
-                UnknownFields::Drop,
+                false,
             )
             .unwrap();
         assert_eq!(kv.get_instance_handshakes("cvm").len(), 2);
@@ -2350,7 +2326,7 @@ mod corruption_tests {
                     node: None,
                     priority: 100,
                 },
-                UnknownFields::Keep,
+                true,
             )
             .expect("raw put should succeed");
 

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -1870,13 +1870,18 @@ mod value_encoding_tests {
     /// An fsync per write runs under the store lock, so it bounds how fast this
     /// gateway accepts registrations; the window is what buys that back, and it
     /// buys nothing if the interval stops at `SyncConfig`.
+    ///
+    /// The window here is long enough that no scheduling delay can end it
+    /// mid-test: the property is "not yet due", and a stalled runner must not be
+    /// able to turn that into a failure.
     #[test]
-    fn a_configured_window_holds_writes_out_of_the_disk_until_it_elapses() {
+    fn a_configured_window_holds_writes_out_of_the_disk() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let window = Duration::from_millis(20);
-        let kv = KvStore::new(1, vec![], dir.path(), Some(window)).expect("kv store");
+        let kv = KvStore::new(1, vec![], dir.path(), Some(Duration::from_secs(3_600)))
+            .expect("kv store");
 
         kv.set_node_status(1, NodeStatus::Up).expect("write");
+
         assert_eq!(
             kv.persistent().read().wal_sync_count(),
             0,
@@ -1886,10 +1891,25 @@ mod value_encoding_tests {
             !kv.sync_wal_if_due().expect("sync check"),
             "nothing is due before the window elapses"
         );
+    }
 
-        std::thread::sleep(window * 3);
+    /// And the window has to end. The only timing this depends on is sleeping
+    /// for longer than the window, which is safe in the direction that matters.
+    #[test]
+    fn an_elapsed_window_forces_the_log() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let window = Duration::from_millis(20);
+        let kv = KvStore::new(1, vec![], dir.path(), Some(window)).expect("kv store");
+
+        kv.set_node_status(1, NodeStatus::Up).expect("write");
+        std::thread::sleep(window * 5);
+
         assert!(kv.sync_wal_if_due().expect("sync"), "the window elapsed");
         assert_eq!(kv.persistent().read().wal_sync_count(), 1);
+        assert!(
+            !kv.sync_wal_if_due().expect("sync check"),
+            "a second call with nothing written must not force the disk again"
+        );
     }
 
     /// Without a window every write is on the disk before it returns, which is

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -38,6 +38,7 @@
 //! whole node pair, so a node writing a key its peer does not know silently stops the
 //! two from converging. Bound what a peer can consume; do not police what it means.
 
+mod compat;
 mod https_client;
 pub mod import;
 mod sync_service;
@@ -481,6 +482,10 @@ pub fn gunzip_bounded(data: &[u8], limit: usize) -> Result<Vec<u8>> {
 /// in `#[serde(default)]` fields it does not receive, so the value types below
 /// can gain fields without breaking gateways running an older build. Decoding
 /// accepts both forms, so values written by older releases stay readable.
+///
+/// Skipping on read is only half of a rolling upgrade: this encoding contains
+/// exactly the fields the writing binary declares, so an older node rewriting a
+/// record would drop the rest. [`compat`] puts them back on the way out.
 pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     rmp_serde::encode::to_vec_named(value).context("failed to encode value")
 }
@@ -492,7 +497,11 @@ pub fn decode<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T> {
 trait GetPutCodec {
     fn decode<T: for<'de> serde::Deserialize<'de>>(&self, key: &str) -> Option<T>;
     fn decode_strict<T: for<'de> serde::Deserialize<'de>>(&self, key: &str) -> Result<Option<T>>;
-    fn put_encoded<T: serde::Serialize>(&mut self, key: String, value: &T) -> Result<()>;
+    fn put_encoded<T: serde::Serialize + serde::de::DeserializeOwned>(
+        &mut self,
+        key: String,
+        value: &T,
+    ) -> Result<()>;
     fn iter_decoded<T: for<'de> serde::Deserialize<'de>>(
         &self,
         prefix: &str,
@@ -541,8 +550,23 @@ impl GetPutCodec for NodeState {
             .with_context(|| format!("corrupt record at KV key {key}"))
     }
 
-    fn put_encoded<T: serde::Serialize>(&mut self, key: String, value: &T) -> Result<()> {
-        self.put(key.clone(), encode(value)?)
+    /// Write a value, keeping any field of the stored record that this binary
+    /// does not declare — see [`compat`] for why that is not the same as
+    /// keeping every field the encoding happens to be missing.
+    fn put_encoded<T: serde::Serialize + serde::de::DeserializeOwned>(
+        &mut self,
+        key: String,
+        value: &T,
+    ) -> Result<()> {
+        let encoded = encode(value)?;
+        let stored = compat::is_long_lived_record(&key)
+            .then(|| self.get(&key).and_then(|entry| entry.value))
+            .flatten();
+        let bytes = match stored {
+            Some(stored) => compat::carry_unknown_fields::<T>(&key, &stored, encoded),
+            None => encoded,
+        };
+        self.put(key.clone(), bytes)
             .with_context(|| format!("failed to put key {key}"))?;
         Ok(())
     }
@@ -1055,10 +1079,11 @@ impl KvStore {
     pub fn register_peer_url(&self, node_id: NodeId, url: &str) -> Result<()> {
         validate_peer_url(url)?;
 
-        // Store URL in persistent KvStore
+        // Store URL in persistent KvStore. Owned, because the value has to be a
+        // type a reader can name: `&str` borrows from the buffer it decodes.
         self.persistent
             .write()
-            .put_encoded(keys::peer_addr(node_id), &url)?;
+            .put_encoded(keys::peer_addr(node_id), &url.to_string())?;
 
         let _ = self.add_peer(node_id);
         Ok(())
@@ -1142,7 +1167,7 @@ impl KvStore {
     pub fn set_default_dns_credential_id(&self, cred_id: &str) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::DNS_CRED_DEFAULT.to_string(), &cred_id)?;
+            .put_encoded(keys::DNS_CRED_DEFAULT.to_string(), &cred_id.to_string())?;
         Ok(())
     }
 
@@ -1782,6 +1807,135 @@ mod value_encoding_tests {
                 "{label}"
             );
         }
+    }
+
+    /// An instance record as some later release will declare it.
+    #[derive(Debug, Serialize, Deserialize)]
+    struct FutureInstanceData {
+        app_id: String,
+        ip: Ipv4Addr,
+        public_key: String,
+        reg_time: u64,
+        /// The field this build has never heard of.
+        health_probe_path: String,
+    }
+
+    /// The write-path half of the mixed-version contract. Skipping an unknown
+    /// field on read is not enough: this build re-encodes the record from the
+    /// fields it declares, so without the merge a single re-registration by an
+    /// older node erases a newer node's field for the entire cluster.
+    #[test]
+    fn a_record_keeps_the_fields_its_writer_does_not_know() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let kv = KvStore::new(1, vec![], dir.path()).expect("failed to create kv store");
+
+        let written_by_a_newer_node = encode(&FutureInstanceData {
+            app_id: "app".to_string(),
+            ip: Ipv4Addr::new(10, 0, 0, 1),
+            public_key: "pubkey".to_string(),
+            reg_time: 1_700_000_000,
+            health_probe_path: "/healthz".to_string(),
+        })
+        .expect("encode should succeed");
+        kv.persistent
+            .write()
+            .put(keys::inst("app"), written_by_a_newer_node)
+            .expect("put should succeed");
+
+        // This build re-registers the instance, knowing nothing of the new field.
+        kv.sync_instance(
+            "app",
+            &InstanceData {
+                app_id: "app".to_string(),
+                ip: Ipv4Addr::new(10, 0, 0, 2),
+                public_key: "pubkey".to_string(),
+                reg_time: 1_700_000_100,
+                port_policy: None,
+                port_policy_hash: String::new(),
+                admin_port_policy: None,
+            },
+        )
+        .expect("sync should succeed");
+
+        let stored = kv
+            .persistent
+            .read()
+            .get(&keys::inst("app"))
+            .and_then(|entry| entry.value)
+            .expect("record should exist");
+        let seen_by_a_newer_node: FutureInstanceData =
+            decode(&stored).expect("the newer node must still read its own field");
+        assert_eq!(
+            seen_by_a_newer_node.health_probe_path, "/healthz",
+            "the unknown field must survive a write by a build that cannot see it"
+        );
+        assert_eq!(
+            seen_by_a_newer_node.ip,
+            Ipv4Addr::new(10, 0, 0, 2),
+            "the writer's own fields must still take effect"
+        );
+        let seen_by_this_build: InstanceData =
+            decode(&stored).expect("this build must still read the record");
+        assert_eq!(seen_by_this_build.reg_time, 1_700_000_100);
+    }
+
+    /// A certificate is a complete new fact on every write, so nothing may be
+    /// carried across one. Attributing a previous certificate's field to the one
+    /// just issued is worse than dropping the field: absent is a case the newer
+    /// reader already handles, stale is not.
+    #[test]
+    fn a_snapshot_does_not_inherit_the_previous_writes_fields() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let kv = KvStore::new(1, vec![], dir.path()).expect("failed to create kv store");
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct FutureCertData {
+            cert_pem: String,
+            key_pem: String,
+            not_after: u64,
+            issued_by: NodeId,
+            issued_at: u64,
+            chain_pem: String,
+        }
+
+        kv.persistent
+            .write()
+            .put(
+                keys::cert_data("a.example"),
+                encode(&FutureCertData {
+                    cert_pem: "old-cert".to_string(),
+                    key_pem: "old-key".to_string(),
+                    not_after: 1_700_000_000,
+                    issued_by: 2,
+                    issued_at: 1_600_000_000,
+                    chain_pem: "old-chain".to_string(),
+                })
+                .expect("encode should succeed"),
+            )
+            .expect("put should succeed");
+
+        kv.save_cert_data(
+            "a.example",
+            &CertData {
+                cert_pem: "new-cert".to_string(),
+                key_pem: "new-key".to_string(),
+                not_after: 1_800_000_000,
+                issued_by: 1,
+                issued_at: 1_700_000_100,
+            },
+        )
+        .expect("save should succeed");
+
+        let stored = kv
+            .persistent
+            .read()
+            .get(&keys::cert_data("a.example"))
+            .and_then(|entry| entry.value)
+            .expect("record should exist");
+        assert!(
+            decode::<FutureCertData>(&stored).is_err(),
+            "the previous certificate's chain must not be attached to the new one"
+        );
     }
 }
 

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -43,6 +43,7 @@ mod https_client;
 pub mod import;
 mod sync_service;
 
+pub use compat::UnknownFields;
 #[cfg(test)]
 pub(crate) use https_client::HttpsClient;
 pub use https_client::{AppIdValidator, HttpsClientConfig};
@@ -501,6 +502,7 @@ trait GetPutCodec {
         &mut self,
         key: String,
         value: &T,
+        unknown: compat::UnknownFields,
     ) -> Result<()>;
     fn iter_decoded<T: for<'de> serde::Deserialize<'de>>(
         &self,
@@ -550,21 +552,31 @@ impl GetPutCodec for NodeState {
             .with_context(|| format!("corrupt record at KV key {key}"))
     }
 
-    /// Write a value, keeping any field of the stored record that this binary
-    /// does not declare — see [`compat`] for why that is not the same as
-    /// keeping every field the encoding happens to be missing.
+    /// Write a value.
+    ///
+    /// `unknown` says what becomes of the fields the stored record holds and
+    /// this binary does not declare: [`compat::UnknownFields::Keep`] for a
+    /// write that updates a record, `Drop` for one that states a complete new
+    /// fact. See [`compat`] for why that is the caller's call, and why keeping
+    /// them is not the same as keeping every field the encoding happens to be
+    /// missing.
     fn put_encoded<T: serde::Serialize + serde::de::DeserializeOwned>(
         &mut self,
         key: String,
         value: &T,
+        unknown: compat::UnknownFields,
     ) -> Result<()> {
         let encoded = encode(value)?;
-        let stored = compat::is_long_lived_record(&key)
-            .then(|| self.get(&key).and_then(|entry| entry.value))
-            .flatten();
-        let bytes = match stored {
-            Some(stored) => compat::carry_unknown_fields::<T>(&key, &stored, encoded),
-            None => encoded,
+        let bytes = match (unknown, compat::declared_fields::<T>()) {
+            (compat::UnknownFields::Keep, Some(declared)) => {
+                match self.get(&key).and_then(|entry| entry.value) {
+                    Some(stored) => {
+                        compat::carry_unknown_fields::<T>(&key, declared, &stored, encoded)
+                    }
+                    None => encoded,
+                }
+            }
+            _ => encoded,
         };
         self.put(key.clone(), bytes)
             .with_context(|| format!("failed to put key {key}"))?;
@@ -755,7 +767,7 @@ impl KvStore {
     pub fn sync_instance(&self, instance_id: &str, data: &InstanceData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::inst(instance_id), data)
+            .put_encoded(keys::inst(instance_id), data, UnknownFields::Keep)
     }
 
     /// Sync instance deletion to other nodes
@@ -805,7 +817,7 @@ impl KvStore {
     pub fn sync_node(&self, node_id: NodeId, data: &NodeData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::node_info(node_id), data)
+            .put_encoded(keys::node_info(node_id), data, UnknownFields::Keep)
     }
 
     /// Load all nodes from sync store
@@ -853,9 +865,11 @@ impl KvStore {
 
     /// Set node status (stored separately from NodeData)
     pub fn set_node_status(&self, node_id: NodeId, status: NodeStatus) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::node_status(node_id), &status)?;
+        self.persistent.write().put_encoded(
+            keys::node_status(node_id),
+            &status,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -909,9 +923,11 @@ impl KvStore {
 
     /// Sync connection count for an instance (from this node)
     pub fn sync_connections(&self, instance_id: &str, count: u64) -> Result<()> {
-        self.ephemeral
-            .write()
-            .put_encoded(keys::conn(instance_id, self.my_node_id), &count)?;
+        self.ephemeral.write().put_encoded(
+            keys::conn(instance_id, self.my_node_id),
+            &count,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -919,9 +935,11 @@ impl KvStore {
 
     /// Sync handshake timestamp for an instance (as observed by this node)
     pub fn sync_instance_handshake(&self, instance_id: &str, timestamp: u64) -> Result<()> {
-        self.ephemeral
-            .write()
-            .put_encoded(keys::handshake(instance_id, self.my_node_id), &timestamp)?;
+        self.ephemeral.write().put_encoded(
+            keys::handshake(instance_id, self.my_node_id),
+            &timestamp,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -960,9 +978,11 @@ impl KvStore {
 
     /// Sync node last_seen (as observed by this node)
     pub fn sync_node_last_seen(&self, node_id: NodeId, timestamp: u64) -> Result<()> {
-        self.ephemeral
-            .write()
-            .put_encoded(keys::last_seen_node(node_id, self.my_node_id), &timestamp)?;
+        self.ephemeral.write().put_encoded(
+            keys::last_seen_node(node_id, self.my_node_id),
+            &timestamp,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -1081,9 +1101,11 @@ impl KvStore {
 
         // Store URL in persistent KvStore. Owned, because the value has to be a
         // type a reader can name: `&str` borrows from the buffer it decodes.
-        self.persistent
-            .write()
-            .put_encoded(keys::peer_addr(node_id), &url.to_string())?;
+        self.persistent.write().put_encoded(
+            keys::peer_addr(node_id),
+            &url.to_string(),
+            UnknownFields::Drop,
+        )?;
 
         let _ = self.add_peer(node_id);
         Ok(())
@@ -1103,7 +1125,11 @@ impl KvStore {
     pub fn update_peer_last_seen(&self, peer_id: NodeId) {
         let ts = now_secs();
         let key = keys::last_seen_node(peer_id, self.my_node_id);
-        if let Err(e) = self.ephemeral.write().put_encoded(key, &ts) {
+        if let Err(e) = self
+            .ephemeral
+            .write()
+            .put_encoded(key, &ts, UnknownFields::Drop)
+        {
             warn!("failed to update peer {peer_id} last_seen: {e}");
         }
     }
@@ -1137,7 +1163,7 @@ impl KvStore {
     pub fn save_dns_credential(&self, cred: &DnsCredential) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::dns_cred(&cred.id), cred)?;
+            .put_encoded(keys::dns_cred(&cred.id), cred, UnknownFields::Keep)?;
         Ok(())
     }
 
@@ -1165,9 +1191,11 @@ impl KvStore {
 
     /// Set the default DNS credential ID
     pub fn set_default_dns_credential_id(&self, cred_id: &str) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::DNS_CRED_DEFAULT.to_string(), &cred_id.to_string())?;
+        self.persistent.write().put_encoded(
+            keys::DNS_CRED_DEFAULT.to_string(),
+            &cred_id.to_string(),
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -1196,9 +1224,11 @@ impl KvStore {
 
     /// Set global certbot configuration
     pub fn set_certbot_config(&self, config: &GlobalCertbotConfig) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::GLOBAL_CERTBOT_CONFIG.to_string(), config)?;
+        self.persistent.write().put_encoded(
+            keys::GLOBAL_CERTBOT_CONFIG.to_string(),
+            config,
+            UnknownFields::Keep,
+        )?;
         Ok(())
     }
 
@@ -1226,9 +1256,11 @@ impl KvStore {
 
     /// Save ZT-Domain configuration
     pub fn save_zt_domain_config(&self, config: &ZtDomainConfig) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::zt_domain_config(&config.domain), config)?;
+        self.persistent.write().put_encoded(
+            keys::zt_domain_config(&config.domain),
+            config,
+            UnknownFields::Keep,
+        )?;
         Ok(())
     }
 
@@ -1322,7 +1354,7 @@ impl KvStore {
     pub fn save_cert_data(&self, domain: &str, data: &CertData) -> Result<()> {
         self.persistent
             .write()
-            .put_encoded(keys::cert_data(domain), data)?;
+            .put_encoded(keys::cert_data(domain), data, UnknownFields::Drop)?;
         Ok(())
     }
 
@@ -1367,9 +1399,11 @@ impl KvStore {
 
     /// Save global ACME credentials
     pub fn save_acme_credentials(&self, creds: &CertCredentials) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::GLOBAL_ACME_CREDENTIALS.to_string(), creds)?;
+        self.persistent.write().put_encoded(
+            keys::GLOBAL_ACME_CREDENTIALS.to_string(),
+            creds,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -1386,9 +1420,11 @@ impl KvStore {
 
     /// Save global ACME attestation
     pub fn save_acme_attestation(&self, attestation: &AcmeAttestation) -> Result<()> {
-        self.persistent
-            .write()
-            .put_encoded(keys::GLOBAL_ACME_ATTESTATION.to_string(), attestation)?;
+        self.persistent.write().put_encoded(
+            keys::GLOBAL_ACME_ATTESTATION.to_string(),
+            attestation,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -1418,7 +1454,7 @@ impl KvStore {
         };
         self.persistent
             .write()
-            .put_encoded(keys::cert_lock(domain), &lock)
+            .put_encoded(keys::cert_lock(domain), &lock, UnknownFields::Drop)
             .is_ok()
     }
 
@@ -1455,7 +1491,11 @@ impl KvStore {
         };
         self.persistent
             .write()
-            .put_encoded(keys::GLOBAL_ACME_ROTATION_LOCK.to_string(), &lock)
+            .put_encoded(
+                keys::GLOBAL_ACME_ROTATION_LOCK.to_string(),
+                &lock,
+                UnknownFields::Drop,
+            )
             .ok()?;
         Some(lock)
     }
@@ -1508,9 +1548,14 @@ impl KvStore {
         state.put_encoded(
             keys::cert_attestation_history(domain, attestation.generated_at),
             attestation,
+            UnknownFields::Drop,
         )?;
         // Update latest
-        state.put_encoded(keys::cert_attestation_latest(domain), attestation)?;
+        state.put_encoded(
+            keys::cert_attestation_latest(domain),
+            attestation,
+            UnknownFields::Drop,
+        )?;
         Ok(())
     }
 
@@ -1658,6 +1703,7 @@ mod acme_credentials_tests {
                     started_at: u64::MAX,
                     started_by: 2,
                 },
+                UnknownFields::Drop,
             )
             .expect("lock write should succeed");
 
@@ -1674,6 +1720,7 @@ mod acme_credentials_tests {
                     started_at: u64::MAX,
                     started_by: 2,
                 },
+                UnknownFields::Drop,
             )
             .expect("certificate lock write should succeed");
         assert!(
@@ -2174,11 +2221,15 @@ mod corruption_tests {
 
         kv.ephemeral
             .write()
-            .put_encoded(keys::handshake("cvm", 2), &(now.saturating_sub(30)))
+            .put_encoded(
+                keys::handshake("cvm", 2),
+                &(now.saturating_sub(30)),
+                UnknownFields::Drop,
+            )
             .unwrap();
         kv.ephemeral
             .write()
-            .put_encoded(keys::handshake("cvm", 3), &u64::MAX)
+            .put_encoded(keys::handshake("cvm", 3), &u64::MAX, UnknownFields::Drop)
             .unwrap();
         // A peer with a broken clock must not keep a dead CVM alive forever.
         let latest = kv
@@ -2189,7 +2240,7 @@ mod corruption_tests {
 
         kv.ephemeral
             .write()
-            .put_encoded(keys::last_seen_node(7, 3), &u64::MAX)
+            .put_encoded(keys::last_seen_node(7, 3), &u64::MAX, UnknownFields::Drop)
             .unwrap();
         assert_eq!(kv.get_node_latest_last_seen(7), None);
         assert!(kv.get_node_last_seen_by_all(7).is_empty());
@@ -2199,7 +2250,11 @@ mod corruption_tests {
         // instances look stale.
         kv.ephemeral
             .write()
-            .put_encoded(keys::handshake("cvm", 4), &(now + MAX_CLOCK_DRIFT_SECS / 2))
+            .put_encoded(
+                keys::handshake("cvm", 4),
+                &(now + MAX_CLOCK_DRIFT_SECS / 2),
+                UnknownFields::Drop,
+            )
             .unwrap();
         assert_eq!(kv.get_instance_handshakes("cvm").len(), 2);
     }
@@ -2295,6 +2350,7 @@ mod corruption_tests {
                     node: None,
                     priority: 100,
                 },
+                UnknownFields::Keep,
             )
             .expect("raw put should succeed");
 

--- a/dstack/gateway/src/kv/mod.rs
+++ b/dstack/gateway/src/kv/mod.rs
@@ -688,13 +688,28 @@ impl KvStore {
     /// operator, which for a single-node deployment holding the only copy of
     /// the ACME account and DNS credentials is the difference between a restart
     /// and a rebuild.
+    ///
+    /// `wal_sync_interval` is how long a write may sit in the page cache before
+    /// the log is forced to disk; `None` forces every write before it returns.
+    /// It applies only to the persistent store — the ephemeral one keeps no log
+    /// and never touches the disk.
     pub fn new(
         my_node_id: NodeId,
         peer_ids: Vec<NodeId>,
         data_dir: impl AsRef<Path>,
+        wal_sync_interval: Option<Duration>,
     ) -> Result<Self> {
         let data_dir = data_dir.as_ref();
-        let persistent = match Node::new_with_persistence(my_node_id, peer_ids.clone(), data_dir) {
+        let node_config = wavekv::NodeConfig {
+            wal_sync_interval,
+            ..Default::default()
+        };
+        let persistent = match Node::with_persistence_and_config(
+            my_node_id,
+            peer_ids.clone(),
+            data_dir,
+            node_config.clone(),
+        ) {
             Ok(node) => node,
             Err(err) if is_storage_failure(&err) => {
                 return Err(err).with_context(|| {
@@ -721,8 +736,13 @@ impl KvStore {
                     data_dir.display(),
                     quarantined.display(),
                 );
-                Node::new_with_persistence(my_node_id, peer_ids.clone(), data_dir)
-                    .context("failed to create persistent wavekv node on a fresh data dir")?
+                Node::with_persistence_and_config(
+                    my_node_id,
+                    peer_ids.clone(),
+                    data_dir,
+                    node_config,
+                )
+                .context("failed to create persistent wavekv node on a fresh data dir")?
             }
         };
 
@@ -1031,6 +1051,15 @@ impl KvStore {
 
     pub fn persist_if_dirty(&self) -> Result<bool> {
         self.persistent.persist_if_dirty()
+    }
+
+    /// Force the write-ahead log to disk if the configured window has elapsed.
+    ///
+    /// Returns whether an fsync happened. A no-op when no window is configured
+    /// — every write was already forced — or when nothing has been written
+    /// since the last one, so an idle gateway costs a lock acquisition.
+    pub fn sync_wal_if_due(&self) -> Result<bool> {
+        self.persistent.sync_wal_if_due()
     }
 
     // ==================== Peer Management ====================
@@ -1625,7 +1654,7 @@ mod acme_credentials_tests {
     use super::*;
 
     fn test_kv(data_dir: &std::path::Path) -> KvStore {
-        KvStore::new(1, vec![], data_dir).expect("failed to create kv store")
+        KvStore::new(1, vec![], data_dir, None).expect("failed to create kv store")
     }
 
     #[test]
@@ -1772,7 +1801,7 @@ mod value_encoding_tests {
     #[test]
     fn legacy_positional_records_are_still_readable() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let kv = KvStore::new(1, vec![], dir.path()).expect("failed to create kv store");
+        let kv = KvStore::new(1, vec![], dir.path(), None).expect("failed to create kv store");
 
         let legacy = rmp_serde::encode::to_vec(&CertRenewLock {
             started_at: 1_700_000_000,
@@ -1836,6 +1865,51 @@ mod value_encoding_tests {
         }
     }
 
+    /// The configured window has to reach the store, not just the config file.
+    ///
+    /// An fsync per write runs under the store lock, so it bounds how fast this
+    /// gateway accepts registrations; the window is what buys that back, and it
+    /// buys nothing if the interval stops at `SyncConfig`.
+    #[test]
+    fn a_configured_window_holds_writes_out_of_the_disk_until_it_elapses() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let window = Duration::from_millis(20);
+        let kv = KvStore::new(1, vec![], dir.path(), Some(window)).expect("kv store");
+
+        kv.set_node_status(1, NodeStatus::Up).expect("write");
+        assert_eq!(
+            kv.persistent().read().wal_sync_count(),
+            0,
+            "a write inside the window must not reach the disk"
+        );
+        assert!(
+            !kv.sync_wal_if_due().expect("sync check"),
+            "nothing is due before the window elapses"
+        );
+
+        std::thread::sleep(window * 3);
+        assert!(kv.sync_wal_if_due().expect("sync"), "the window elapsed");
+        assert_eq!(kv.persistent().read().wal_sync_count(), 1);
+    }
+
+    /// Without a window every write is on the disk before it returns, which is
+    /// what every release before this one did and what a single-node gateway
+    /// holding the only copy of its ACME account still wants.
+    #[test]
+    fn without_a_window_every_write_reaches_the_disk_before_it_returns() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let kv = KvStore::new(1, vec![], dir.path(), None).expect("kv store");
+
+        kv.set_node_status(1, NodeStatus::Up).expect("write");
+        kv.set_node_status(2, NodeStatus::Down).expect("write");
+
+        assert_eq!(kv.persistent().read().wal_sync_count(), 2);
+        assert!(
+            !kv.sync_wal_if_due().expect("sync check"),
+            "with no window there is never anything owing"
+        );
+    }
+
     /// An instance record as some later release will declare it.
     #[derive(Debug, Serialize, Deserialize)]
     struct FutureInstanceData {
@@ -1854,7 +1928,7 @@ mod value_encoding_tests {
     #[test]
     fn a_record_keeps_the_fields_its_writer_does_not_know() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let kv = KvStore::new(1, vec![], dir.path()).expect("failed to create kv store");
+        let kv = KvStore::new(1, vec![], dir.path(), None).expect("failed to create kv store");
 
         let written_by_a_newer_node = encode(&FutureInstanceData {
             app_id: "app".to_string(),
@@ -1913,7 +1987,7 @@ mod value_encoding_tests {
     #[test]
     fn a_snapshot_does_not_inherit_the_previous_writes_fields() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let kv = KvStore::new(1, vec![], dir.path()).expect("failed to create kv store");
+        let kv = KvStore::new(1, vec![], dir.path(), None).expect("failed to create kv store");
 
         #[derive(Debug, Serialize, Deserialize)]
         struct FutureCertData {
@@ -1973,7 +2047,7 @@ mod sync_wire_tests {
     use wavekv::sync::SyncEnvelope;
 
     fn store(dir: &std::path::Path, id: NodeId, peers: Vec<NodeId>) -> KvStore {
-        KvStore::new(id, peers, dir).expect("failed to create kv store")
+        KvStore::new(id, peers, dir, None).expect("failed to create kv store")
     }
 
     #[test]
@@ -2048,7 +2122,8 @@ mod wavekv_v1_migration_tests {
                 .expect("write trailing v1 WAL entry");
         }
 
-        let upgraded = KvStore::new(1, Vec::new(), dir.path()).expect("open v1 data after upgrade");
+        let upgraded =
+            KvStore::new(1, Vec::new(), dir.path(), None).expect("open v1 data after upgrade");
         assert_eq!(
             upgraded
                 .persistent()
@@ -2078,7 +2153,8 @@ mod wavekv_v1_migration_tests {
         upgraded.persist_if_dirty().expect("persist upgraded data");
         drop(upgraded);
 
-        let restarted = KvStore::new(1, Vec::new(), dir.path()).expect("restart upgraded store");
+        let restarted =
+            KvStore::new(1, Vec::new(), dir.path(), None).expect("restart upgraded store");
         for (key, expected) in [(key, value), (wal_key, wal_value), (new_key, new_value)] {
             assert_eq!(
                 restarted
@@ -2131,7 +2207,7 @@ mod corruption_tests {
     use super::*;
 
     fn test_kv(data_dir: &std::path::Path) -> KvStore {
-        KvStore::new(1, vec![], data_dir).expect("failed to create kv store")
+        KvStore::new(1, vec![], data_dir, None).expect("failed to create kv store")
     }
 
     fn put_raw(kv: &KvStore, key: &str, value: &[u8]) {
@@ -2245,7 +2321,7 @@ mod corruption_tests {
         let data_dir = dir.path().join("kv");
         std::fs::write(&data_dir, b"not a directory").expect("failed to create blocker");
 
-        let Err(err) = KvStore::new(1, vec![], &data_dir) else {
+        let Err(err) = KvStore::new(1, vec![], &data_dir, None) else {
             panic!("startup must fail when the storage is unusable");
         };
         assert!(
@@ -2285,7 +2361,8 @@ mod corruption_tests {
         // replicated, so it must not keep the gateway from booting.
         std::fs::write(data_dir.join("node_1.wal"), b"garbage").expect("failed to corrupt wal");
 
-        let kv = KvStore::new(1, vec![], &data_dir).expect("startup must survive a corrupt wal");
+        let kv =
+            KvStore::new(1, vec![], &data_dir, None).expect("startup must survive a corrupt wal");
         let loaded = kv.load_all_instances();
         assert!(loaded.decoded.is_empty());
         assert!(loaded.undecodable.is_empty());

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1019,7 +1019,16 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
         }
     });
 
-    // Start periodic persistence task
+    // Start periodic persistence task.
+    //
+    // Both this and the WAL sync below run on the blocking pool. Each ends in a
+    // synchronous fsync — a snapshot plus its directory entry here, the log
+    // there — which is tens of microseconds on an NVMe host and milliseconds on
+    // the virtio disk a CVM gets. On a runtime worker that would park every
+    // other future assigned to it for the duration, which is the one thing a
+    // proxy's event loop cannot afford. It does not make the store lock any
+    // shorter: a reader still waits on the writer. It stops one slow disk from
+    // being a slow gateway.
     let persist_interval = proxy.config.sync.persist_interval;
     if !persist_interval.is_zero() {
         let kv_store_for_persist = kv_store.clone();
@@ -1027,12 +1036,17 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
             let mut ticker = tokio::time::interval(persist_interval);
             loop {
                 ticker.tick().await;
-                match kv_store_for_persist.persist_if_dirty() {
-                    Ok(true) => info!("WaveKV: periodic persist completed"),
-                    Ok(false) => {} // No changes to persist
-                    Err(err) => {
+                let kv = kv_store_for_persist.clone();
+                match tokio::task::spawn_blocking(move || kv.persist_if_dirty()).await {
+                    Ok(Ok(true)) => info!("WaveKV: periodic persist completed"),
+                    Ok(Ok(false)) => {} // No changes to persist
+                    Ok(Err(err)) => {
                         crate::metrics::record_kv_persist_failure();
                         error!("WaveKV: periodic persist failed: {err:?}");
+                    }
+                    Err(err) => {
+                        crate::metrics::record_kv_persist_failure();
+                        error!("WaveKV: the persist task did not finish: {err}");
                     }
                 }
             }
@@ -1053,9 +1067,17 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
             let mut ticker = tokio::time::interval(wal_sync_interval);
             loop {
                 ticker.tick().await;
-                if let Err(err) = kv_store_for_wal.sync_wal_if_due() {
-                    crate::metrics::record_kv_wal_sync_failure();
-                    error!("WaveKV: forcing the write-ahead log failed: {err:?}");
+                let kv = kv_store_for_wal.clone();
+                match tokio::task::spawn_blocking(move || kv.sync_wal_if_due()).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(err)) => {
+                        crate::metrics::record_kv_wal_sync_failure();
+                        error!("WaveKV: forcing the write-ahead log failed: {err:?}");
+                    }
+                    Err(err) => {
+                        crate::metrics::record_kv_wal_sync_failure();
+                        error!("WaveKV: the write-ahead log sync did not finish: {err}");
+                    }
                 }
             }
         });

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -263,8 +263,13 @@ impl ProxyInner {
 
         // Initialize WaveKV store without peers (peers will be added dynamically from bootnode)
         let kv_store = Arc::new(
-            KvStore::new(config.sync.node_id, vec![], &config.sync.data_dir)
-                .context("failed to initialize WaveKV store")?,
+            KvStore::new(
+                config.sync.node_id,
+                vec![],
+                &config.sync.data_dir,
+                (!config.sync.wal_sync_interval.is_zero()).then_some(config.sync.wal_sync_interval),
+            )
+            .context("failed to initialize WaveKV store")?,
         );
         info!(
             "WaveKV store initialized: node_id={}, sync_enabled={}",
@@ -1033,6 +1038,27 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
             }
         });
         info!("WaveKV: periodic persistence enabled (interval: {persist_interval:?})");
+    }
+
+    // Force the write-ahead log on the window the operator configured. Nothing
+    // else forces it on a schedule — a snapshot does, but that is minutes apart
+    // — so without this the window would be a hope rather than a bound. Ticking
+    // at the window itself is enough to make it one: the store measures from
+    // its last fsync, so a write is forced at the first tick that finds the
+    // window elapsed, never more than one window after it landed.
+    let wal_sync_interval = proxy.config.sync.wal_sync_interval;
+    if !wal_sync_interval.is_zero() {
+        let kv_store_for_wal = kv_store.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(wal_sync_interval);
+            loop {
+                ticker.tick().await;
+                if let Err(err) = kv_store_for_wal.sync_wal_if_due() {
+                    error!("WaveKV: forcing the write-ahead log failed: {err:?}");
+                }
+            }
+        });
+        info!("WaveKV: deferred WAL sync enabled (window: {wal_sync_interval:?})");
     }
 
     // Start periodic connection sync task

--- a/dstack/gateway/src/main_service.rs
+++ b/dstack/gateway/src/main_service.rs
@@ -1054,6 +1054,7 @@ fn start_wavekv_watch_task(proxy: Proxy) -> Result<()> {
             loop {
                 ticker.tick().await;
                 if let Err(err) = kv_store_for_wal.sync_wal_if_due() {
+                    crate::metrics::record_kv_wal_sync_failure();
                     error!("WaveKV: forcing the write-ahead log failed: {err:?}");
                 }
             }

--- a/dstack/gateway/src/metrics.rs
+++ b/dstack/gateway/src/metrics.rs
@@ -55,6 +55,7 @@ static DECODE_FAILURES: [AtomicU64; METERED_PREFIXES.len() + 1] =
 static WG_RECONFIGURE_TOTAL: AtomicU64 = AtomicU64::new(0);
 static WG_RECONFIGURE_FAILURES: AtomicU64 = AtomicU64::new(0);
 static KV_PERSIST_FAILURES: AtomicU64 = AtomicU64::new(0);
+static KV_WAL_SYNC_FAILURES: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     /// Set while a scrape is sampling live state.
@@ -121,6 +122,10 @@ pub(crate) fn record_wg_reconfigure(ok: bool) {
 /// never managed to snapshot.
 pub(crate) fn record_kv_persist_failure() {
     KV_PERSIST_FAILURES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_kv_wal_sync_failure() {
+    KV_WAL_SYNC_FAILURES.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Index of the longest prefix in `prefixes` that `key` starts with.
@@ -349,6 +354,13 @@ pub(crate) fn render(snapshot: &Snapshot) -> String {
         "Periodic WaveKV snapshots that failed.",
         "",
         KV_PERSIST_FAILURES.load(Ordering::Relaxed),
+    );
+    counter(
+        &mut out,
+        "dstack_gateway_kv_wal_sync_failures_total",
+        "Attempts to force the WaveKV write-ahead log to disk that failed. While this is rising, writes accepted in the last wal_sync_interval are not durable.",
+        "",
+        KV_WAL_SYNC_FAILURES.load(Ordering::Relaxed),
     );
 
     gauge(


### PR DESCRIPTION
## Problem

KV values are msgpack maps keyed by field name, so a gateway running an older build
already *reads* a record written by a newer one without tripping over the fields it does
not know. `kv/mod.rs` documents exactly that, and it is only half of a rolling upgrade.

The other half is the write path. `encode` serializes the struct as the running binary
declares it, so the encoding contains those fields and nothing else. The moment an older
node rewrites a record, every field added by a later release is gone — for the whole
cluster, since the record then replicates as the newest write. The node that added the
field has no way to notice.

This is not a read-modify-write bug that a `update()` helper would fix, because the worst
path never reads the KV type at all. `inst/` records are hydrated into `InstanceInfo`
(`main_service.rs`), a hand-mirrored in-memory struct, and every write-back rebuilds
`InstanceData` field by field (`main_service.rs:1028`, `:1138`, `:1155`). An unknown field
is dropped at hydration; the next re-registration, admin call or lazily-filled port policy
persists that loss. `update_dns_credential` and `set_certbot_config` are true
read-modify-writes with the same outcome.

Concretely: node A on a newer build writes `inst/x` with a new `health_probe_path`; node B
on the current build re-registers the same instance; the field is gone everywhere, and A
keeps serving as though it had never been set.

## Fix

`kv/compat.rs` carries forward, at write time, the fields present in the stored record that
the running binary does not declare. `put_encoded` splices them onto the outgoing encoding
before the `put`.

Three decisions worth reviewing:

**Unknown is decided against the field list `T` declares, not against the keys missing from
the new encoding.** The list comes from the derived `Deserialize` impl, via a `Deserializer`
whose only job is to capture what `deserialize_struct` hands it. This matters because
`#[serde(skip_serializing_if)]` — `DnsProvider::Cloudflare::api_url` uses it — makes a field
this build deliberately *cleared* absent from the encoding for exactly the same reason a
field from the future is. Keying on the declaration keeps the clear and still carries the
unknown. Aliases and renames count as declared, so `#[serde(alias)]` is safe too. The probe
answers `None` for scalars, `#[serde(flatten)]` types and internally tagged enums, and the
merge then declines entirely — that last one on purpose, since an internally tagged enum's
variants have disjoint fields and merging across a variant change would graft one variant's
secrets onto another.

**Only long-lived records carry fields; snapshots do not.** `inst/`, `node/info/`,
`dns_cred/`, `cert/*/config` and `global/certbot_config` are records that a write updates.
A certificate, an attestation, a lock or a counter is a complete new fact on every write,
and carrying a field across one would attribute the previous snapshot's value to the new
one — an older gateway renewing a certificate would publish a stale chain next to the key
it just issued. Absent is a case the newer reader already has to handle; stale is not.

**Only the root map is merged.** Below it nothing distinguishes a struct encoded as a map
from a `BTreeMap` field, so recursing would resurrect map entries that were deliberately
removed. New fields therefore go at the root of a value type; a nested type that has to
grow needs its own `#[serde(flatten)]` catch-all. A field this build stops declaring is
carried forever, since it is indistinguishable from one a newer peer wrote — retiring a
field for real needs an explicit drop list, which is left for the release that first needs
it rather than landing empty here.

The merge is byte-level: the header is rewritten and the known fields keep the exact bytes
`rmp_serde` produced, so nothing is re-encoded and unknown values are copied verbatim,
whatever their type. It uses `rmp::Marker` — already in the tree under `rmp-serde`, not a
new supply-chain entry — rather than a hand-copied opcode table, and the walker is
iterative so a deeply nested value cannot exhaust the stack. Every failure declines the
merge and writes the original encoding, which is today's behavior.

## Verification

`cargo test -p dstack-gateway`: 184 passed. `cargo clippy -p dstack-gateway --all-targets
-- -D warnings`: clean.

End-to-end through a real `KvStore` (`value_encoding_tests`): a record written with an
extra `health_probe_path`, then re-registered by this build via `sync_instance`, still has
the field and still decodes as `InstanceData`; the same setup on `cert/{domain}/data`
confirms a snapshot does *not* inherit the previous write's `chain_pem`.

The byte walker is differential-tested against `rmpv` (dev-dependency only):

| Test | Cases | Result |
| --- | --- | --- |
| Random values, every header width (str/bin/ext/array/map, 4 levels deep) | 2,000 | Lands on the same byte as `rmpv` |
| Valid encodings with 1–3 bit flips and random truncation | 50,000 | Same accept/reject and same length |
| Arbitrary random bytes | 100,000 | No panic, never reads past the buffer |
| 200,000-deep nesting | 1 | Parsed, no stack growth |

The one divergence found across the fuzz corpus is the reserved marker `0xc1`, which `rmpv`
decodes as `Nil` and this walker rejects. `rmp_serde` also rejects it
(`Err(TypeMismatch(Reserved))`), so the walker matches the decoder that actually reads these
values; the test asserts the exception rather than hiding it.

## Rollout note

Like widening a key schema, this only helps once it is deployed: a field added in release
N+1 survives only if the nodes running release N already carry unknown fields. This lands
before any further field is added to a KV value type, not with it.


## Upgrade note

This changes a durability default. `sync.wal_sync_interval` ships at `"5s"`, so after an
upgrade a KV write is no longer forced to the disk before it returns; it is forced within the
window instead. Losing the process costs nothing either way — the bytes reach the kernel on
every write, so a panic, an OOM kill or a restart loses none of them, which
`test_wal_integrity` demonstrates by SIGKILLing a gateway two seconds after five
registrations and finding all of them in the log. Losing the *machine* costs up to the
window.

A cluster recovers that window from its peers: acks never become durable ahead of the data
they cover, so a restarted node cannot claim coverage of what it lost. A single-node gateway
has no such backstop, and holds the only copy of its ACME account and DNS credentials.
Operators running one should set `wal_sync_interval = "0s"`, which restores the previous
behaviour exactly.
