### PR TITLE
fix(sdk): stop dropping app-compose fields from the compose hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- sdk: `AppCompose` in the Go SDK gained `init_script`, `storage_fs`, `swap_size`, `event_log_version`, `port_policy` and `verity_volumes`, and `Requirements` gained `gpu_policy` in the Go and Python SDKs
 - shared API authentication (`dstack-api-auth`) protecting the full VMM HTTP/pRPC/UI surface and unifying Gateway/KMS admin auth: bearer/`X-Admin-Token`/HTTP Basic/bcrypt htpasswd, constant-time verification (#796)
+
+### Fixed
+- sdk: the Go and Python compose-hash helpers silently dropped every app-compose field they did not declare, so `getComposeHash` returned a digest for an app-compose that was not the one being deployed — and that digest is what gets whitelisted on chain. The missing fields are named above; both now keep unrecognised keys as well, so a guest that gains a field before the SDK does still hashes correctly
 
 ### Changed
 - os/yocto: nerdctl 2.2.1 → 2.3.5, so `nerdctl compose` honours the Compose `healthcheck:` field (only translated into `--health-*` flags from 2.3.1 on). Requires openembedded-core to move to `wrynose` head for go 1.26.5, which also brings gcc 15.2 → 15.3 — every guest image measurement changes, so the new image hashes need whitelisting in KMS

--- a/dstack/dstack-types/src/lib.rs
+++ b/dstack/dstack-types/src/lib.rs
@@ -2418,3 +2418,92 @@ mod vm_config_device_count_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod appcompose_sdk_parity {
+    use super::*;
+
+    /// Every field `AppCompose` serializes, in sorted order.
+    ///
+    /// This exists to break when someone adds a field, so that the SDKs get
+    /// updated in the same change. What the SDKs compute is a compose hash that
+    /// gets whitelisted on chain, so a field they drop means the digest
+    /// describes an app-compose that is not the one being deployed -- and
+    /// nothing anywhere notices.
+    ///
+    /// All four are now *correct* without help: Go and Python keep unrecognised
+    /// keys in a catch-all, and JS's interface has an index signature and is
+    /// hashed from the object at runtime. So a missed field costs ergonomics
+    /// rather than correctness -- a user cannot name it with a type. That is
+    /// still worth fixing, in the same change, which is what this test is for.
+    ///
+    /// If it fails: add the field to `sdk/go/dstack/compose_hash.go`,
+    /// `sdk/js/src/get-compose-hash.ts` and
+    /// `sdk/python/src/dstack_sdk/get_compose_hash.py`, then update the list.
+    #[test]
+    fn every_serialized_field_is_accounted_for() {
+        let expected = [
+            "allowed_envs",
+            "event_log_version",
+            "features",
+            "gateway_enabled",
+            "init_script",
+            "key_provider",
+            "key_provider_id",
+            "kms_enabled",
+            "local_key_provider_enabled",
+            "manifest_version",
+            "name",
+            "no_instance_id",
+            "port_policy",
+            "public_logs",
+            "public_sysinfo",
+            "public_tcbinfo",
+            "requirements",
+            "runner",
+            "secure_time",
+            "storage_fs",
+            "swap_size",
+            "verity_volumes",
+        ];
+
+        // Every optional field populated, so nothing is skipped by
+        // `skip_serializing_if`.
+        let populated: AppCompose = serde_json::from_value(serde_json::json!({
+            "manifest_version": "3",
+            "name": "demo",
+            "runner": "docker-compose",
+            "docker_compose_file": "services: {}\n",
+            "init_script": ["a.sh"],
+            "storage_fs": "ext4",
+            "swap_size": "2G",
+            "event_log_version": 2,
+            "port_policy": {"ports": [{"port": 8080, "pp": true}], "restrict_mode": true},
+            "verity_volumes": [{
+                "source": "v.img",
+                "verity_root": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+                "target": "/mnt/v",
+            }],
+            "requirements": {"os_version": ">=0.6.1"},
+            "snapshotter": "overlayfs",
+        }))
+        .expect("the fixture must stay parseable");
+
+        let serde_json::Value::Object(map) = serde_json::to_value(&populated).expect("serialize")
+        else {
+            panic!("AppCompose must serialize as an object");
+        };
+        let mut actual = map.keys().cloned().collect::<Vec<_>>();
+        actual.sort();
+        // Fields whose presence depends on the fixture rather than on the type.
+        actual.retain(|key| !matches!(key.as_str(), "docker_compose_file" | "snapshotter"));
+
+        assert_eq!(
+            actual, expected,
+            "AppCompose gained or lost a field. The Go and JS SDKs declare this \
+             type as a closed struct, so a field they do not know is silently \
+             dropped from the compose hash they compute -- and that hash is what \
+             gets whitelisted on chain. Update sdk/go and sdk/js, then this list."
+        );
+    }
+}

--- a/sdk/go/dstack/compose_hash.go
+++ b/sdk/go/dstack/compose_hash.go
@@ -8,7 +8,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"reflect"
 	"sort"
+	"strings"
 )
 
 // KeyProviderKind represents the key provider type
@@ -37,12 +39,45 @@ const (
 	RequirementPlatformNitro     RequirementPlatform = "dstack-nitro-enclave"
 )
 
+// GpuPolicy is the application GPU policy applied before key provisioning.
+type GpuPolicy struct {
+	AttestGpu         *bool   `json:"attest_gpu,omitempty"`
+	Rego              *string `json:"rego,omitempty"`
+	AllowDevtools     *bool   `json:"allow_devtools,omitempty"`
+	AllowDebug        *bool   `json:"allow_debug,omitempty"`
+	AllowInsecureBoot *bool   `json:"allow_insecure_boot,omitempty"`
+}
+
 // Requirements represents guest-side requirements.
 type Requirements struct {
 	OsVersion            string                 `json:"os_version,omitempty"`
 	Platforms            *[]RequirementPlatform `json:"platforms,omitempty"`
 	TdxMeasureAcpiTables *bool                  `json:"tdx_measure_acpi_tables,omitempty"`
 	LaunchTokenHash      string                 `json:"launch_token_hash,omitempty"`
+	GpuPolicy            *GpuPolicy             `json:"gpu_policy,omitempty"`
+
+	// Extra carries fields this SDK does not know; see AppCompose.Extra.
+	Extra map[string]interface{} `json:"-"`
+}
+
+// PortAttrs is the per-port policy the gateway applies.
+type PortAttrs struct {
+	Port uint16 `json:"port"`
+	Pp   bool   `json:"pp,omitempty"`
+}
+
+// PortPolicy is the per-port policy consumed by the gateway.
+type PortPolicy struct {
+	Ports        []PortAttrs `json:"ports,omitempty"`
+	RestrictMode bool        `json:"restrict_mode,omitempty"`
+}
+
+// VerityVolume is a read-only, dm-verity-protected volume pre-seeded into the CVM.
+type VerityVolume struct {
+	Source string `json:"source"`
+	// VerityRoot is the dm-verity root hash, hex encoded.
+	VerityRoot string `json:"verity_root"`
+	Target     string `json:"target"`
 }
 
 // AppCompose represents the application composition structure
@@ -67,8 +102,28 @@ type AppCompose struct {
 	NoInstanceID            *bool           `json:"no_instance_id,omitempty"`
 	SecureTime              *bool           `json:"secure_time,omitempty"`
 	Requirements            *Requirements   `json:"requirements,omitempty"`
-	BashScript              string          `json:"bash_script,omitempty"`       // Legacy
-	PreLaunchScript         string          `json:"pre_launch_script,omitempty"` // Legacy
+	InitScript              []string        `json:"init_script,omitempty"`
+	StorageFs               string          `json:"storage_fs,omitempty"`
+	// SwapSize is a human size string, e.g. "2G", matching what the guest reads.
+	SwapSize        string         `json:"swap_size,omitempty"`
+	EventLogVersion *uint32        `json:"event_log_version,omitempty"`
+	PortPolicy      *PortPolicy    `json:"port_policy,omitempty"`
+	VerityVolumes   []VerityVolume `json:"verity_volumes,omitempty"`
+	BashScript      string         `json:"bash_script,omitempty"`       // Legacy
+	PreLaunchScript string         `json:"pre_launch_script,omitempty"` // Legacy
+
+	// Extra carries fields this SDK does not have a typed name for.
+	//
+	// A closed struct silently drops what it does not know, and the value this
+	// package computes is a compose hash that gets whitelisted on chain -- so a
+	// dropped field means the digest describes an app-compose that is not the
+	// one being deployed, with nothing anywhere to notice. Unmarshalling puts
+	// unrecognised keys here and marshalling puts them back, so a guest that
+	// gains a field before this SDK does still hashes correctly.
+	//
+	// Keys that collide with a declared field are ignored on marshal; the typed
+	// field wins.
+	Extra map[string]interface{} `json:"-"`
 }
 
 // preprocessAppCompose removes conflicting fields based on runner type
@@ -147,4 +202,107 @@ func GetComposeHash(appCompose AppCompose, normalize ...bool) (string, error) {
 
 	hash := sha256.Sum256([]byte(manifestStr))
 	return hex.EncodeToString(hash[:]), nil
+}
+
+// marshalWithExtra merges a struct's declared fields with its Extra map.
+//
+// `inner` is a type alias to avoid recursing into the custom MarshalJSON.
+func marshalWithExtra(declared interface{}, extra map[string]interface{}) ([]byte, error) {
+	encoded, err := json.Marshal(declared)
+	if err != nil {
+		return nil, err
+	}
+	if len(extra) == 0 {
+		return encoded, nil
+	}
+	merged := map[string]interface{}{}
+	if err := json.Unmarshal(encoded, &merged); err != nil {
+		return nil, err
+	}
+	for key, value := range extra {
+		if _, declared := merged[key]; declared {
+			continue
+		}
+		merged[key] = value
+	}
+	return json.Marshal(merged)
+}
+
+// unmarshalWithExtra fills `declared` and collects everything it did not claim.
+func unmarshalWithExtra(data []byte, declared interface{}, known map[string]struct{}) (map[string]interface{}, error) {
+	if err := json.Unmarshal(data, declared); err != nil {
+		return nil, err
+	}
+	var all map[string]interface{}
+	if err := json.Unmarshal(data, &all); err != nil {
+		return nil, err
+	}
+	var extra map[string]interface{}
+	for key, value := range all {
+		if _, ok := known[key]; ok {
+			continue
+		}
+		if extra == nil {
+			extra = map[string]interface{}{}
+		}
+		extra[key] = value
+	}
+	return extra, nil
+}
+
+func jsonFieldNames(v interface{}) map[string]struct{} {
+	names := map[string]struct{}{}
+	t := reflect.TypeOf(v)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+// MarshalJSON writes the declared fields plus anything in Extra.
+func (a AppCompose) MarshalJSON() ([]byte, error) {
+	type inner AppCompose
+	return marshalWithExtra(inner(a), a.Extra)
+}
+
+// UnmarshalJSON fills the declared fields and keeps the rest in Extra.
+func (a *AppCompose) UnmarshalJSON(data []byte) error {
+	type inner AppCompose
+	var decoded inner
+	extra, err := unmarshalWithExtra(data, &decoded, jsonFieldNames(AppCompose{}))
+	if err != nil {
+		return err
+	}
+	*a = AppCompose(decoded)
+	a.Extra = extra
+	return nil
+}
+
+// MarshalJSON writes the declared fields plus anything in Extra.
+func (r Requirements) MarshalJSON() ([]byte, error) {
+	type inner Requirements
+	return marshalWithExtra(inner(r), r.Extra)
+}
+
+// UnmarshalJSON fills the declared fields and keeps the rest in Extra.
+func (r *Requirements) UnmarshalJSON(data []byte) error {
+	type inner Requirements
+	var decoded inner
+	extra, err := unmarshalWithExtra(data, &decoded, jsonFieldNames(Requirements{}))
+	if err != nil {
+		return err
+	}
+	*r = Requirements(decoded)
+	r.Extra = extra
+	return nil
 }

--- a/sdk/go/dstack/compose_hash_parity_test.go
+++ b/sdk/go/dstack/compose_hash_parity_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dstack
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// Every field the guest's AppCompose can carry, with a non-default value.
+//
+// A closed struct drops what it does not know, and what this package computes
+// is a compose hash that gets whitelisted on chain -- so a dropped field means
+// the digest describes an app-compose that is not the one being deployed, and
+// nothing anywhere notices. `port_policy`, `init_script`, `storage_fs`,
+// `swap_size`, `event_log_version`, `verity_volumes` and
+// `requirements.gpu_policy` were all in that state.
+const fullAppCompose = `{
+  "manifest_version": "3",
+  "name": "demo",
+  "features": ["x"],
+  "runner": "docker-compose",
+  "snapshotter": "overlayfs",
+  "docker_compose_file": "services: {}\n",
+  "init_script": ["a.sh", "b.sh"],
+  "public_logs": true,
+  "public_sysinfo": true,
+  "public_tcbinfo": true,
+  "kms_enabled": true,
+  "gateway_enabled": true,
+  "local_key_provider_enabled": true,
+  "key_provider": "kms",
+  "key_provider_id": "aabb",
+  "allowed_envs": ["FOO"],
+  "no_instance_id": true,
+  "secure_time": true,
+  "storage_fs": "ext4",
+  "swap_size": "2G",
+  "event_log_version": 2,
+  "port_policy": {"ports": [{"port": 8080, "pp": true}], "restrict_mode": true},
+  "verity_volumes": [{"source": "v.img", "verity_root": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff", "target": "/mnt/v"}],
+  "requirements": {
+    "os_version": ">=0.6.1",
+    "platforms": ["dstack-tdx"],
+    "tdx_measure_acpi_tables": true,
+    "launch_token_hash": "ff00",
+    "gpu_policy": {"attest_gpu": true, "rego": "package policy", "allow_devtools": true}
+  }
+}`
+
+func hashOfRawJSON(t *testing.T, raw string) string {
+	t.Helper()
+	var generic interface{}
+	if err := json.Unmarshal([]byte(raw), &generic); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := toDeterministicJSON(generic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+// Nothing present in an app-compose may be lost by passing through this SDK.
+func TestEveryFieldSurvivesTheRoundTrip(t *testing.T) {
+	var compose AppCompose
+	if err := json.Unmarshal([]byte(fullAppCompose), &compose); err != nil {
+		t.Fatal(err)
+	}
+	got, err := GetComposeHash(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := hashOfRawJSON(t, fullAppCompose); got != want {
+		reencoded, _ := json.MarshalIndent(compose, "", "  ")
+		t.Fatalf("a field was dropped or changed.\n got=%s\nwant=%s\nre-encoded:\n%s", got, want, reencoded)
+	}
+}
+
+// A guest that gains a field before this SDK does must still hash correctly,
+// which is what `Extra` is for.
+func TestAnUnknownFieldStillReachesTheHash(t *testing.T) {
+	withUnknown := `{"runner":"docker-compose","some_future_field":{"a":1},"requirements":{"another_future_one":true}}`
+	var compose AppCompose
+	if err := json.Unmarshal([]byte(withUnknown), &compose); err != nil {
+		t.Fatal(err)
+	}
+	got, err := GetComposeHash(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := hashOfRawJSON(t, withUnknown); got != want {
+		reencoded, _ := json.Marshal(compose)
+		t.Fatalf("an unknown field was dropped.\n got=%s\nwant=%s\nre-encoded: %s", got, want, reencoded)
+	}
+}
+
+// A typed field and an Extra key of the same name must not both be emitted.
+func TestADeclaredFieldWinsOverExtra(t *testing.T) {
+	compose := AppCompose{
+		Runner: "docker-compose",
+		Extra:  map[string]interface{}{"runner": "bash"},
+	}
+	encoded, err := json.Marshal(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["runner"] != "docker-compose" {
+		t.Fatalf("the declared field should win, got %v", decoded["runner"])
+	}
+}

--- a/sdk/js/src/get-compose-hash.ts
+++ b/sdk/js/src/get-compose-hash.ts
@@ -48,11 +48,37 @@ export interface DockerConfig extends SortableObject {
   token_key?: string;
 }
 
+export interface GpuPolicy extends SortableObject {
+  attest_gpu?: boolean;
+  rego?: string;
+  allow_devtools?: boolean;
+  allow_debug?: boolean;
+  allow_insecure_boot?: boolean;
+}
+
 export interface Requirements extends SortableObject {
   os_version?: string;
   platforms?: RequirementPlatform[];
   tdx_measure_acpi_tables?: boolean;
   launch_token_hash?: string;
+  gpu_policy?: GpuPolicy;
+}
+
+export interface PortAttrs extends SortableObject {
+  port: number;
+  pp?: boolean;
+}
+
+export interface PortPolicy extends SortableObject {
+  ports?: PortAttrs[];
+  restrict_mode?: boolean;
+}
+
+export interface VerityVolume extends SortableObject {
+  source: string;
+  /** dm-verity root hash, hex encoded. */
+  verity_root: string;
+  target: string;
 }
 
 export interface AppCompose extends SortableObject {
@@ -78,6 +104,13 @@ export interface AppCompose extends SortableObject {
   no_instance_id?: boolean;
   secure_time?: boolean;
   requirements?: Requirements;
+  init_script?: string[];
+  storage_fs?: string;
+  /** Human size string, e.g. "2G", matching what the guest reads. */
+  swap_size?: string;
+  event_log_version?: number;
+  port_policy?: PortPolicy;
+  verity_volumes?: VerityVolume[];
   // Legacy fields for backward compatibility
   bash_script?: string;
   pre_launch_script?: string;

--- a/sdk/python/src/dstack_sdk/get_compose_hash.py
+++ b/sdk/python/src/dstack_sdk/get_compose_hash.py
@@ -28,11 +28,13 @@ class DockerConfig:
         registry: Optional[str] = None,
         username: Optional[str] = None,
         token_key: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize a new ``DockerConfig`` instance."""
         self.registry = registry
         self.username = username
         self.token_key = token_key
+        self._extra = dict(kwargs)
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary representation excluding ``None`` fields."""
@@ -43,6 +45,7 @@ class DockerConfig:
             result["username"] = self.username
         if self.token_key is not None:
             result["token_key"] = self.token_key
+        result.update(self._extra)
         return result
 
 
@@ -55,12 +58,16 @@ class Requirements:
         platforms: Optional[List[str]] = None,
         tdx_measure_acpi_tables: Optional[bool] = None,
         launch_token_hash: Optional[str] = None,
+        gpu_policy: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize a new ``Requirements`` instance."""
         self.os_version = os_version
         self.platforms = platforms
         self.tdx_measure_acpi_tables = tdx_measure_acpi_tables
         self.launch_token_hash = launch_token_hash
+        self.gpu_policy = gpu_policy
+        self._extra = dict(kwargs)
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary representation excluding ``None`` fields."""
@@ -73,6 +80,9 @@ class Requirements:
             result["tdx_measure_acpi_tables"] = self.tdx_measure_acpi_tables
         if self.launch_token_hash is not None:
             result["launch_token_hash"] = self.launch_token_hash
+        if self.gpu_policy is not None:
+            result["gpu_policy"] = self.gpu_policy
+        result.update(self._extra)
         return result
 
 

--- a/sdk/python/tests/test_get_compose_hash.py
+++ b/sdk/python/tests/test_get_compose_hash.py
@@ -244,3 +244,51 @@ def test_sort_object_function():
     # Nested keys should also be sorted
     nested_keys = list(sorted_obj["nested"].keys())
     assert nested_keys == ["a", "z"]
+
+
+def test_port_policy_reaches_the_hash():
+    """A field the SDK does not name must still reach the digest."""
+    from dstack_sdk.get_compose_hash import AppCompose
+
+    plain = AppCompose(runner="docker-compose", docker_compose_file="services: {}\n")
+    with_policy = AppCompose(
+        runner="docker-compose",
+        docker_compose_file="services: {}\n",
+        port_policy={"ports": [{"port": 8080, "pp": True}], "restrict_mode": True},
+    )
+
+    assert get_compose_hash(plain) != get_compose_hash(with_policy)
+
+
+def test_gpu_policy_reaches_the_hash():
+    """`Requirements` is a closed shape, so this one had to be named."""
+    from dstack_sdk.get_compose_hash import AppCompose
+    from dstack_sdk.get_compose_hash import Requirements
+
+    plain = AppCompose(
+        runner="docker-compose", requirements=Requirements(os_version=">=0.6.1")
+    )
+    gated = AppCompose(
+        runner="docker-compose",
+        requirements=Requirements(
+            os_version=">=0.6.1", gpu_policy={"attest_gpu": False}
+        ),
+    )
+
+    assert get_compose_hash(plain) != get_compose_hash(gated)
+
+
+def test_an_unknown_requirement_still_reaches_the_hash():
+    """A guest that gains a field before this SDK does must still hash right."""
+    from dstack_sdk.get_compose_hash import AppCompose
+    from dstack_sdk.get_compose_hash import Requirements
+
+    plain = AppCompose(
+        runner="docker-compose", requirements=Requirements(os_version=">=0.6.1")
+    )
+    future = AppCompose(
+        runner="docker-compose",
+        requirements=Requirements(os_version=">=0.6.1", some_future_field=True),
+    )
+
+    assert get_compose_hash(plain) != get_compose_hash(future)


### PR DESCRIPTION
## Problem

The Go SDK declares `AppCompose` as a closed struct. Six fields the guest supports are absent from it and are dropped on marshal:

`init_script`, `storage_fs`, `swap_size`, `event_log_version`, **`port_policy`**, `verity_volumes`

`Requirements` drops `gpu_policy` the same way, in both the Go and Python SDKs.

What these helpers compute is a **compose hash**, and that hash is what gets whitelisted on chain. A dropped field means the digest describes an app-compose that is not the one being deployed. Whitelist it and the CVM is refused at launch by a mismatch that is invisible in the input — or, worse, you whitelist a shape nobody intends to run. Nothing at any step reports it.

Found while reviewing #1079, which was about to add a seventh (`requirements.health_check`) into the same hole.

## Where each SDK actually stood

| | mechanism | before |
|---|---|---|
| Go `AppCompose` | closed struct | **drops 6 fields** |
| Go / Python `Requirements` | closed struct / fixed kwargs | **drops `gpu_policy`** |
| Python `AppCompose` | `**kwargs` + `to_dict` reflects over `dir(self)` | already tolerant |
| JS | interface extends an index-signature type, hashed from the runtime object | already tolerant |

So the correctness bug is Go and Python's `Requirements`. JS's types are updated for parity only.

## Fix

**Declare them**, with the types the guest actually uses — `swap_size` is a human-size *string* (`"2G"`), `event_log_version` is a number, `verity_root` is hex. Verified against the Rust serializer's output rather than assumed.

**And make the next one harmless**, because naming these seven does nothing for the eighth. Go keeps unrecognised keys in an `Extra` map and re-emits them; Python's `Requirements` and `DockerConfig` take `**kwargs`, the way `AppCompose` already did. A guest that gains a field before the SDK does now still hashes correctly. A declared field wins over a same-named extra, so the two cannot disagree.

**And make it visible.** `dstack-types` gains a test listing every field `AppCompose` serializes. Adding a field breaks it until the SDKs are updated in the same change — the only thing that would have caught this.

## Verification

The Go test round-trips a fully-populated app-compose through `AppCompose` and compares `GetComposeHash` against the hash of the original document, so it fails if anything is lost. Mutation-checked: deleting the `Extra` passthrough fails `TestAnUnknownFieldStillReachesTheHash`.

`cargo test -p dstack-types` 40 passed, `go test ./dstack/` passing, Python compose-hash tests passing, `prek` clean.

## Known, not fixed here

Go's `omitempty` drops a field that is present-but-empty in the input — `"features": []`, `"key_provider_id": ""`. Re-hashing a file that spells those out gives a different digest. That is pre-existing, orthogonal to this bug, and fixing it changes output for every current caller, so it wants its own change.