### PR TITLE
fix: bound guest agent vsock RPCs

### DIFF
--- a/.agent/CODING_TASTE.md
+++ b/.agent/CODING_TASTE.md
@@ -257,6 +257,11 @@ not just the symptom:
 
 ## Readability and idioms
 
+- **Import for readability, not minimum path length.** Import specific types and
+  frequently repeated operations when their short names remain unambiguous
+  (`TcpListener::bind`, `timeout`, `Command::new`). Keep qualifiers that carry useful
+  semantic context (`serde_json::from_slice`, `tokio::spawn`, `anyhow::bail!`). Follow
+  the surrounding module when either form is equally clear.
 - **Errors**: `anyhow` everywhere in services — `thiserror` only in library crates whose
   callers match on error variants. `bail!` inside an `if` is the guard idiom; **`ensure!`
   is never used in this codebase** (0 occurrences) and reads as foreign. `let ... else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - os/yocto: nerdctl 2.2.1 → 2.3.5, so `nerdctl compose` honours the Compose `healthcheck:` field (only translated into `--health-*` flags from 2.3.1 on). Requires openembedded-core to move to `wrynose` head for go 1.26.5, which also brings gcc 15.2 → 15.3 — every guest image measurement changes, so the new image hashes need whitelisting in KMS
 
+### Fixed
+- bound VMM-to-guest RPCs and guest-agent dependency calls to prevent stalled peers from retaining request resources indefinitely
+
 ## [0.5.5] - 2025-10-20
 
 ### Added

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "hyperlocal",
  "log",
  "pin-project-lite",
+ "prost 0.13.5",
  "prpc",
  "reqwest",
  "serde",

--- a/dstack/guest-agent/Cargo.toml
+++ b/dstack/guest-agent/Cargo.toml
@@ -19,7 +19,7 @@ fs-err.workspace = true
 rcgen.workspace = true
 sha2.workspace = true
 clap.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["process"] }
 hex.workspace = true
 serde_json.workspace = true
 bollard.workspace = true

--- a/dstack/guest-agent/src/guest_api_service.rs
+++ b/dstack/guest-agent/src/guest_api_service.rs
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
+use std::{collections::HashSet, fmt::Debug, path::PathBuf, process::ExitStatus, time::Duration};
 
 use anyhow::{Context, Result};
 use bollard::{container::ListContainersOptions, Docker};
-use cmd_lib::{run_cmd as cmd, run_fun};
 use dstack_guest_agent_rpc::worker_server::WorkerRpc as _;
 use dstack_types::shared_filenames::{HOST_SHARED_DIR, SYS_CONFIG};
 use dstack_types::SysConfig;
@@ -18,9 +17,16 @@ use guest_api::{
 };
 use host_api::Notification;
 use ra_rpc::{CallContext, RpcCall};
+use tokio::{process::Command, task::spawn_blocking, time::timeout};
 use tracing::error;
 
 use crate::{rpc_service::ExternalRpcHandler, AppState};
+
+const GUEST_API_HANDLER_TIMEOUT: Duration = Duration::from_secs(20);
+const DOCKER_API_TIMEOUT: Duration = Duration::from_secs(15);
+const SHUTDOWN_NOTIFY_TIMEOUT: Duration = Duration::from_secs(5);
+const POWEROFF_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const WG_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct GuestApiHandler {
     state: AppState,
@@ -39,7 +45,9 @@ impl RpcCall<AppState> for GuestApiHandler {
 impl GuestApiRpc for GuestApiHandler {
     async fn info(self) -> Result<GuestInfo> {
         let ext_rpc = ExternalRpcHandler::new(self.state);
-        let info = ext_rpc.info().await?;
+        let info = timeout(GUEST_API_HANDLER_TIMEOUT, ext_rpc.info())
+            .await
+            .context("Guest Info request timed out")??;
         Ok(GuestInfo {
             version: env!("CARGO_PKG_VERSION").to_string(),
             app_id: info.app_id,
@@ -52,79 +60,118 @@ impl GuestApiRpc for GuestApiHandler {
 
     async fn shutdown(self) -> Result<()> {
         tokio::spawn(async move {
-            notify_host("shutdown.progress", "powering off").await.ok();
-            perr(cmd!(systemctl poweroff));
+            let _ = timeout(
+                SHUTDOWN_NOTIFY_TIMEOUT,
+                notify_host("shutdown.progress", "powering off"),
+            )
+            .await;
+            let mut command = Command::new("systemctl");
+            command.arg("poweroff").kill_on_drop(true);
+            perr(
+                timeout(POWEROFF_COMMAND_TIMEOUT, command.status())
+                    .await
+                    .context("systemctl poweroff timed out")
+                    .and_then(|result| result.context("failed to run systemctl poweroff"))
+                    .and_then(|status| ensure_command_success("systemctl poweroff", status)),
+            );
         });
         Ok(())
     }
 
     async fn network_info(self) -> Result<NetworkInformation> {
-        Ok(NetworkInformation {
-            dns_servers: get_dns_servers(),
-            gateways: get_gateways(),
-            interfaces: get_interfaces(),
-            wg_info: get_wg_info().unwrap_or_else(|e| e.to_string()),
-        })
+        let mut info = timeout(
+            GUEST_API_HANDLER_TIMEOUT,
+            spawn_blocking(collect_network_info),
+        )
+        .await
+        .context("NetworkInfo request timed out")?
+        .context("NetworkInfo worker failed")??;
+        info.wg_info = get_wg_info().await.unwrap_or_else(|e| e.to_string());
+        Ok(info)
     }
 
     async fn sys_info(self) -> Result<SystemInfo> {
-        use sysinfo::System;
-
-        let system = System::new_all();
-        let cpus = system.cpus();
-
-        let disks = sysinfo::Disks::new_with_refreshed_list();
-        let config = self.state.config();
-        let mut disks = disks
-            .list()
-            .iter()
-            .filter(|d| config.data_disks.contains(d.mount_point()))
-            .map(|d| DiskInfo {
-                name: d.name().to_string_lossy().to_string(),
-                mount_point: d.mount_point().to_string_lossy().to_string(),
-                total_size: d.total_space(),
-                free_size: d.available_space(),
-            })
-            .collect::<Vec<_>>();
-        disks.sort_by(|d1, d2| d1.mount_point.cmp(&d2.mount_point));
-        let avg = System::load_average();
-        Ok(SystemInfo {
-            os_name: System::name().unwrap_or_default(),
-            os_version: System::os_version().unwrap_or_default(),
-            kernel_version: System::kernel_version().unwrap_or_default(),
-            cpu_model: cpus.first().map_or("".into(), |cpu| {
-                format!("{} @{} MHz", cpu.name(), cpu.frequency())
-            }),
-            num_cpus: cpus.len() as _,
-            total_memory: system.total_memory(),
-            available_memory: system.available_memory(),
-            used_memory: system.used_memory(),
-            free_memory: system.free_memory(),
-            total_swap: system.total_swap(),
-            used_swap: system.used_swap(),
-            free_swap: system.free_swap(),
-            uptime: System::uptime(),
-            loadavg_one: (avg.one * 100.0) as u32,
-            loadavg_five: (avg.five * 100.0) as u32,
-            loadavg_fifteen: (avg.fifteen * 100.0) as u32,
-            disks,
-        })
+        let data_disks = self.state.config().data_disks.clone();
+        timeout(
+            GUEST_API_HANDLER_TIMEOUT,
+            spawn_blocking(move || collect_sys_info(&data_disks)),
+        )
+        .await
+        .context("SysInfo request timed out")?
+        .context("SysInfo worker failed")
     }
 
     async fn list_containers(self) -> Result<ListContainersResponse> {
-        list_containers().await
+        timeout(GUEST_API_HANDLER_TIMEOUT, list_containers())
+            .await
+            .context("ListContainers request timed out")?
+    }
+}
+
+fn collect_network_info() -> Result<NetworkInformation> {
+    Ok(NetworkInformation {
+        dns_servers: get_dns_servers(),
+        gateways: get_gateways(),
+        interfaces: get_interfaces(),
+        wg_info: String::new(),
+    })
+}
+
+fn collect_sys_info(data_disks: &HashSet<PathBuf>) -> SystemInfo {
+    use sysinfo::{Disks, System};
+
+    let system = System::new_all();
+    let cpus = system.cpus();
+
+    let disks = Disks::new_with_refreshed_list();
+    let mut disks = disks
+        .list()
+        .iter()
+        .filter(|d| data_disks.contains(d.mount_point()))
+        .map(|d| DiskInfo {
+            name: d.name().to_string_lossy().to_string(),
+            mount_point: d.mount_point().to_string_lossy().to_string(),
+            total_size: d.total_space(),
+            free_size: d.available_space(),
+        })
+        .collect::<Vec<_>>();
+    disks.sort_by(|d1, d2| d1.mount_point.cmp(&d2.mount_point));
+    let avg = System::load_average();
+    SystemInfo {
+        os_name: System::name().unwrap_or_default(),
+        os_version: System::os_version().unwrap_or_default(),
+        kernel_version: System::kernel_version().unwrap_or_default(),
+        cpu_model: cpus.first().map_or("".into(), |cpu| {
+            format!("{} @{} MHz", cpu.name(), cpu.frequency())
+        }),
+        num_cpus: cpus.len() as _,
+        total_memory: system.total_memory(),
+        available_memory: system.available_memory(),
+        used_memory: system.used_memory(),
+        free_memory: system.free_memory(),
+        total_swap: system.total_swap(),
+        used_swap: system.used_swap(),
+        free_swap: system.free_swap(),
+        uptime: System::uptime(),
+        loadavg_one: (avg.one * 100.0) as u32,
+        loadavg_five: (avg.five * 100.0) as u32,
+        loadavg_fifteen: (avg.fifteen * 100.0) as u32,
+        disks,
     }
 }
 
 pub(crate) async fn list_containers() -> Result<ListContainersResponse> {
     let docker = Docker::connect_with_defaults().context("Failed to connect to Docker")?;
-    let containers = docker
-        .list_containers::<&str>(Some(ListContainersOptions {
+    let containers = timeout(
+        DOCKER_API_TIMEOUT,
+        docker.list_containers::<&str>(Some(ListContainersOptions {
             all: true,
             ..Default::default()
-        }))
-        .await
-        .context("Failed to list containers")?;
+        })),
+    )
+    .await
+    .context("Docker list-containers request timed out")?
+    .context("Failed to list containers")?;
     Ok(ListContainersResponse {
         containers: containers
             .into_iter()
@@ -200,9 +247,22 @@ fn get_dns_servers() -> Vec<String> {
     dns_servers
 }
 
-fn get_wg_info() -> Result<String> {
-    let output = run_fun!(wg)?;
-    Ok(output)
+async fn get_wg_info() -> Result<String> {
+    let mut command = Command::new("wg");
+    command.kill_on_drop(true);
+    let output = timeout(WG_COMMAND_TIMEOUT, command.output())
+        .await
+        .context("wg command timed out")?
+        .context("failed to run wg")?;
+    ensure_command_success("wg", output.status)?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn ensure_command_success(command: &str, status: ExitStatus) -> Result<()> {
+    if !status.success() {
+        anyhow::bail!("{command} exited with {status}");
+    }
+    Ok(())
 }
 
 pub async fn notify_host(event: &str, payload: &str) -> Result<()> {
@@ -224,5 +284,25 @@ pub async fn notify_host(event: &str, payload: &str) -> Result<()> {
 fn perr<T, E: Debug>(result: Result<T, E>) {
     if let Err(e) = &result {
         error!("{e:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_command_success;
+    use std::{os::unix::process::ExitStatusExt, process::ExitStatus};
+
+    #[test]
+    fn command_status_accepts_zero_exit_code() {
+        assert!(ensure_command_success("test", ExitStatus::from_raw(0)).is_ok());
+    }
+
+    #[test]
+    fn command_status_rejects_nonzero_exit_code() {
+        let error = ensure_command_success("test", ExitStatus::from_raw(7 << 8))
+            .expect_err("nonzero exit status must fail");
+        assert!(error
+            .to_string()
+            .contains("test exited with exit status: 7"));
     }
 }

--- a/dstack/guest-api/src/client.rs
+++ b/dstack/guest-api/src/client.rs
@@ -4,9 +4,14 @@
 
 use crate::guest_api_client::GuestApiClient;
 use http_client::prpc::PrpcClient;
+use std::time::Duration;
 
 pub type DefaultClient = GuestApiClient<PrpcClient>;
 
 pub fn new_client(base_url: String) -> DefaultClient {
     DefaultClient::new(PrpcClient::new(base_url))
+}
+
+pub fn new_client_with_timeout(base_url: String, timeout: Duration) -> DefaultClient {
+    DefaultClient::new(PrpcClient::new(base_url).with_request_timeout(timeout))
 }

--- a/dstack/http-client/Cargo.toml
+++ b/dstack/http-client/Cargo.toml
@@ -25,6 +25,7 @@ tokio-vsock.workspace = true
 tower-service = "0.3.3"
 
 [dev-dependencies]
+prost.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [features]

--- a/dstack/http-client/src/prpc.rs
+++ b/dstack/http-client/src/prpc.rs
@@ -8,11 +8,13 @@ use prpc::{
     serde_json, Message,
 };
 use serde::{de::DeserializeOwned, Serialize};
+use std::time::Duration;
 
 pub struct PrpcClient {
     base_url: String,
     path_append: String,
     auth_token: Option<String>,
+    request_timeout: Option<Duration>,
 }
 
 impl PrpcClient {
@@ -21,6 +23,7 @@ impl PrpcClient {
             base_url,
             path_append: String::new(),
             auth_token: None,
+            request_timeout: None,
         }
     }
 
@@ -32,6 +35,7 @@ impl PrpcClient {
             base_url: format!("unix:{socket_path}"),
             path_append: path,
             auth_token: None,
+            request_timeout: None,
         }
     }
 
@@ -41,6 +45,13 @@ impl PrpcClient {
         self.auth_token = (!token.is_empty()).then_some(token);
         self
     }
+
+    /// Bound the complete request, including connection establishment, request
+    /// upload, response headers, and response body.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
+        self
+    }
 }
 
 fn normalize_json_response_body(body: &[u8]) -> &[u8] {
@@ -48,26 +59,6 @@ fn normalize_json_response_body(body: &[u8]) -> &[u8] {
         b"null"
     } else {
         body
-    }
-}
-
-#[cfg(test)]
-mod response_tests {
-    use super::{normalize_json_response_body, serde_json};
-
-    #[test]
-    fn empty_json_response_decodes_as_unit() {
-        let value: () = serde_json::from_slice(normalize_json_response_body(b""))
-            .expect("empty response should decode as unit");
-        assert_eq!(value, ());
-    }
-
-    #[test]
-    fn non_empty_json_response_is_unchanged() {
-        assert_eq!(
-            normalize_json_response_body(br#"{"value":1}"#),
-            br#"{"value":1}"#
-        );
     }
 }
 
@@ -85,14 +76,65 @@ impl RequestClient for PrpcClient {
             auth_header = format!("Bearer {token}");
             headers.push(("Authorization", auth_header.as_str()));
         }
-        let (status, body) =
-            super::http_request_with_headers("POST", &self.base_url, &path, &body, &headers)
-                .await?;
+        let request =
+            super::http_request_with_headers("POST", &self.base_url, &path, &body, &headers);
+        let (status, body) = match self.request_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, request)
+                .await
+                .context("pRPC request timed out")??,
+            None => request.await?,
+        };
         if status != 200 {
             anyhow::bail!("Invalid status code: {status}, path={path}");
         }
         let response = serde_json::from_slice(normalize_json_response_body(&body))
             .context("Failed to deserialize response")?;
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod response_tests {
+    use super::{normalize_json_response_body, serde_json, PrpcClient};
+    use prpc::client::RequestClient;
+    use std::{future::pending, time::Duration};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, PartialEq, prpc::Message, serde::Serialize, serde::Deserialize)]
+    struct Empty {}
+
+    #[test]
+    fn empty_json_response_decodes_as_unit() {
+        let value: () = serde_json::from_slice(normalize_json_response_body(b""))
+            .expect("empty response should decode as unit");
+        assert_eq!(value, ());
+    }
+
+    #[test]
+    fn non_empty_json_response_is_unchanged() {
+        assert_eq!(
+            normalize_json_response_body(br#"{"value":1}"#),
+            br#"{"value":1}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn request_timeout_covers_waiting_for_the_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            pending::<()>().await;
+        });
+        let client = PrpcClient::new(format!("http://{addr}"))
+            .with_request_timeout(Duration::from_millis(50));
+
+        let error = client
+            .request::<Empty, Empty>("Test.Hang", Empty {})
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("pRPC request timed out"));
+        server.abort();
     }
 }

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -34,7 +34,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use supervisor_client::SupervisorClient;
 use tracing::{debug, error, info, warn};
 
@@ -299,6 +299,8 @@ pub struct App {
     /// Pull status for registry images: tag → status.
     pub(crate) pull_status: Arc<Mutex<std::collections::HashMap<String, PullStatus>>>,
 }
+
+const GUEST_AGENT_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl App {
     pub(crate) fn lock(&self) -> MutexGuard<'_, AppState> {
@@ -1326,9 +1328,10 @@ impl App {
 
     pub(crate) fn guest_agent_client(&self, id: &str) -> Result<GuestClient> {
         let cid = self.lock().get(id).context("vm not found")?.config.cid;
-        Ok(guest_api::client::new_client(format!(
-            "vsock://{cid}:8000/api"
-        )))
+        Ok(guest_api::client::new_client_with_timeout(
+            format!("vsock://{cid}:8000/api"),
+            GUEST_AGENT_RPC_TIMEOUT,
+        ))
     }
 
     fn try_allocate_gpus(&self, manifest: &Manifest) -> Result<GpuConfig> {


### PR DESCRIPTION
## Summary

- add an optional full-request deadline to the pRPC HTTP client and enable a 30-second deadline for VMM-to-Guest-Agent calls
- bound Guest Agent handler dependencies, move blocking system inspection off async workers, and terminate timed-out child processes

## Rationale

A peer or local dependency that stops making progress could previously retain request resources indefinitely. The timeout is applied at the pRPC client boundary rather than hard-coded in the low-level vsock connector.

Concurrency admission control is intentionally kept out of this focused change and tracked separately in https://github.com/Dstack-TEE/dstack/issues/1096.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p http-client -p guest-api -p dstack-vmm -p dstack-guest-agent`
- `cargo clippy -p http-client -p guest-api -p dstack-vmm -p dstack-guest-agent --all-targets -- -D warnings`
- `cargo test -p http-client -p guest-api -p dstack-vmm -p dstack-guest-agent`
