### PR TITLE
chore(deps): update dcap-qvl to 0.5.3

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -1438,9 +1438,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a14fb8954c867d6855e44d98eab18e769816357738406691ebe60d8fdd005d"
+checksum = "8b3d93e370c7f1bc394106d8f1dc7b58d7d23e765c95b084fe3657efe02ba166"
 dependencies = [
  "anyhow",
  "asn1_der",

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -231,7 +231,7 @@ url = "2.5"
 # Cryptography/Security
 aes-gcm = "0.10.3"
 curve25519-dalek = "4.1.3"
-dcap-qvl = "0.5.2"
+dcap-qvl = "0.5.3"
 dcap-qvl-webpki = "0.103.4"
 elliptic-curve = { version = "0.13.8", features = ["pkcs8"] }
 getrandom = "0.3.1"


### PR DESCRIPTION
## Summary

Bumps the workspace `dcap-qvl` dependency from 0.5.2 to 0.5.3.

Upstream 0.5.3 ([Phala-Network/dcap-qvl#220](https://github.com/Phala-Network/dcap-qvl/pull/220)) masks the PERFMON bit out of `reserved_other` in `TDAttributes::parse`. Without it, quotes from platforms that have PERFMON enabled are rejected for having reserved TD attribute bits set.

## Impact

dstack only reads the raw `td_attributes` bytes (`dstack-attest`, `dstack-verifier`, `mock-attestation`) and never touches the parsed `TDAttributes` struct, so no call-site changes are required. The `sdk/rust` workspace is on the separate 0.3.x line and is left untouched.

## Testing

- `cargo check --workspace --all-features`
- `cargo test -p dstack-verifier -p dstack-attest -p ra-tls -p mock-attestation --all-features` — all pass