### PR TITLE
fix(certbot): upgrade instant-acme so an unknown challenge type does not break issuance

### DIFF
--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -203,7 +203,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -214,10 +214,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,7 +523,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -503,6 +531,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitfield"
@@ -821,7 +858,7 @@ dependencies = [
  "instant-acme",
  "path-absolutize",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -830,7 +867,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1308,7 +1345,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1527,7 +1564,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1788,7 +1839,7 @@ dependencies = [
  "parity-scale-codec",
  "pem",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "rmp-serde",
  "rsa",
  "rustix 0.38.44",
@@ -1808,7 +1859,7 @@ dependencies = [
  "tpm-types",
  "tpm2",
  "tracing",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1926,7 +1977,7 @@ dependencies = [
  "uuid",
  "wavekv 1.0.0",
  "wavekv 2.1.0",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1975,7 +2026,7 @@ dependencies = [
  "ra-rpc",
  "ra-tls",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "ring",
  "rinja",
@@ -2074,8 +2125,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "x25519-dalek",
- "x509-parser",
- "yasna",
+ "x509-parser 0.16.0",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -2273,7 +2324,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "x25519-dalek",
- "x509-parser",
+ "x509-parser 0.16.0",
  "yaml-rust2",
 ]
 
@@ -2296,7 +2347,7 @@ dependencies = [
  "hex-literal",
  "nsm-attest",
  "ra-tls",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "rocket",
  "serde",
@@ -2310,7 +2361,7 @@ dependencies = [
  "tpm-types",
  "tracing",
  "tracing-subscriber",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -3467,6 +3518,7 @@ dependencies = [
  "hyper-util",
  "rustls",
  "rustls-native-certs",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3741,24 +3793,28 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
  "http-body-util",
+ "httpdate",
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ring",
+ "rcgen 0.14.9",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4414,7 +4470,7 @@ dependencies = [
  "p384",
  "parity-scale-codec",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -4427,7 +4483,7 @@ dependencies = [
  "tpm-qvl",
  "tpm-types",
  "urlencoding",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -4651,7 +4707,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -4886,7 +4942,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -5716,7 +5781,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -5743,7 +5808,7 @@ dependencies = [
  "p256",
  "parity-scale-codec",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "ring",
  "rmp-serde",
  "rustls-pki-types",
@@ -5757,8 +5822,8 @@ dependencies = [
  "tpm-qvl",
  "tpm-types",
  "tracing",
- "x509-parser",
- "yasna",
+ "x509-parser 0.16.0",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -5862,8 +5927,22 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser",
- "yasna",
+ "x509-parser 0.16.0",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.1",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -6205,7 +6284,7 @@ dependencies = [
  "tracing-subscriber",
  "ubyte",
  "version_check",
- "x509-parser",
+ "x509-parser 0.16.0",
  "yansi",
 ]
 
@@ -7035,7 +7114,7 @@ dependencies = [
  "rustls-webpki",
  "sev",
  "tokio",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -7970,7 +8049,7 @@ dependencies = [
  "tokio",
  "tpm-types",
  "tracing",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -9094,15 +9173,33 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -9165,6 +9262,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -203,7 +203,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.5.1",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -214,38 +214,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
-dependencies = [
- "asn1-rs-derive 0.6.0",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,7 +495,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
 
 [[package]]
@@ -531,15 +503,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitfield"
@@ -858,7 +821,7 @@ dependencies = [
  "instant-acme",
  "path-absolutize",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",
@@ -867,7 +830,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1345,7 +1308,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1564,21 +1527,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1839,7 +1788,7 @@ dependencies = [
  "parity-scale-codec",
  "pem",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "rmp-serde",
  "rsa",
  "rustix 0.38.44",
@@ -1859,7 +1808,7 @@ dependencies = [
  "tpm-types",
  "tpm2",
  "tracing",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1977,7 +1926,7 @@ dependencies = [
  "uuid",
  "wavekv 1.0.0",
  "wavekv 2.1.0",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2026,7 +1975,7 @@ dependencies = [
  "ra-rpc",
  "ra-tls",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "reqwest",
  "ring",
  "rinja",
@@ -2125,8 +2074,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "x25519-dalek",
- "x509-parser 0.16.0",
- "yasna 0.5.2",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2324,7 +2273,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "x25519-dalek",
- "x509-parser 0.16.0",
+ "x509-parser",
  "yaml-rust2",
 ]
 
@@ -2347,7 +2296,7 @@ dependencies = [
  "hex-literal",
  "nsm-attest",
  "ra-tls",
- "rcgen 0.13.2",
+ "rcgen",
  "reqwest",
  "rocket",
  "serde",
@@ -2361,7 +2310,7 @@ dependencies = [
  "tpm-types",
  "tracing",
  "tracing-subscriber",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -3518,7 +3467,6 @@ dependencies = [
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3793,28 +3741,24 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.8.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
+checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
 dependencies = [
  "async-trait",
- "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
  "http-body-util",
- "httpdate",
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen 0.14.9",
- "rustls",
+ "ring",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
- "tokio",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4470,7 +4414,7 @@ dependencies = [
  "p384",
  "parity-scale-codec",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",
@@ -4483,7 +4427,7 @@ dependencies = [
  "tpm-qvl",
  "tpm-types",
  "urlencoding",
- "yasna 0.5.2",
+ "yasna",
 ]
 
 [[package]]
@@ -4707,7 +4651,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -4942,16 +4886,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -5781,7 +5716,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -5808,7 +5743,7 @@ dependencies = [
  "p256",
  "parity-scale-codec",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "ring",
  "rmp-serde",
  "rustls-pki-types",
@@ -5822,8 +5757,8 @@ dependencies = [
  "tpm-qvl",
  "tpm-types",
  "tracing",
- "x509-parser 0.16.0",
- "yasna 0.5.2",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -5927,22 +5862,8 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.16.0",
- "yasna 0.5.2",
-]
-
-[[package]]
-name = "rcgen"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
-dependencies = [
- "aws-lc-rs",
- "pem",
- "rustls-pki-types",
- "time",
- "x509-parser 0.18.1",
- "yasna 0.6.0",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -6284,7 +6205,7 @@ dependencies = [
  "tracing-subscriber",
  "ubyte",
  "version_check",
- "x509-parser 0.16.0",
+ "x509-parser",
  "yansi",
 ]
 
@@ -7114,7 +7035,7 @@ dependencies = [
  "rustls-webpki",
  "sev",
  "tokio",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -8049,7 +7970,7 @@ dependencies = [
  "tokio",
  "tpm-types",
  "tracing",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -9173,33 +9094,15 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.7.1",
+ "oid-registry",
  "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
-dependencies = [
- "asn1-rs 0.7.2",
- "aws-lc-rs",
- "data-encoding",
- "der-parser 10.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.8.1",
- "rusticata-macros",
- "thiserror 2.0.18",
  "time",
 ]
 
@@ -9262,16 +9165,6 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time",
-]
-
-[[package]]
-name = "yasna"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
-dependencies = [
- "bit-vec 0.9.1",
  "time",
 ]
 

--- a/dstack/Cargo.toml
+++ b/dstack/Cargo.toml
@@ -261,7 +261,7 @@ ez-hash = "1.1.0"
 
 # Certificate/DNS
 hickory-resolver = "0.26.1"
-instant-acme = "0.7.2"
+instant-acme = "0.8.5"
 pem = "3.0"
 rcgen = { version = "0.13.2", features = ["pem"] }
 x509-parser = "0.16.0"

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -38,7 +38,6 @@ pub struct AcmeClient {
 struct Challenge {
     id: String,
     acme_domain: String,
-    url: String,
     dns_value: String,
 }
 
@@ -70,8 +69,9 @@ impl AcmeClient {
     ) -> Result<Self> {
         let credentials: Credentials = serde_json::from_str(encoded_credentials)?;
         let http_client = Box::new(ReqwestHttpClient::new()?);
-        let account =
-            Account::from_credentials_and_http(credentials.credentials, http_client).await?;
+        let account = Account::builder_with_http(http_client)
+            .from_credentials(credentials.credentials)
+            .await?;
         let credentials: Credentials = serde_json::from_str(encoded_credentials)?;
         Ok(Self {
             account,
@@ -90,18 +90,18 @@ impl AcmeClient {
         dns_txt_ttl: u32,
     ) -> Result<Self> {
         let http_client = Box::new(ReqwestHttpClient::new()?);
-        let (account, credentials) = Account::create_with_http(
-            &NewAccount {
-                contact: &[],
-                terms_of_service_agreed: true,
-                only_return_existing: false,
-            },
-            acme_url,
-            None,
-            http_client,
-        )
-        .await
-        .with_context(|| format!("failed to create ACME account for {acme_url}"))?;
+        let (account, credentials) = Account::builder_with_http(http_client)
+            .create(
+                &NewAccount {
+                    contact: &[],
+                    terms_of_service_agreed: true,
+                    only_return_existing: false,
+                },
+                acme_url.to_string(),
+                None,
+            )
+            .await
+            .with_context(|| format!("failed to create ACME account for {acme_url}"))?;
         let credentials = Credentials {
             acme_url: acme_url.to_string(),
             account_id: account.id().to_string(),
@@ -320,11 +320,9 @@ impl AcmeClient {
 
 impl AcmeClient {
     async fn authorize(&self, order: &mut Order, challenges: &mut Vec<Challenge>) -> Result<()> {
-        let authorizations = order
-            .authorizations()
-            .await
-            .context("failed to get authorizations")?;
-        for authz in &authorizations {
+        let mut authorizations = order.authorizations();
+        while let Some(authz) = authorizations.next().await {
+            let mut authz = authz.context("failed to get authorizations")?;
             match authz.status {
                 AuthorizationStatus::Pending => {}
                 AuthorizationStatus::Valid => continue,
@@ -332,14 +330,17 @@ impl AcmeClient {
             }
 
             let challenge = authz
-                .challenges
-                .iter()
-                .find(|c| c.r#type == ChallengeType::Dns01)
+                .challenge(ChallengeType::Dns01)
                 .context("no dns01 challenge found")?;
 
-            let Identifier::Dns(identifier) = &authz.identifier;
+            // The bare identifier, without any wildcard prefix: the TXT record for
+            // `*.example.com` is published under `_acme-challenge.example.com`.
+            let Identifier::Dns(identifier) = challenge.identifier().identifier else {
+                bail!("unsupported identifier type in authorization");
+            };
+            let identifier = identifier.clone();
 
-            let dns_value = order.key_authorization(challenge).dns_value();
+            let dns_value = challenge.key_authorization().dns_value();
             debug!("creating dns record for {identifier}");
             let acme_domain = format!("_acme-challenge.{identifier}");
             debug!("removing existing TXT record for {acme_domain}");
@@ -359,7 +360,6 @@ impl AcmeClient {
             challenges.push(Challenge {
                 id,
                 acme_domain,
-                url: challenge.url.clone(),
                 dns_value,
             });
         }
@@ -434,6 +434,31 @@ impl AcmeClient {
         Ok(())
     }
 
+    /// Tell the ACME server every pending dns-01 challenge is answerable.
+    ///
+    /// The TXT records are published first and verified for propagation, so this
+    /// is a second pass over the same authorizations: 0.8 dropped
+    /// `Order::set_challenge_ready(url)`, and `ChallengeHandle::set_ready()`
+    /// borrows the order, so the handle cannot be held across the DNS wait.
+    async fn set_challenges_ready(&self, order: &mut Order) -> Result<()> {
+        let mut authorizations = order.authorizations();
+        while let Some(authz) = authorizations.next().await {
+            let mut authz = authz.context("failed to get authorizations")?;
+            if authz.status != AuthorizationStatus::Pending {
+                continue;
+            }
+            let mut challenge = authz
+                .challenge(ChallengeType::Dns01)
+                .context("no dns01 challenge found")?;
+            debug!("setting challenge ready");
+            challenge
+                .set_ready()
+                .await
+                .context("failed to set challenge ready")?;
+        }
+        Ok(())
+    }
+
     async fn request_new_certificate_inner(
         &self,
         key: &str,
@@ -448,9 +473,7 @@ impl AcmeClient {
             .collect::<Vec<_>>();
         let mut order = self
             .account
-            .new_order(&NewOrder {
-                identifiers: &identifiers,
-            })
+            .new_order(&NewOrder::new(&identifiers))
             .await
             .context("failed to cread new order")?;
         let mut challenges_ready = false;
@@ -474,13 +497,9 @@ impl AcmeClient {
                     self.check_dns(challenges)
                         .await
                         .context("failed to check dns")?;
-                    for challenge in &*challenges {
-                        debug!("setting challenge ready for {}", challenge.url);
-                        order
-                            .set_challenge_ready(&challenge.url)
-                            .await
-                            .context("failed to set challenge ready")?;
-                    }
+                    self.set_challenges_ready(&mut order)
+                        .await
+                        .context("failed to set challenges ready")?;
                     challenges_ready = true;
                     continue;
                 }
@@ -489,7 +508,7 @@ impl AcmeClient {
                     debug!("order is ready, uploading CSR");
                     let csr = make_csr(key, domains)?;
                     order
-                        .finalize(csr.as_ref())
+                        .finalize_csr(csr.as_ref())
                         .await
                         .context("failed to finalize order")?;
                     continue;
@@ -511,6 +530,7 @@ impl AcmeClient {
                         r#type: None,
                         detail: None,
                         status: None,
+                        subproblems: Vec::new(),
                     });
                     bail!("order is invalid: {error}");
                 }
@@ -532,10 +552,11 @@ async fn find_error(order: &mut Order) -> Option<Problem> {
     if let Some(error) = order.state().error.as_ref() {
         return Some(error.clone());
     }
-    for auth in order.authorizations().await.ok()? {
-        for challenge in auth.challenges {
-            if let Some(error) = challenge.error {
-                return Some(error);
+    let mut authorizations = order.authorizations();
+    while let Some(Ok(authz)) = authorizations.next().await {
+        for challenge in &authz.challenges {
+            if let Some(error) = &challenge.error {
+                return Some(error.clone());
             }
         }
     }

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -643,3 +643,63 @@ fn ln_force(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod challenge_parsing_tests {
+    use instant_acme::{AuthorizationState, AuthorizationStatus, ChallengeType};
+
+    /// Let's Encrypt offers `dns-persist-01` alongside `dns-01`, and that
+    /// challenge object carries no `token`. Deserializing the authorization must
+    /// still succeed: `challenges` is one array, so a single unparseable entry
+    /// used to take the usable `dns-01` challenge down with it.
+    #[test]
+    fn an_authorization_survives_a_challenge_type_without_a_token() {
+        // Shape taken from a real acme-staging-v02 authorization response.
+        let authz = r#"{
+            "identifier": { "type": "dns", "value": "example.com" },
+            "status": "pending",
+            "expires": "2026-09-01T00:00:00Z",
+            "challenges": [
+                {
+                    "type": "dns-persist-01",
+                    "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall/1/a",
+                    "status": "pending"
+                },
+                {
+                    "type": "dns-01",
+                    "url": "https://acme-staging-v02.api.letsencrypt.org/acme/chall/1/b",
+                    "status": "pending",
+                    "token": "a-real-token"
+                }
+            ],
+            "wildcard": true
+        }"#;
+
+        let state: AuthorizationState = serde_json::from_str(authz)
+            .expect("authorization with an unknown challenge must parse");
+        assert_eq!(state.status, AuthorizationStatus::Pending);
+        assert_eq!(state.challenges.len(), 2);
+
+        let dns01 = state
+            .challenges
+            .iter()
+            .find(|c| c.r#type == ChallengeType::Dns01)
+            .expect("the dns-01 challenge must survive alongside the unknown one");
+        assert_eq!(dns01.token, "a-real-token");
+
+        // The tokenless challenge parses with an empty token rather than failing.
+        let other = state
+            .challenges
+            .iter()
+            .find(|c| c.r#type != ChallengeType::Dns01)
+            .expect("the unknown challenge is kept");
+        assert!(other.token.is_empty());
+
+        // A wildcard authorization still reports the bare name, which is what the
+        // `_acme-challenge.<name>` TXT record is published under.
+        let instant_acme::Identifier::Dns(name) = state.identifier().identifier else {
+            panic!("expected a dns identifier");
+        };
+        assert_eq!(name, "example.com");
+    }
+}

--- a/dstack/certbot/src/http_client.rs
+++ b/dstack/certbot/src/http_client.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use http::Request;
 use http_body_util::{BodyExt, Full};
-use instant_acme::{BytesResponse, HttpClient};
+use instant_acme::{BodyWrapper, BytesResponse, HttpClient};
 use reqwest::Client;
 use std::error::Error as StdError;
 use std::future::Future;
@@ -35,7 +35,7 @@ impl ReqwestHttpClient {
 impl HttpClient for ReqwestHttpClient {
     fn request(
         &self,
-        req: Request<Full<Bytes>>,
+        req: Request<BodyWrapper<Bytes>>,
     ) -> Pin<Box<dyn Future<Output = Result<BytesResponse, instant_acme::Error>> + Send>> {
         let client = self.client.clone();
         Box::pin(async move {


### PR DESCRIPTION
## Problem

Certificate issuance against Let's Encrypt fails outright. A gateway asking staging for `*.06rc0.kvin.wang` never gets a certificate:

```
WARN dstack_gateway::main_service: cert[06rc0.kvin.wang]: auto-renewal failed: failed to request new certificate

Caused by:
    0: failed to authorize
    1: failed to get authorizations
    2: failed to (de)serialize JSON: missing field `token` at line 16 column 5
```

Let's Encrypt now offers two DNS challenges on the same authorization:

```json
"challenges": [
  { "type": "dns-persist-01", "url": ".../chall/329528784/4019775194/a8DD1w", "status": "pending" },
  { "type": "dns-01",         "url": ".../chall/329528784/4019775194/HV5G9g", "status": "pending", "token": "..." }
]
```

`dns-persist-01` carries no `token`. `instant-acme` 0.7.2 declares `Challenge.token` as a plain `String` with no default (`instant-acme-0.7.2/src/types.rs:262`), so that entry fails to deserialize — and because `challenges` is a single array, the failure takes the whole authorization down with it, including the perfectly usable `dns-01` challenge sitting next to it.

The challenge *type* is not the problem: 0.7.2 already models unknown types as `ChallengeType::Unknown(String)`. It is the required `token` field on a sibling object that breaks the parse, which is why the error is `missing field` rather than `unknown variant`.

Nothing in certbot's own code is wrong, and no configuration avoids this: the failure happens inside the library while reading the authorization, before certbot ever picks a challenge.

This is not limited to staging. Once `dns-persist-01` reaches production, every gateway's issuance **and renewal** fails the same way, so deployments would start losing certificates as they expire rather than failing loudly on day one.

## Fix

Upgrade `instant-acme` 0.7.2 → 0.8.5, which fixes exactly this upstream:

```rust
/// Token for this challenge
///
/// Unknown `ChallengeType` instances may omit this field, leaving it empty.
#[serde(default)]
pub token: String,
```

certbot's challenge selection is unchanged — it still does `find(|c| c.r#type == ChallengeType::Dns01)` — it just no longer loses the array before getting there.

The 0.8 API required matching changes, all mechanical:

- `Account::from_credentials_and_http` / `create_with_http` → `Account::builder_with_http(..).from_credentials(..)` / `.create(..)`.
- `NewOrder` fields are private → `NewOrder::new(&identifiers)`.
- `Order::authorizations()` returns a stream instead of a `Vec`, so `authorize()` and `find_error()` iterate with `while let Some(..) = .next().await`.
- `Order::set_challenge_ready(url)` is gone; readiness now goes through `ChallengeHandle::set_ready()`. The handle borrows the order and cannot be held across the DNS-propagation wait, so setting challenges ready became a second pass over the authorizations (`set_challenges_ready`). The ordering is unchanged: publish every TXT record, verify propagation, then tell the server. Because the handle no longer exposes the challenge URL, the `url` field was dropped from certbot's own `Challenge` record, which only used it for this call and a log line.
- `Order::finalize(csr)` → `finalize_csr(csr)`; `Problem` gained `subproblems`.
- `HttpClient::request` now takes `Request<BodyWrapper<Bytes>>`. `BodyWrapper<Bytes>` implements `http_body::Body`, so the existing `.collect()` works unchanged.

One subtlety worth calling out: the identifier now arrives as `AuthorizedIdentifier`, whose `Display` renders a wildcard authorization as `*.example.com`. Formatting that into `_acme-challenge.{}` would publish the record at `_acme-challenge.*.example.com`. The code takes the bare `identifier` field instead, preserving 0.7's behaviour.

## Verification

**The bug, isolated.** Same authorization JSON, same library, two versions:

| `instant-acme` | Result |
| --- | --- |
| 0.7.2 | `FAILED: missing field 'token' at line 5 column 83` |
| 0.8.5 | `PARSED ok, 2 challenges` |

The 0.7.2 message is character-for-character the one from the gateway log above, which is what ties this minimal case to the real failure rather than to something merely similar.

**Regression test** (`challenge_parsing_tests`, shaped from a real acme-staging-v02 response) asserts that an authorization containing `dns-persist-01` parses, that both challenges survive, that `dns-01` keeps its token, that the tokenless challenge yields an empty token rather than an error, and that a wildcard authorization still reports the bare name.

Note on its scope: this test cannot be run against 0.7.2 as a counterfactual — `AuthorizationState` did not exist there (it was `Authorization`), so the crate does not compile at all on the old version. The counterfactual above is what proves the failure; the test exists to stop a future downgrade from silently reintroducing it.

**Build/lint:** `cargo check --workspace`, `cargo test -p certbot`, `cargo fmt --check`, and `cargo clippy -p certbot -p dstack-gateway -- -D warnings` all pass.

**Not yet covered:** a live issuance against Let's Encrypt staging through a deployed gateway. The image build for that was still running when this was opened; I'll add the result as a comment. Everything above is offline evidence.