### PR TITLE
fix(ci): run prek over all files when a push has no base commit

### DIFF
--- a/.github/workflows/prek-check.yml
+++ b/.github/workflows/prek-check.yml
@@ -49,4 +49,16 @@ jobs:
 
     - name: Run prek checks (push)
       if: github.event_name == 'push'
-      run: prek run --from-ref ${{ github.event.before }} --to-ref ${{ github.event.after }} --show-diff-on-failure
+      env:
+        BEFORE: ${{ github.event.before }}
+        AFTER: ${{ github.event.after }}
+      run: |
+        # A push that creates a branch reports an all-zero "before", and a
+        # force-push can name one this clone no longer has. Neither is a commit,
+        # so the range would be invalid; check every file instead.
+        if git rev-parse --verify --quiet "$BEFORE^{commit}" >/dev/null; then
+          prek run --from-ref "$BEFORE" --to-ref "$AFTER" --show-diff-on-failure
+        else
+          echo "no usable base commit ($BEFORE); checking all files"
+          prek run --all-files --show-diff-on-failure
+        fi


### PR DESCRIPTION
## Problem

`prek-check.yml` passes `github.event.before` straight to `prek run --from-ref`:

```yaml
run: prek run --from-ref ${{ github.event.before }} --to-ref ${{ github.event.after }}
```

A push that **creates** a branch reports `before` as the all-zero SHA, which is git's "this ref did not exist" sentinel rather than a commit. The resulting range is invalid, so prek dies while collecting files — before a single hook runs:

```
error: Failed to collect files
  caused by: Command `/usr/bin/git diff --name-only --diff-filter=ACMRT -z \
    0000000000000000000000000000000000000000..1bee77fd99 -- .` exited with an error:
fatal: Invalid revision range 0000000000000000000000000000000000000000..1bee77fd99
exit status: 128
```

The workflow triggers on `push` to `next` and `release/**`. `next` always exists, so `before` is always a real commit there and the bug stayed latent — all 30 most recent push-event runs are on `next` and all passed. Cutting `release/0.6.0-rc0` produced the first push-event run on a newly created branch, and it failed instantly ([run 32810551612](https://github.com/Dstack-TEE/dstack/actions/runs/32810551612)). Every future `release/**` branch would fail the same way on its first push.

Re-running does not help: `before` is part of the event payload, so a re-run replays the same all-zero SHA.

A force-push has the same shape — `before` can name a commit this clone no longer has — so the guard covers that too rather than only special-casing the zero SHA.

## Fix

Resolve `before` first, and check every file when it is not a usable commit:

```yaml
if git rev-parse --verify --quiet "$BEFORE^{commit}" >/dev/null; then
  prek run --from-ref "$BEFORE" --to-ref "$AFTER" --show-diff-on-failure
else
  prek run --all-files --show-diff-on-failure
fi
```

Checking all files is the correct fallback, not merely a safe one: when there is no base commit there is no "changed files" set to narrow to, and a new branch's entire tree is what is being introduced. The SHAs move to `env:` so they reach the shell as data rather than being interpolated into the script text.

The incremental path is unchanged for the normal case. The checkout is `fetch-depth: 0`, so a real `before` always resolves and keeps taking the range branch; the fallback fires only when the range genuinely cannot be built.

## Verification

Guard evaluated against all three inputs, in a real clone:

| `before` | Case | Branch taken |
|---|---|---|
| `0000...0000` | branch creation | all-files fallback |
| real commit SHA | normal push | range mode |
| `dead...beef` | force-push, commit absent | all-files fallback |

- `prek run --all-files` passes on the current tree — all 14 hooks `Passed`, exit 0 — so the fallback does not trade one failure for another.
- `prek run --from-ref HEAD~1 --to-ref HEAD` still exits 0 on the range path.
- Workflow YAML parses; the `prek` job's step count is unchanged at 7.

Note on scope of the evidence: the `push` trigger is restricted to `next` and `release/**`, so pushing this branch produced no push-event run and this PR's own CI exercises only the `pull_request` step, which is unchanged. The fallback path is verified locally (table above); the live evidence that a branch-creation push reports the all-zero SHA is the linked `release/0.6.0-rc0` failure. A full end-to-end check would mean creating a throwaway `release/**` branch after this merges.