### PR TITLE
feat(vmm): shuffle service URLs per CVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - dstack-util: a CVM re-registers with the gateway node that last accepted it, before falling back to the configured order. The list used to be walked from the top every time, so every CVM piled onto the first URL and the whole fleet snapped back to it the moment it recovered from an outage — and each move rewrites the instance record from a different node's memory
+- vmm: optionally randomize the KMS and gateway URL orders written to each CVM's system configuration so new CVMs distribute their initial requests across service nodes; both are enabled by default in `vmm.toml`
 - os/yocto: nerdctl 2.2.1 → 2.3.5, so `nerdctl compose` honours the Compose `healthcheck:` field (only translated into `--health-*` flags from 2.3.1 on). Requires openembedded-core to move to `wrynose` head for go 1.26.5, which also brings gcc 15.2 → 15.3 — every guest image measurement changes, so the new image hashes need whitelisting in KMS
 
 ### Fixed

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "or-panic",
  "path-absolutize",
  "ra-rpc",
+ "rand 0.8.6",
  "reqwest",
  "rocket",
  "rocket-vsock-listener",

--- a/dstack/vmm/Cargo.toml
+++ b/dstack/vmm/Cargo.toml
@@ -60,6 +60,7 @@ fscommon.workspace = true
 or-panic.workspace = true
 url.workspace = true
 reqwest.workspace = true
+rand.workspace = true
 flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -27,6 +27,7 @@ use id_pool::IdPool;
 use nix::unistd::Uid;
 use or_panic::ResultOrPanic;
 use ra_rpc::client::RaClient;
+use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -1605,17 +1606,29 @@ pub(crate) fn make_sys_config(
     let image_path = cfg.image.path.join(&manifest.image);
     let image = Image::load(image_path).context("Failed to load image info")?;
     let img_ver = image.info.version_tuple().unwrap_or((0, 0, 0));
-    let kms_urls = if manifest.kms_urls.is_empty() {
+    let mut kms_urls = if manifest.kms_urls.is_empty() {
         cfg.cvm.kms_urls.clone()
     } else {
         manifest.kms_urls.clone()
     };
-    let gateway_urls = if manifest.gateway_urls.is_empty() {
+    if cfg.cvm.shuffle_kms_urls {
+        kms_urls.shuffle(&mut rand::thread_rng());
+    }
+    let mut gateway_urls = if manifest.gateway_urls.is_empty() {
         cfg.cvm.gateway_urls.clone()
     } else {
         manifest.gateway_urls.clone()
     };
-    let gateway_clusters = cfg.cvm.gateway_clusters.clone();
+    let mut gateway_clusters = cfg.cvm.gateway_clusters.clone();
+    if cfg.cvm.shuffle_gateway_urls {
+        // Give each CVM an independent starting gateway. The guest preserves
+        // these orders when it has no previously successful gateway to prefer.
+        let mut rng = rand::thread_rng();
+        gateway_urls.shuffle(&mut rng);
+        for cluster in &mut gateway_clusters {
+            cluster.urls.shuffle(&mut rng);
+        }
+    }
     if img_ver < (0, 5, 0) {
         bail!("Unsupported image version: {img_ver:?}");
     }

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -302,6 +302,9 @@ pub struct CvmConfig {
     pub qemu_path: PathBuf,
     /// The URL of the KMS server
     pub kms_urls: Vec<String>,
+    /// Randomize KMS failover order independently for each CVM.
+    #[serde(default)]
+    pub shuffle_kms_urls: bool,
     /// The URL of the dstack-gateway server
     #[serde(alias = "tproxy_urls")]
     pub gateway_urls: Vec<String>,
@@ -309,6 +312,9 @@ pub struct CvmConfig {
     /// failover endpoints for that cluster.
     #[serde(default)]
     pub gateway_clusters: Vec<dstack_types::GatewayClusterConfig>,
+    /// Randomize gateway failover order independently for each CVM.
+    #[serde(default)]
+    pub shuffle_gateway_urls: bool,
     /// The URL of the PCCS server
     #[serde(default)]
     pub pccs_url: String,
@@ -1196,6 +1202,8 @@ mod tests {
     fn config_validation_accepts_defaults() {
         let config = default_config();
         assert_eq!(config.netd.socket_mode, 0o660);
+        assert!(config.cvm.shuffle_kms_urls);
+        assert!(config.cvm.shuffle_gateway_urls);
         config.validate().unwrap();
     }
 

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -25,7 +25,9 @@ registry = ""
 platform = "auto"
 qemu_path = ""
 kms_urls = ["http://127.0.0.1:8081"]
+shuffle_kms_urls = true
 gateway_urls = ["http://127.0.0.1:8082"]
+shuffle_gateway_urls = true
 # PCCS URL used by guest to verify the quote from local key provider
 pccs_url = ""
 # Optional dstack GPU attestation proxy. When configured, guests use its


### PR DESCRIPTION
## Problem

Guests use configured service URL order when they have no previous successful endpoint. If every VMM writes the same order, every new CVM initially contacts the first KMS and gateway nodes. PR #1093 adds gateway affinity after a successful registration, but it intentionally preserves the initial order and therefore cannot distribute cold starts by itself.

## Fix

Add two independent VMM options:

- `cvm.shuffle_kms_urls`
- `cvm.shuffle_gateway_urls`

Both are enabled in the default `vmm.toml`; their defaults live in TOML rather than Rust. Operators can disable either behavior explicitly.

When enabled, the VMM shuffles the corresponding URL list while writing each CVM's system configuration. Gateway cluster endpoint lists are shuffled as well as the legacy gateway list. Empty and single-URL deployments are unchanged.

## Verification

- `cargo fmt --check`
- `cargo test -p dstack-vmm` (128 passed)