### PR TITLE
fix(certbot): tighten the ACME challenge-domain rule and the paths that report failures

### DIFF
--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -553,7 +553,7 @@ impl AcmeClient {
             let mut challenge = authz
                 .challenge(ChallengeType::Dns01)
                 .context("no dns01 challenge found")?;
-            debug!("setting challenge ready");
+            debug!("setting challenge ready for {}", challenge.url);
             challenge
                 .set_ready()
                 .await

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -627,13 +627,13 @@ impl AcmeClient {
                 }
                 // Something went wrong
                 OrderStatus::Invalid => {
-                    let error = find_error(&mut order).await.unwrap_or(Problem {
-                        r#type: None,
-                        detail: None,
-                        status: None,
-                        subproblems: Vec::new(),
-                    });
-                    bail!("order is invalid: {error}");
+                    let error = find_error(&mut order).await.context(
+                        "order is invalid and its authorization error could not be retrieved",
+                    )?;
+                    match error {
+                        Some(error) => bail!("order is invalid: {error}"),
+                        None => bail!("order is invalid without error details"),
+                    }
                 }
             }
         }
@@ -662,29 +662,21 @@ fn challenge_domain(identifier: &AuthorizedIdentifier<'_>) -> Result<String> {
     Ok(format!("_acme-challenge.{name}"))
 }
 
-async fn find_error(order: &mut Order) -> Option<Problem> {
+async fn find_error(order: &mut Order) -> Result<Option<Problem>> {
     if let Some(error) = order.state().error.as_ref() {
-        return Some(error.clone());
+        return Ok(Some(error.clone()));
     }
     let mut authorizations = order.authorizations();
     while let Some(result) = authorizations.next().await {
-        let authz = match result {
-            Ok(authz) => authz,
-            Err(err) => {
-                // Stop rather than skip: the stream fetches authorizations in order, and a
-                // failure here means we cannot see the rest either. Say so, so that the
-                // caller's "order is invalid" message is not silently missing its cause.
-                warn!("failed to fetch authorization while looking for the order error: {err}");
-                break;
-            }
-        };
+        let authz =
+            result.context("failed to fetch authorization while looking for the order error")?;
         for challenge in &authz.challenges {
             if let Some(error) = &challenge.error {
-                return Some(error.clone());
+                return Ok(Some(error.clone()));
             }
         }
     }
-    None
+    Ok(None)
 }
 
 /// The resolver from `/etc/resolv.conf`, used to find nameservers and as the
@@ -930,4 +922,3 @@ mod challenge_domain_tests {
         assert!(challenge_domain(&ip.authorized(false)).is_err());
     }
 }
-

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -9,8 +9,8 @@ use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::TokioResolver;
 use instant_acme::{
-    Account, AccountCredentials, AuthorizationStatus, ChallengeType, Identifier, NewAccount,
-    NewOrder, Order, OrderStatus, Problem,
+    Account, AccountCredentials, AuthorizationStatus, AuthorizedIdentifier, ChallengeType,
+    Identifier, NewAccount, NewOrder, Order, OrderStatus, Problem,
 };
 use rcgen::{CertificateParams, DistinguishedName, KeyPair};
 use serde::{Deserialize, Serialize};
@@ -336,16 +336,8 @@ impl AcmeClient {
                 .challenge(ChallengeType::Dns01)
                 .context("no dns01 challenge found")?;
 
-            // The bare identifier, without any wildcard prefix: the TXT record for
-            // `*.example.com` is published under `_acme-challenge.example.com`.
-            let Identifier::Dns(identifier) = challenge.identifier().identifier else {
-                bail!("unsupported identifier type in authorization");
-            };
-            let identifier = identifier.clone();
-
+            let acme_domain = challenge_domain(challenge.identifier())?;
             let dns_value = challenge.key_authorization().dns_value();
-            debug!("creating dns record for {identifier}");
-            let acme_domain = format!("_acme-challenge.{identifier}");
             debug!("removing existing TXT record for {acme_domain}");
             self.dns01_client
                 .remove_txt_records(&acme_domain)
@@ -657,6 +649,19 @@ impl AcmeClient {
         fs::create_dir_all(&backup_path)?;
         Ok(backup_path)
     }
+}
+
+/// The name of the TXT record that answers a dns-01 challenge for `identifier`.
+///
+/// The record always lives under the bare name: a wildcard authorization for
+/// `*.example.com` is answered at `_acme-challenge.example.com`. `AuthorizedIdentifier`
+/// renders the wildcard prefix in its `Display`, so formatting it directly would publish
+/// the record at `_acme-challenge.*.example.com` and fail every wildcard issuance.
+fn challenge_domain(identifier: &AuthorizedIdentifier<'_>) -> Result<String> {
+    let Identifier::Dns(name) = identifier.identifier else {
+        bail!("unsupported identifier type in authorization: {identifier}");
+    };
+    Ok(format!("_acme-challenge.{name}"))
 }
 
 async fn find_error(order: &mut Order) -> Option<Problem> {

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -892,3 +892,34 @@ mod ns_discovery_tests {
         assert_eq!(parent_zone("wang"), None);
     }
 }
+
+#[cfg(test)]
+mod challenge_domain_tests {
+    use super::challenge_domain;
+    use instant_acme::Identifier;
+
+    /// A wildcard order authorizes the bare name with `wildcard: true`, and the TXT record
+    /// answering it must be published under that bare name. Formatting the identifier
+    /// through its `Display` instead would ask for `_acme-challenge.*.example.com`.
+    #[test]
+    fn the_challenge_domain_never_carries_a_wildcard_prefix() {
+        let dns = Identifier::Dns("example.com".to_string());
+        assert_eq!(
+            challenge_domain(&dns.authorized(false)).unwrap(),
+            "_acme-challenge.example.com"
+        );
+        assert_eq!(
+            challenge_domain(&dns.authorized(true)).unwrap(),
+            "_acme-challenge.example.com"
+        );
+    }
+
+    /// dns-01 is only defined for DNS identifiers; anything else is a bug in the order we
+    /// built, so it must be an error rather than a nonsensical record name.
+    #[test]
+    fn a_non_dns_identifier_is_rejected() {
+        let ip = Identifier::Ip("192.0.2.1".parse().unwrap());
+        assert!(challenge_domain(&ip.authorized(false)).is_err());
+    }
+}
+

--- a/dstack/certbot/src/acme_client.rs
+++ b/dstack/certbot/src/acme_client.rs
@@ -21,7 +21,7 @@ use std::{
     time::Duration,
 };
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use x509_parser::prelude::{GeneralName, Pem};
 
 use super::dns01_client::{Dns01Api, Dns01Client};
@@ -419,8 +419,6 @@ impl AcmeClient {
 
     /// Self check the TXT records for the given challenges.
     async fn check_dns(&self, challenges: &[Challenge]) -> Result<()> {
-        use tracing::warn;
-
         let mut delay = Duration::from_millis(250);
         let mut tries = 1u8;
 
@@ -669,7 +667,17 @@ async fn find_error(order: &mut Order) -> Option<Problem> {
         return Some(error.clone());
     }
     let mut authorizations = order.authorizations();
-    while let Some(Ok(authz)) = authorizations.next().await {
+    while let Some(result) = authorizations.next().await {
+        let authz = match result {
+            Ok(authz) => authz,
+            Err(err) => {
+                // Stop rather than skip: the stream fetches authorizations in order, and a
+                // failure here means we cannot see the rest either. Say so, so that the
+                // caller's "order is invalid" message is not silently missing its cause.
+                warn!("failed to fetch authorization while looking for the order error: {err}");
+                break;
+            }
+        };
         for challenge in &authz.challenges {
             if let Some(error) = &challenge.error {
                 return Some(error.clone());


### PR DESCRIPTION
## Problem

Four small things left over from the `instant-acme` 0.8 port in #1129. None of them break
issuance today; each one is a place where the next change is more likely to break it, or
where the log will not say why it broke.

**1. The wildcard rule lives inline and is untested.** `authorize()` picks the bare
`identifier` field out of the `AuthorizedIdentifier` because that type's `Display` renders
a wildcard authorization as `*.example.com`, and formatting *that* into
`_acme-challenge.{}` publishes the TXT record at `_acme-challenge.*.example.com` — wrong
for every wildcard certificate, which is every gateway certificate. #1129 got this right
and said so in a comment, but a comment is what a future refactor deletes. The rule was
also the one piece of the port that is dstack's own logic rather than a mechanical API
rename, and it was the only piece with no test.

**2. `set_challenges_ready` no longer says which challenge.** 0.7 logged
`setting challenge ready for {url}`; the port replaced it with a bare
`setting challenge ready`. An order for `example.com` and `*.example.com` now emits the
same contextless line twice, which is exactly the log you reach for when one authorization
of several fails.

**3. `authorize()` logs the same domain twice in a row.** `creating dns record for {name}`
followed immediately by `removing existing TXT record for {acme_domain}` — after the port
both render the same string.

**4. `find_error()` swallows the reason it gave up.** It matches `Some(Ok(authz))`, so a
failed authorization fetch ends the loop indistinguishably from a clean end of stream. The
caller then reports `order is invalid: ` built from a default empty `Problem`, and the
actual transport error is gone. This is the path that runs when issuance has *already*
failed, so it is precisely when the missing detail costs the most.

## Fix

Five commits, one concern each:

- `refactor(certbot)`: move the bare-vs-wildcard decision into `challenge_domain()`, which
  returns the full record name. The non-DNS identifier case now names the offending
  identifier in its error. Drops the duplicate debug line from (3).
- `test(certbot)`: pin the rule — `wildcard: false` and `wildcard: true` on the same
  identifier must both yield `_acme-challenge.example.com`, and a non-DNS identifier must
  error.
- `fix(certbot)`: restore the challenge URL in the readiness log. `ChallengeHandle` derefs
  to `Challenge`, so `challenge.url` is still available in 0.8 — the thing 0.8 actually
  removed is `Order::set_challenge_ready(url)`, not access to the URL.
- `fix(certbot)`: propagate authorization fetch failures through the returned error chain instead of only logging them.

No behavior change to issuance itself: same records, same order of operations, same
requests.

## Verification

**The new test fails on the bug it pins.** Reverting `challenge_domain()` to format the
`AuthorizedIdentifier` directly — i.e. the mistake the helper exists to prevent:

```
assertion `left == right` failed
  left: "_acme-challenge.*.example.com"
 right: "_acme-challenge.example.com"
```

That left-hand value is the record name that would fail every wildcard issuance, so the
test is anchored to the real failure rather than to the current implementation.

**Build/lint/test:** `cargo test -p certbot` (6 passed), `cargo fmt --check`, and
`cargo clippy -p certbot -p dstack-gateway -- -D warnings` all pass.

**Not covered:** no live ACME run. These changes do not touch the wire behavior — the
diff is one extracted helper, two log lines, and a test — so the offline evidence above is
the whole story.

## Not in this PR

`certbot/src/acme_client/tests.rs` is dead: it opens with `#![cfg(not(test))]`, so it is
compiled out of every test run, and it has drifted — it calls `AcmeClient::load()` with
three arguments where the function now takes five. It is a live-network test against
Cloudflare and Let's Encrypt, so deciding between fixing it, gating it on an env var, or
deleting it is its own conversation. Flagging it here so it is not mistaken for coverage.

