### PR TITLE
feat(ra-rpc): report accurate status codes for rpc errors

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -5696,6 +5696,7 @@ dependencies = [
  "rocket-vsock-listener",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "x509-parser",
 ]

--- a/dstack/ra-rpc/Cargo.toml
+++ b/dstack/ra-rpc/Cargo.toml
@@ -25,6 +25,9 @@ x509-parser.workspace = true
 prost-types = { workspace = true, optional = true }
 or-panic.workspace = true
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
 [features]
 default = ["rocket", "client"]
 rocket = ["dep:rocket", "dep:rocket-vsock-listener"]

--- a/dstack/ra-rpc/src/lib.rs
+++ b/dstack/ra-rpc/src/lib.rs
@@ -130,8 +130,18 @@ pub fn code_of(err: &anyhow::Error) -> Option<u16> {
         .next()
 }
 
+/// Whether `method` is one the service actually implements.
+///
+/// `prpc-build` generates the method table and the dispatcher's match arms from
+/// the same list, so this answers exactly what the dispatcher would accept.
+fn is_known_method<S: PrpcService>(method: &str) -> bool {
+    S::methods().as_ref().contains(&method)
+}
+
 /// Status code reported for an error that carries no code of its own.
 pub const CODE_BAD_REQUEST: u16 = 400;
+/// Status code reported when a requested method does not exist.
+pub const CODE_NOT_FOUND: u16 = 404;
 /// Status code reported when the request body exceeds the configured limit.
 pub const CODE_PAYLOAD_TOO_LARGE: u16 = 413;
 
@@ -147,26 +157,35 @@ pub trait RpcCall<State>: Sized {
         is_json: bool,
         is_query: bool,
     ) -> (u16, Vec<u8>) {
-        dispatch_prpc(
-            method,
+        let (code, body) = dispatch_prpc(
+            &method,
             payload,
             is_json,
             is_query,
             <Self::PrpcService as From<Self>>::from(self),
         )
-        .await
+        .await;
+        // The dispatcher reports an unknown method as an ordinary error, so it
+        // arrives here as a generic bad request. Only that case needs refining,
+        // so the method table is consulted lazily: a successful call, or a
+        // failure the service chose a code for, never pays for the lookup. The
+        // dispatcher's own message is reused verbatim rather than rebuilt here.
+        if code == CODE_BAD_REQUEST && !is_known_method::<Self::PrpcService>(&method) {
+            return (CODE_NOT_FOUND, body);
+        }
+        (code, body)
     }
 }
 
 async fn dispatch_prpc(
-    path: String,
+    path: &str,
     data: Vec<u8>,
     json: bool,
     query: bool,
     server: impl PrpcService + Send + 'static,
 ) -> (u16, Vec<u8>) {
     info!("dispatching request: {path}");
-    let result = server.dispatch_request(&path, data, json, query).await;
+    let result = server.dispatch_request(path, data, json, query).await;
     let (code, data) = match result {
         Ok(data) => (200, data),
         Err(err) => {

--- a/dstack/ra-rpc/src/lib.rs
+++ b/dstack/ra-rpc/src/lib.rs
@@ -59,6 +59,82 @@ pub struct CallContext<'a, State> {
     pub remote_app_info: Option<AppInfo>,
 }
 
+/// An RPC error carrying a status code, so a failure can be reported as
+/// something more specific than a generic bad request.
+///
+/// `Display` and `source` delegate to the inner error, so attaching a code
+/// leaves the rendered error message byte-for-byte unchanged.
+#[derive(Debug)]
+pub struct CodedError {
+    code: u16,
+    inner: anyhow::Error,
+}
+
+impl CodedError {
+    pub fn code(&self) -> u16 {
+        self.code
+    }
+}
+
+impl Display for CodedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl std::error::Error for CodedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+/// Attach a status code to an error.
+pub trait ErrorExt {
+    fn with_code(self, code: u16) -> anyhow::Error;
+}
+
+impl<E: Into<anyhow::Error>> ErrorExt for E {
+    fn with_code(self, code: u16) -> anyhow::Error {
+        anyhow::Error::new(CodedError {
+            code,
+            inner: self.into(),
+        })
+    }
+}
+
+/// Attach a status code to the error of a `Result`.
+pub trait ResultExt<T> {
+    fn with_code(self, code: u16) -> Result<T>;
+}
+
+impl<T, E: Into<anyhow::Error>> ResultExt<T> for std::result::Result<T, E> {
+    fn with_code(self, code: u16) -> Result<T> {
+        self.map_err(|e| ErrorExt::with_code(e, code))
+    }
+}
+
+/// Extract the status code attached to `err`, if any.
+///
+/// Walks the whole error chain and returns the outermost code, so a code
+/// survives `.context(..)` layers and foreign error types wrapped around it.
+/// `anyhow::Error::downcast_ref` alone is not enough: it only follows anyhow's
+/// own context chain and stops at the first foreign error type, which would
+/// silently drop a code buried under, say, a `thiserror` wrapper.
+///
+/// The outermost code wins: the layer closest to the caller has the most
+/// context about how the failure should be reported.
+pub fn code_of(err: &anyhow::Error) -> Option<u16> {
+    err.chain()
+        .filter_map(|cause| cause.downcast_ref::<CodedError>())
+        .map(CodedError::code)
+        .next()
+}
+
+/// Status code reported for an error that carries no code of its own.
+pub const CODE_BAD_REQUEST: u16 = 400;
+/// Status code reported when the request body exceeds the configured limit.
+pub const CODE_PAYLOAD_TOO_LARGE: u16 = 413;
+
 pub trait RpcCall<State>: Sized {
     type PrpcService: PrpcService + From<Self> + Send + 'static;
 
@@ -95,7 +171,10 @@ async fn dispatch_prpc(
         Ok(data) => (200, data),
         Err(err) => {
             error!("rpc error: {err:?}");
-            (400, encode_error(json, &err))
+            // Services can attach a status code to their error; anything that
+            // does not is reported as a generic bad request, as before.
+            let code = code_of(&err).unwrap_or(CODE_BAD_REQUEST);
+            (code, encode_error(json, &err))
         }
     };
     (code, data)
@@ -109,5 +188,102 @@ pub fn encode_error(json: bool, error: &impl Display) -> Vec<u8> {
             .into_bytes()
     } else {
         encode_message_to_vec(&::prpc::server::ProtoError::new(error))
+    }
+}
+
+#[cfg(test)]
+mod coded_error_tests {
+    use super::{code_of, ErrorExt, ResultExt};
+    use anyhow::{anyhow, Context, Error};
+
+    /// A foreign error type that keeps its source in the chain, like `thiserror`.
+    #[derive(Debug)]
+    struct Wrapper(Error);
+
+    impl std::fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "wrapper")
+        }
+    }
+
+    impl std::error::Error for Wrapper {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(self.0.as_ref())
+        }
+    }
+
+    #[test]
+    fn attaching_a_code_leaves_the_message_unchanged() {
+        let plain = anyhow!("something went wrong");
+        let coded = anyhow!("something went wrong").with_code(403);
+        assert_eq!(format!("{plain}"), format!("{coded}"));
+        assert_eq!(format!("{plain:#}"), format!("{coded:#}"));
+    }
+
+    #[test]
+    fn an_error_without_a_code_reports_none() {
+        assert_eq!(code_of(&anyhow!("boom")), None);
+    }
+
+    #[test]
+    fn a_code_can_be_attached_to_a_result() {
+        let err = Err::<(), _>(anyhow!("bad body"))
+            .with_code(400)
+            .unwrap_err();
+        assert_eq!(code_of(&err), Some(400));
+    }
+
+    #[test]
+    fn a_code_is_found_through_many_context_layers() {
+        let err = Err::<(), _>(anyhow!("db down").with_code(503))
+            .context("a")
+            .context("b")
+            .context("c")
+            .unwrap_err();
+        assert_eq!(code_of(&err), Some(503));
+        assert_eq!(format!("{err:#}"), "c: b: a: db down");
+    }
+
+    #[test]
+    fn a_code_is_found_under_a_foreign_error_type() {
+        // This is the case a bare `downcast_ref::<CodedError>()` misses, because
+        // anyhow stops walking at the first foreign error type.
+        let err = Error::new(Wrapper(anyhow!("db down").with_code(503)));
+        assert_eq!(code_of(&err), Some(503));
+    }
+
+    #[test]
+    fn a_code_is_found_under_a_foreign_error_type_plus_context() {
+        let err = Err::<(), _>(Error::new(Wrapper(anyhow!("db down").with_code(503))))
+            .context("outer")
+            .unwrap_err();
+        assert_eq!(code_of(&err), Some(503));
+    }
+
+    #[test]
+    fn the_outermost_code_wins() {
+        assert_eq!(
+            code_of(&anyhow!("db down").with_code(503).with_code(404)),
+            Some(404)
+        );
+        let err = Err::<(), _>(anyhow!("db down").with_code(503))
+            .context("mid")
+            .unwrap_err()
+            .with_code(404);
+        assert_eq!(code_of(&err), Some(404));
+    }
+
+    #[test]
+    fn a_code_survives_a_question_mark_boundary() {
+        fn inner() -> anyhow::Result<()> {
+            Err(anyhow!("db down").with_code(503))
+        }
+        fn outer() -> anyhow::Result<()> {
+            inner().context("outer failed")?;
+            Ok(())
+        }
+        let err = outer().unwrap_err();
+        assert_eq!(code_of(&err), Some(503));
+        assert_eq!(format!("{err:#}"), "outer failed: db down");
     }
 }

--- a/dstack/ra-rpc/src/openapi.rs
+++ b/dstack/ra-rpc/src/openapi.rs
@@ -402,17 +402,25 @@ fn build_operation(
             }
         }),
     );
-    responses.insert(
-        "400".into(),
-        json!({
-            "description": "RPC error",
-            "content": {
-                "application/json": {
-                    "schema": { "$ref": "#/components/schemas/RpcError" }
+    // A service may report a more specific status than a generic bad request;
+    // these are the ones the framework itself produces.
+    for (code, description) in [
+        ("400", "RPC error"),
+        ("404", "No such method"),
+        ("413", "Request body exceeds the configured limit"),
+    ] {
+        responses.insert(
+            code.into(),
+            json!({
+                "description": description,
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/RpcError" }
+                    }
                 }
-            }
-        }),
-    );
+            }),
+        );
+    }
     operation.insert("responses".into(), Value::Object(responses));
 
     Ok(Value::Object(operation))

--- a/dstack/ra-rpc/src/rocket_helper.rs
+++ b/dstack/ra-rpc/src/rocket_helper.rs
@@ -325,7 +325,10 @@ async fn read_data(data: Data<'_>, limit: ByteUnit) -> Result<Vec<u8>> {
     let stream = data.open(limit);
     let data = stream.into_bytes().await.context("failed to read data")?;
     if !data.is_complete() {
-        anyhow::bail!("payload too large");
+        return Err(crate::ErrorExt::with_code(
+            anyhow::anyhow!("payload too large"),
+            crate::CODE_PAYLOAD_TOO_LARGE,
+        ));
     }
     Ok(data.into_inner())
 }
@@ -384,9 +387,12 @@ impl<S> PrpcHandler<'_, '_, S> {
             Err(err) => {
                 warn!("error handling prpc: {err:?}");
                 let body = encode_error(json, &err);
+                let status = crate::code_of(&err)
+                    .and_then(Status::from_code)
+                    .unwrap_or(Status::BadRequest);
                 RpcResponse {
                     is_json: json,
-                    status: Status::BadRequest,
+                    status,
                     body,
                 }
             }

--- a/dstack/ra-rpc/tests/status_codes.rs
+++ b/dstack/ra-rpc/tests/status_codes.rs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2024-2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage for the status code an RPC failure is reported with.
+//!
+//! The service is hand-written rather than generated so the test needs no
+//! `.proto` and no build script. It mirrors what `prpc-build` emits: a
+//! `methods()` table, and a `dispatch_request` whose fallback arm reports an
+//! unknown method as an ordinary error.
+
+use anyhow::{anyhow, Context, Result};
+use ra_rpc::{CallContext, ErrorExt, RpcCall};
+use rocket::local::asynchronous::Client;
+
+/// A foreign error type that keeps its source in the chain, like `thiserror`.
+#[derive(Debug)]
+struct ForeignError(anyhow::Error);
+
+impl std::fmt::Display for ForeignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "storage layer failed")
+    }
+}
+
+impl std::error::Error for ForeignError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
+#[derive(Clone, Default)]
+struct AppState;
+
+struct DemoHandler;
+
+struct DemoServer(#[allow(dead_code)] DemoHandler);
+
+impl From<DemoHandler> for DemoServer {
+    fn from(handler: DemoHandler) -> Self {
+        Self(handler)
+    }
+}
+
+impl prpc::server::Service for DemoServer {
+    type Methods = &'static [&'static str];
+
+    fn methods() -> Self::Methods {
+        &[
+            "Echo",
+            "PlainFail",
+            "Forbidden",
+            "Unavailable",
+            "DeeplyBuried",
+        ]
+    }
+
+    async fn dispatch_request(
+        self,
+        path: &str,
+        data: impl AsRef<[u8]>,
+        _json: bool,
+        _query: bool,
+    ) -> Result<Vec<u8>, prpc::server::Error> {
+        match path {
+            "Echo" => {
+                // Decoding the payload is what turns a malformed body into a
+                // generic bad request, exactly as the generated code does.
+                let value: serde_json::Value = serde_json::from_slice(data.as_ref())?;
+                Ok(serde_json::to_vec(&value)?)
+            }
+            "PlainFail" => Err(anyhow!("something went wrong")),
+            "Forbidden" => Err(anyhow!("caller is not authorized").with_code(403)),
+            // The code is attached at the bottom and wrapped in context on the
+            // way out; it still has to reach the transport.
+            "Unavailable" => Err(anyhow!("db down").with_code(503)).context("load app"),
+            // The worst case: a code buried under a foreign error type and
+            // three context layers.
+            "DeeplyBuried" => Err(anyhow::Error::new(ForeignError(
+                anyhow!("no such app").with_code(404),
+            )))
+            .context("lookup app")
+            .context("handle request")
+            .context("serve"),
+            _ => anyhow::bail!("Service not found: {path}"),
+        }
+    }
+}
+
+impl RpcCall<AppState> for DemoHandler {
+    type PrpcService = DemoServer;
+
+    fn construct(_context: CallContext<'_, AppState>) -> Result<Self> {
+        Ok(DemoHandler)
+    }
+}
+
+async fn client() -> Client {
+    let rocket = rocket::build().manage(AppState).mount(
+        "/",
+        ra_rpc::prpc_routes!(AppState, DemoHandler, trim: "Demo."),
+    );
+    Client::tracked(rocket)
+        .await
+        .expect("failed to build the test client")
+}
+
+async fn post(client: &Client, path: &str, body: &str) -> (u16, String) {
+    let response = client
+        .post(format!("/{path}?json"))
+        .body(body.to_string())
+        .dispatch()
+        .await;
+    let status = response.status().code;
+    let text = response.into_string().await.unwrap_or_default();
+    (status, text)
+}
+
+#[tokio::test]
+async fn a_successful_call_is_reported_as_ok() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.Echo", r#"{"text":"hello"}"#).await;
+    assert_eq!(status, 200);
+    assert_eq!(body, r#"{"text":"hello"}"#);
+}
+
+#[tokio::test]
+async fn an_unknown_method_is_reported_as_not_found() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.NoSuchMethod", "{}").await;
+    assert_eq!(status, 404);
+    // The dispatcher's own message is reused rather than rebuilt.
+    assert!(body.contains("Service not found: NoSuchMethod"), "{body}");
+}
+
+#[tokio::test]
+async fn a_malformed_body_is_reported_as_a_bad_request() {
+    let client = client().await;
+    let (status, _) = post(&client, "Demo.Echo", "{not json").await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn an_error_without_a_code_is_reported_as_a_bad_request() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.PlainFail", "{}").await;
+    assert_eq!(status, 400);
+    assert!(body.contains("something went wrong"), "{body}");
+}
+
+#[tokio::test]
+async fn a_service_can_choose_the_status_code() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.Forbidden", "{}").await;
+    assert_eq!(status, 403);
+    assert!(body.contains("caller is not authorized"), "{body}");
+}
+
+#[tokio::test]
+async fn a_code_survives_a_context_layer() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.Unavailable", "{}").await;
+    assert_eq!(status, 503);
+    // The message reads as if no code had been attached at all.
+    assert!(body.contains("load app: db down"), "{body}");
+    assert!(!body.contains("503"), "{body}");
+}
+
+#[tokio::test]
+async fn a_code_survives_a_foreign_error_type_and_several_context_layers() {
+    let client = client().await;
+    let (status, body) = post(&client, "Demo.DeeplyBuried", "{}").await;
+    assert_eq!(status, 404);
+    assert!(
+        body.contains("serve: handle request: lookup app: storage layer failed: no such app"),
+        "{body}"
+    );
+}
+
+#[tokio::test]
+async fn a_body_over_the_limit_is_reported_as_payload_too_large() {
+    // `limit_for_method` looks the limit up by method name.
+    let figment = rocket::Config::figment().merge((
+        "limits",
+        rocket::data::Limits::default().limit("Echo", rocket::data::ToByteUnit::bytes(8u64)),
+    ));
+    let rocket = rocket::custom(figment).manage(AppState).mount(
+        "/",
+        ra_rpc::prpc_routes!(AppState, DemoHandler, trim: "Demo."),
+    );
+    let client = Client::tracked(rocket)
+        .await
+        .expect("failed to build the test client");
+
+    let oversized = format!(r#"{{"text":"{}"}}"#, "x".repeat(64));
+    let (status, body) = post(&client, "Demo.Echo", &oversized).await;
+    assert_eq!(status, 413, "{body}");
+    assert!(body.contains("payload too large"), "{body}");
+
+    // A body within the limit still succeeds.
+    let (status, _) = post(&client, "Demo.Echo", "{}").await;
+    assert_eq!(status, 200);
+}


### PR DESCRIPTION
## Problem

Every RPC failure is reported as `400 Bad Request`, whatever went wrong.

`dispatch_prpc` maps any dispatch error to a hardcoded 400 (`ra-rpc/src/lib.rs`), and
`PrpcHandler::handle` does the same with `Status::BadRequest` (`ra-rpc/src/rocket_helper.rs`).
The transport already has a status-code channel — `dispatch_prpc` returns `(u16, Vec<u8>)` —
it is just never used for anything but 400.

Two cases are actively misreported:

- **A method that does not exist.** The generated dispatcher's fallback arm is
  `anyhow::bail!("Service not found: {path}")`, an ordinary error indistinguishable from a
  service-level failure, so it surfaces as 400. Callers cannot tell "you called a method I
  do not have" from "the method ran and rejected your request".
- **A body over the configured limit.** `read_data` bails with `payload too large` after
  `Data::open` truncates the stream, which also surfaces as 400 rather than 413.

Services have no way to report anything else either — an authorization failure and a
malformed field are the same 400 on the wire.

## Fix

`prpc::server::Error` is `anyhow::Error`, so a code can ride along in the error chain
without changing any signature.

`CodedError` wraps an error with a `u16`. Its `Display` and `source` delegate to the inner
error, so attaching a code leaves the rendered message byte-for-byte unchanged — important
because those strings are the wire format. `ErrorExt::with_code` / `ResultExt::with_code`
attach one; `code_of` reads it back; an error without one is still 400.

`code_of` walks the whole chain rather than calling `downcast_ref::<CodedError>()`.
`anyhow`'s downcast only follows its own context chain and stops at the first foreign error
type, so a code buried under a `thiserror`-style wrapper would be silently dropped. Where
both work they agree; walking the chain is strictly more robust. The outermost code wins.

Unknown methods are resolved against `Service::methods()`. `prpc-build` generates that table
and the dispatcher's match arms from the same `join_path(..)` expression, so it answers
exactly what the dispatcher would accept; I verified all 13 generated services in the tree
have `supported_methods()` identical to their match arms. The lookup happens **after**
dispatch and only when the result is 400, so a successful call — or a failure the service
chose a code for — never pays for it, and the dispatcher's own message is reused rather than
rebuilt.

This is deliberately confined to `ra-rpc`; `prpc` is untouched. Most of the errors that need
a status live above it — `payload too large` happens in `read_data` before the body is fully
read, so `prpc` never sees it — and `prpc` is transport-agnostic (vsock, unix sockets), where
HTTP status codes have no meaning.

Behaviour change: unknown methods now return 404 and oversized bodies 413, both previously
400. No SDK inspects the status code — the Rust client only checks `status.is_success()`, and
the Python/Go/JS SDKs do not branch on it.

## Verification

`ra-rpc/tests/status_codes.rs` drives a service through the real `prpc_routes!` stack with
rocket's local client (hand-written service, so no `.proto` or build script):

| Case | Status |
|---|---|
| successful call | 200 |
| unknown method | 404 |
| malformed body | 400 |
| error with no code attached | 400 |
| service attaches 403 | 403 |
| 503 attached under a `.context()` layer | 503 |
| 404 under a foreign error type + 3 context layers | 404 |
| body over the configured limit | 413 |

Also verified against a real `dstack-guest-agent` (simulator, over its unix sockets):

```
unknown method                        404  {"error": "Service not found: Nope"}
oversized body (11MiB, limit 10MiB)   413  {"error": "failed to read data: payload too large"}
malformed body                        400  {"error": "key must be a string at line 1 column 2"}
happy path                            200
```

To confirm the method-table lookup never rejects a real call, every method of every service
the simulator serves — 18 across `TappdServer`, `DstackGuestServer` and `WorkerServer`, over
all three mount points and both trim prefixes — was driven over HTTP: **0 false 404s**.

`cargo clippy -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow
unused_variables` and `cargo fmt --check --all` are clean, on each commit of the stack
individually. Full suite: 811 passed, 0 failed.

## Left out

- **Failed attestation is still 400.** `invalid quote` in `handle_prpc_impl` is an
  authorization failure, not a malformed request, but exercising it needs a client presenting
  a cert with a bad quote, which this PR has no harness for. I would rather land it with a
  test than assert it works — and 401 vs 403 deserves its own discussion.
- **`Call::construct` failures are still 400**, where 500 may fit better; it depends on what
  each handler's `construct` can actually fail on.
