### PR TITLE
docs(security): describe both external API surfaces in cvm-boundaries

### DIFF
--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -192,7 +192,9 @@ Neither surface returns key material, and no caller chooses what gets signed
 or attested. That boundary, not the method list, is what makes this listener
 safe to expose: key material and caller-chosen attestation live only on the
 internal Unix socket (`/var/run/dstack.sock`), which is not a CVM boundary —
-it is reachable only by the application itself.
+it is reachable only by the application itself. An application that re-exports
+that socket has moved the boundary itself, and everything behind it moves with
+it.
 
 **Frozen `Worker` (`/prpc`, alias `/prpc/v0`):**
 
@@ -206,7 +208,7 @@ it is reachable only by the application itself.
 
 | Method | Description | Return Type |
 |--------|-------------|------------|
-| Info | Get application identity and configuration | InfoResponse |
+| Info | Get application identity, plus configuration when `public_tcbinfo` is set | InfoResponse |
 | Version | Get guest agent version | VersionResponse |
 | Health | Report whether the application is serving | HealthResponse |
 
@@ -223,7 +225,8 @@ what it costs and in what it says:
   back. Container names and statuses were already public through the dashboard
   below.
 - `GetAttestationForAppKey` (frozen) generates a fresh platform attestation per
-  call and is by far the most expensive method here. It has no v1 counterpart
+  call. With the frozen `Info` below, it is one of the two methods here that
+  let an anonymous caller drive quote generation. It has no v1 counterpart
   on purpose: a v1 application attests its own key through the internal socket
   (`/v1/GetKey`, then `/v1/Attest`) and serves the result itself, so the public
   listener never gained a second attestation-on-demand entry point.
@@ -231,7 +234,10 @@ what it costs and in what it says:
   costs a hardware quote under the agent's global quote lock. The v1 `Info`
   serves the same identity from a cache decoded once at startup, so an
   anonymous caller cannot drive quote generation through it; if the boot-time
-  decode failed, retries are throttled to one attempt per interval.
+  decode failed, retries are throttled to one attempt per interval. Of the two
+  quote-generating methods, the frozen `Info` is the one worth rate-limiting
+  first: it is what clients actually poll, and it replays the event log on top
+  of the quote.
 - Both `Info` methods honour the app's `public_tcbinfo` choice, with different
   reach. The frozen one blanks `tcb_info` and `vm_config` but always serves
   `key_provider_info`. The v1 one blanks `app_compose`, `vm_config`, and

--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -180,33 +180,66 @@ Full specification: [host_api.proto](../../dstack/host-api/proto/host_api.proto)
 
 The dstack-guest-agent runs an HTTP server on port 8090 inside the CVM. This port is publicly accessible, allowing external clients to view basic CVM information.
 
-| Service | Purpose |
-|---------|--------|
-| Worker | Provides public-facing app information |
+Since dstack 0.6.0 the listener serves two API surfaces, selected by URL path
+alone: the frozen v0.5.11 `Worker` service at `/prpc` (equivalently
+`/prpc/v0`), and the versioned `dstack.guest.v1` `Worker` service at
+`/prpc/v1`. The frozen surface is closed and never changes again; new
+capability arrives only on v1. [guest-api-v1.md](../guest-api-v1.md) is the
+normative specification of the v1 surface, including its status-code and
+version-probing rules.
 
-**Available Methods:**
+Neither surface returns key material, and no caller chooses what gets signed
+or attested. That boundary, not the method list, is what makes this listener
+safe to expose: key material and caller-chosen attestation live only on the
+internal Unix socket (`/var/run/dstack.sock`), which is not a CVM boundary —
+it is reachable only by the application itself.
+
+**Frozen `Worker` (`/prpc`, alias `/prpc/v0`):**
 
 | Method | Description | Return Type |
 |--------|-------------|------------|
 | Info | Get application information | AppInfo |
 | Version | Get guest agent version | WorkerVersion |
 | GetAttestationForAppKey | Attest the key the agent derives for the app | GetQuoteResponse |
-| Health | Report whether the application is serving (`/prpc/v1` only) | HealthResponse |
+
+**v1 `Worker` (`/prpc/v1`):**
+
+| Method | Description | Return Type |
+|--------|-------------|------------|
+| Info | Get application identity and configuration | InfoResponse |
+| Version | Get guest agent version | VersionResponse |
+| Health | Report whether the application is serving | HealthResponse |
 
 Everything on this listener is unauthenticated, so each method is bounded in
 what it costs and in what it says:
 
-- `Health` answers from a cache the agent refreshes on its own timer, so a call
-  costs a lock and a clone however many callers there are. It reveals whether
-  the app opted into health gating, its current verdict, and — when the app
-  declared a `health_status_file` — the path it named and which parsing rule
-  failed. That last part is a narrow oracle for whether a path exists and what
-  shape its first two lines have; the path itself is already public, since it is
-  measured into the compose hash. The file's *contents* are never quoted back.
-  Container names and statuses were already public through the dashboard below.
-- `GetAttestationForAppKey` generates a fresh platform attestation per call and
-  is by far the most expensive method here.
+- `Health` (v1) answers from a cache the agent refreshes on its own timer, so a
+  call costs a lock and a clone however many callers there are. It reveals
+  whether the app opted into health gating, its current verdict, and — when the
+  app declared a `health_status_file` — the path it named and which parsing
+  rule failed. That last part is a narrow oracle for whether a path exists and
+  what shape its first two lines have; the path itself is already public, since
+  it is measured into the compose hash. The file's *contents* are never quoted
+  back. Container names and statuses were already public through the dashboard
+  below.
+- `GetAttestationForAppKey` (frozen) generates a fresh platform attestation per
+  call and is by far the most expensive method here. It has no v1 counterpart
+  on purpose: a v1 application attests its own key through the internal socket
+  (`/v1/GetKey`, then `/v1/Attest`) and serves the result itself, so the public
+  listener never gained a second attestation-on-demand entry point.
+- The frozen `Info` decodes identity out of a boot attestation per call, which
+  costs a hardware quote under the agent's global quote lock. The v1 `Info`
+  serves the same identity from a cache decoded once at startup, so an
+  anonymous caller cannot drive quote generation through it; if the boot-time
+  decode failed, retries are throttled to one attempt per interval.
+- Both `Info` methods honour the app's `public_tcbinfo` choice, with different
+  reach. The frozen one blanks `tcb_info` and `vm_config` but always serves
+  `key_provider_info`. The v1 one blanks `app_compose`, `vm_config`, and
+  `key_provider_info`, and carries no measurement registers or event log at
+  all — those are attestation data and belong to the internal `Attest`, where
+  a quote vouches for them. Identity and the measurement hashes are always
+  visible on both surfaces.
 
 The service also provides a web dashboard at the root URL (`/`) showing basic CVM information. View the dashboard template [here](../../dstack/guest-agent/templates/dashboard.html).
 
-Full specification: [agent_rpc.proto](../../dstack/guest-agent/rpc/proto/agent_rpc.proto)
+Full specifications: [agent_rpc.proto](../../dstack/guest-agent/rpc/proto/agent_rpc.proto) for the frozen surface, [agent_rpc_v1.proto](../../dstack/guest-agent/rpc/proto/agent_rpc_v1.proto) for v1.


### PR DESCRIPTION
Follow-up to #1116. `docs/security/cvm-boundaries.md` documents what crosses the CVM boundary, and its public-listener section predated the v0/v1 split: it showed a single `Worker` service with `Health` bolted onto the frozen method table by a parenthetical, and named `AttestAppKey` — a method that briefly existed on `next` and that #1116 reversed back to the frozen `GetAttestationForAppKey`.

Since that section is the reference for what an unauthenticated caller can reach, a stale method table there is worse than an incomplete one.

## What changed

**Two tables, one per surface.** The frozen `Worker` at `/prpc` (alias `/prpc/v0`) with its three v0.5.11 methods, and the v1 `Worker` at `/prpc/v1` with `Info`, `Version`, `Health`. Correct return types on both.

**The invariant is stated, not implied.** Neither surface returns key material and neither lets a caller choose what gets signed or attested. That — not the method list — is what makes the listener safe to expose, and it is why the internal socket is not a CVM boundary at all: it is reachable only by the application itself.

**The cost/exposure bullets now cover v1.** The existing analysis of `Health`'s narrow oracle and `GetAttestationForAppKey`'s per-call attestation is kept and extended with: why `GetAttestationForAppKey` has no v1 counterpart (a v1 app attests its own key through the internal socket, so the public listener never gained a second attestation-on-demand entry point); the difference between the frozen `Info`, which decodes identity from a boot attestation per call, and the v1 `Info`, which serves it from a cache decoded once at startup so an anonymous caller cannot drive quote generation; and the two `Info` methods' different `public_tcbinfo` reach — the frozen one always serves `key_provider_info`, v1 blanks it and carries no measurement registers at all.

Links now point at `guest-api-v1.md` as the normative v1 reference and at both protos.

No behavior change; documentation only.