### PR TITLE
docs: add a release-candidate testing runbook

### DIFF
--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -1,0 +1,313 @@
+# Release-candidate testing runbook
+
+What to do, in order, to exercise a dstack release candidate on real TEE
+hardware — and the specific things that cost time the last round, so they cost
+nothing the next one.
+
+Written after testing 0.6.0-rc0 on an Intel TDX host and an AMD SEV-SNP host.
+Assumes fresh machines: nothing here depends on state left behind by that run.
+
+---
+
+## 1. Confirm the host can actually do what you think
+
+Get this wrong and you will scope the whole test around a capability you have,
+or skip one you don't.
+
+### Intel TDX host
+
+```bash
+cat /sys/module/kvm_intel/parameters/tdx      # expect: Y
+grep -o -m1 tdx_host_platform /proc/cpuinfo   # expect: tdx_host_platform
+systemctl is-active qgsd pccs                 # expect: active active
+```
+
+**`/dev/tdx_guest` does not exist on a TDX host and its absence means nothing.**
+That device is the *guest*-side attestation interface; it appears inside a TD,
+not on the machine running them. Checking for it will tell you a perfectly good
+TDX host has no TDX. Use the KVM module parameter and the CPU flag.
+
+`qgsd` is what turns a TD's attestation request into a signed quote, and `pccs`
+caches the Intel collateral used to verify it. Without both, CVMs boot but
+cannot obtain keys.
+
+### AMD SEV-SNP host
+
+```bash
+cat /sys/module/kvm_amd/parameters/sev_snp    # expect: Y
+grep -o -m1 sev_snp /proc/cpuinfo             # expect: sev_snp
+ls -l /dev/sev                                # must exist AND be accessible
+qemu-system-x86_64 -object help | grep sev-snp-guest
+lsmod | grep -E '^vhost_vsock|vmw_vsock_vmci'
+```
+
+Three host-level problems each blocked us for a while:
+
+- **`vhost_vsock` not loaded.** The VMM binds its host API on vsock CID 2 and
+  fails with `Cannot assign requested address (os error 99)`. Fix: `sudo modprobe
+  vhost_vsock`. Does not survive reboot — add `/etc/modules-load.d/` to persist.
+
+- **VMware's vsock transport hijacking the stack.** If `vmw_vsock_vmci_transport`
+  is loaded (it often is, by default), it claims the vsock transport and CID 2
+  binding still fails even with `vhost_vsock` present. Fix: `sudo modprobe -r
+  vmw_vsock_vmci_transport vmw_vmci`. It comes back on reboot — blacklist to
+  persist. This one is easy to misdiagnose as a dstack bug.
+
+- **`/dev/sev` is `root:root 0600` out of the box** and your user is probably not
+  in `kvm`. QEMU then fails with `Could not access KVM kernel module: Permission
+  denied`. Fix: `sudo usermod -aG kvm $USER` and `sudo chown root:kvm /dev/sev &&
+  sudo chmod 660 /dev/sev`. The chmod does not survive reboot; a udev rule does.
+
+**After fixing group membership, restart the supervisor.** `dstack-vmm` starts
+`supervisor` detached, and a supervisor started before the `usermod` keeps the old
+group set. QEMU is forked from it, so it still cannot open `/dev/kvm` even though
+your shell can. Symptom: `id` shows `kvm`, QEMU still says permission denied.
+Check with `grep ^Groups /proc/$(pgrep -f bin/supervisor)/status`.
+
+### QEMU version
+
+dstack computes measurements against an ACPI compatibility profile keyed on the
+QEMU major version (`dstack/crates/qemu-acpi/src/profile.rs`). 8.x, 9.x and 10.x
+are all mapped. Check the version resolves to a supported profile *before*
+installing anything, or you will build an environment that cannot produce correct
+measurements.
+
+---
+
+## 2. Pick your disks deliberately
+
+Check the mount that will actually hold the data, not `/`:
+
+```bash
+df -h /home ~/.dstack /var/lib/docker
+```
+
+On one host `/` had 12 GB free while `/home` sat on a 7 TB array. Looking only at
+`/` produced a wrong "we are too tight on disk to use the documented `--disk 50G`"
+conclusion and a plan built around shrinking things unnecessarily.
+
+Keep the VMM's `run_path`, `temp_dir` and the image directory on the large
+volume. CVM disks and temp files land there, and `/tmp` on a small root
+filesystem will fill up mid-test.
+
+---
+
+## 3. Two traps that can reach outside the test
+
+**`~/.dstack-vmm/config.json` may point `vmm-cli.py` at a production VMM.** It is
+the CLI's default `--url`. On both machines used last time it pointed at a live
+deployment with credentials, so any `deploy` that omitted `--url` would have
+landed there. **Pass `--url http://127.0.0.1:<port>` on every single invocation.**
+
+**Component tags publish to Docker Hub.** `kms-v*`, `gateway-v*`, `verifier-v*`
+and friends trigger release workflows that push to `${DOCKERHUB_ORG}` and cut
+GitHub releases. If you only want images in a private registry, build locally and
+push by hand — do not push those tags.
+
+---
+
+## 4. Cutting the release
+
+- Version lives in **four** places with no tool keeping them in sync:
+  `dstack/Cargo.toml` (`workspace.package.version`), `os/mkosi/versions.env`
+  (`DSTACK_VERSION`), `os/mkosi/mkosi.conf` (`ImageVersion`), and
+  `os/yocto/.../dstack.conf` (`DISTRO_VERSION`). Regenerate `Cargo.lock` after.
+  Only the first two are cross-checked (by `os/mkosi/tests/acceptance.sh`); the
+  Yocto one is checked by nothing.
+- **Commit messages must be conventional commits** — `prek.toml` enforces it at
+  commit-msg stage. The historical `Bump version to X` style now fails.
+- `release/**` branches are protected against **deletion and non-fast-forward**.
+  Rebase-and-force will be rejected. Merge instead. This also means the branch
+  name is claimed permanently once pushed.
+- **The container Dockerfiles clone from GitHub and check out `DSTACK_REV`** —
+  they do not use your working tree. Push the commit before building images, or
+  you will build something other than what you are testing.
+- Pre-run the release job's own validation locally before tagging:
+
+  ```bash
+  TAG=mkosi-os-v<version>
+  echo "$TAG" | grep -Eq '^mkosi-os-v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
+  source os/mkosi/versions.env && [ "${TAG#mkosi-os-v}" = "$DSTACK_VERSION" ]
+  ```
+
+  The release job also requires `metadata.json`'s `git_revision` to equal the
+  tagged commit and rejects a `-modified` suffix, so the tag must sit on the exact
+  commit that was built from a clean tree.
+
+---
+
+## 5. Bring-up order
+
+KMS first, then gateway, then the app. Each needs the previous one's identity.
+
+1. **VMM.** Copy `dstack/vmm/vmm.toml` and edit: `address` **and** `port` (the
+   `check-config` subcommand requires both at top level), `run_path`, `temp_dir`,
+   `[image] path` (it is commented out by default), `platform = "tdx"` or
+   `"amd-sev-snp"`, a `cid_start` that avoids running VMs, `[supervisor]` paths,
+   and `[cvm.port_mapping]` — **enabled, with a range covering every port you
+   intend to map.** A port outside the range fails the deploy with `Port mapping
+   is not allowed for tcp:<port>`. Validate with `dstack-vmm -c <cfg>
+   check-config` before starting.
+
+2. **KMS as a CVM** with `--local-key-provider` (needs a
+   gramine-sealing-key-provider on the host, default `127.0.0.1:3443`). The
+   simplest authorization that releases keys without a chain is
+   `[core.auth_api] type = "dev"` with `gateway_app_id = "any"` — no extra
+   containers, unlike the on-chain compose which needs a Helios light client.
+   Keep `[core.image] verify = true`.
+
+3. **Gateway as a CVM** with `--kms`. Internal ports are RPC 8000, admin 8001,
+   WireGuard 51820/udp, proxy 443.
+
+4. **App CVM** with `--kms --gateway`.
+
+### Certificate identity across hosts
+
+If CVMs on more than one machine will talk to the KMS, give it a DNS name rather
+than an IP. The RPC certificate's only SAN is `auto_bootstrap_domain`, and a
+local CVM dialing `10.0.2.2` while a remote one dials the public IP cannot both
+match. A wildcard A record covering `kms.<domain>` and `gw.<domain>` solves it in
+one step.
+
+### ACME is configured at runtime, not in a file
+
+In 0.6.0 certbot config lives in the gateway's KvStore, reached through the admin
+API — `Admin.SetCertbotConfig`, `Admin.CreateDnsCredential`,
+`Admin.AddZtDomain`. The `CF_API_TOKEN` and `ACME_STAGING` variables in
+`gateway/dstack-app/deploy-to-vmm.sh` are **vestigial and unused**; setting them
+does nothing.
+
+**Set `acme_url` to staging explicitly.** The default is Let's Encrypt
+*production*, and the rate limits there are unforgiving of a test loop:
+
+```
+https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+`AddZtDomain` kicks off issuance asynchronously and takes a lock. A subsequent
+explicit `RenewZtDomainCert` returns `{"renewed":false}` immediately while that
+is in flight — that is the lock, not a failure. Watch the gateway container log
+instead of the return value.
+
+---
+
+## 6. What to verify, and what each check actually proves
+
+| Check | Why it is worth doing |
+|---|---|
+| `sha256sum -c sha256sum.txt`, then `sha256(sha256sum.txt) == digest.txt` | Confirms the artifact matches its own manifest |
+| `dstack-mr tdx-measurement-cbor <dir> \| cmp - measurement.tdx.cbor` | Confirms the published measurements are *derivable from the image*, not merely asserted |
+| Boot all three CVMs to `boot_progress: done` | `done` is only reachable after `GetAppKey` succeeds, so it implies attestation worked |
+| `Admin.Status` lists the app with a WireGuard IP | Gateway verified the CVM's RA-TLS quote |
+| **A rejected quote in the KMS log** | The one check that proves verification is not a no-op |
+| `curl` through the proxy to the app | End to end, including TLS termination and routing |
+| `/prpc/v1/Info` and `/prpc/Worker.Info` both answer | v1 works and pre-0.6 clients are not broken |
+
+That fifth row is the one people skip. A run where every quote is accepted cannot
+distinguish "verification passed" from "verification never ran". Last time the
+AMD CVMs supplied it for free — 6 grants and 7 rejections in the same KMS log —
+but if everything passes, arrange a failure deliberately.
+
+**`dstack-mr` binary name collision:** `-p dstack-mr` and `-p dstack-mr-cli` both
+produce `target/release/dstack-mr` and overwrite each other. Build only
+`-p dstack-mr` for `measure-os` / `inspect-measurement` / `*-measurement-cbor`.
+
+**Guest API v1 takes bare method names.** `/prpc/v1/Info`, not
+`/prpc/v1/Worker.Info`. The v0 and legacy mounts use `trim: "Worker."`, which
+*accepts* the prefixed form; v1 has no trim, so the prefix 404s. A 404 there is
+your URL, not a broken agent.
+
+---
+
+## 7. Reading DNS evidence without fooling yourself
+
+Three ways to misread a DNS result, all of which happened:
+
+- **`dig +short` prints nothing for both NODATA and timeout.** Those are the two
+  hypotheses you are usually trying to separate. Use full `dig` output and read
+  `status:` and the `SERVER:` line.
+- **certbot deletes the challenge TXT record after a successful issuance.** Its
+  absence later is cleanup, not a network fault.
+- **Cloudflare takes longer than ten seconds to serve a new record from its own
+  authoritative edge.** An immediate query after creating a record can legitimately
+  return nothing.
+
+When testing whether an external service is reachable from an odd vantage point,
+**always run the same request against a known-good target through the same path.**
+Four public CORS proxies were tried to get an independent view of AMD KDS; every
+one returned the identical error for `github.com` as for the target. Without the
+control, those errors read as evidence about AMD.
+
+---
+
+## 8. AMD SEV-SNP: provision host certificates first
+
+The most valuable thing to do before an AMD run.
+
+Verification needs the ASK and VCEK certificates. By default they are fetched
+from `https://kdsintf.amd.com`, which is a **single global endpoint with no
+mirror**, is aggressively rate-limited (one identical request per ~10s), and was
+completely unreachable during the last round — TCP timeouts and 100% ICMP loss
+from five vantage points across four autonomous systems and two continents, while
+every other external service answered normally. DNS was healthy and unchanged
+throughout, so this was the service, not a migration.
+
+dstack already supports the alternative: `normalize_kernel_cert_table` reads ASK
+and VCEK from the SNP extended report's certificate table, so a host that has
+been provisioned needs no KDS access at all. AMD's own specification recommends
+caching at the host for exactly this reason.
+
+**So: provision the host certificate chain (`snphost` / `sevctl`) as part of
+setup.** It is a one-time fetch and it removes an unreliable dependency from
+every subsequent run. Note the bootstrap problem — obtaining the VCEK to install
+requires KDS access once, so do it from a network that can reach it and carry the
+file over.
+
+A related note for whoever touches this code: the ARK is already compiled in, and
+the ARK fetched from KDS is discarded (`let (_fetched_ark, ask) = ...`). The
+network request exists only to obtain the ASK, which is equally static per product
+family. Bundling it would remove the `cert_chain` request entirely, leaving only
+the per-chip VCEK.
+
+---
+
+## 9. Fixed in 0.6.0-rc0 testing — do not re-diagnose
+
+- **KMS image had no CA certificates** and could not start at all
+  ([#1128](https://github.com/Dstack-TEE/dstack/pull/1128)). Failed at
+  `AttestationVerifier::load` with `No CA certificates were loaded from the
+  system`, because `reqwest` builds its clients eagerly and the AMD KDS client is
+  constructed even on an Intel-only host.
+- **ACME issuance failed outright** ([#1129](https://github.com/Dstack-TEE/dstack/pull/1129)).
+  Let's Encrypt now offers `dns-persist-01` alongside `dns-01`; it carries no
+  `token`, and `instant-acme` 0.7.2 required that field, so the whole
+  authorization failed to deserialize and took the usable challenge with it.
+- **DNS self-check could never pass on some zones**
+  ([#1130](https://github.com/Dstack-TEE/dstack/pull/1130)). The check queried the
+  record immediately after creating it, cached the resulting NXDOMAIN at the
+  recursive resolver for the zone's SOA minimum (1800s is common), and then
+  retried inside a 300s budget against that cache.
+- **`prek` CI failed on any newly created `release/**` branch**
+  ([#1127](https://github.com/Dstack-TEE/dstack/pull/1127)). A branch-creating
+  push reports an all-zero `before` SHA, making the diff range invalid.
+
+If you hit any of these on a build that predates the fixes, that is why.
+
+---
+
+## 10. Housekeeping
+
+- **Keep an inventory as you go**: CVMs, ufw rules, DNS records, host module and
+  permission changes, registry tags. Comment ufw rules so they can be found later
+  (`ufw allow 9350/tcp comment "dstack rc test"`).
+- Host changes from section 1 (`/dev/sev` mode, `vhost_vsock`, the VMware vsock
+  blacklist) **revert on reboot**. Decide whether to persist them; either is fine,
+  but know which you chose.
+- Remove test ZtDomains and stray `_acme-challenge` TXT records when finished.
+- When doing an A/B across dependency versions, **restore `Cargo.lock` along with
+  `Cargo.toml`.** Editing the manifest and running cargo rewrites the lockfile;
+  restoring only the manifest leaves them inconsistent. CI will not catch it
+  unless a step passes `--locked`.
+- Run any A/B with both arms on the current build. Reusing an earlier failure log
+  as the control is tempting and usually invalid — the image, the credentials and
+  the certificate state have all moved since.


### PR DESCRIPTION
## Problem

Testing 0.6.0-rc0 on real TDX and SEV-SNP hardware cost more time in detours than in testing. Most of them were not hard problems — they were things that are obvious once seen and invisible beforehand:

- `/dev/tdx_guest` does not exist on a TDX *host*, so checking for it reports a perfectly good host as having no TDX. I concluded a machine could not run the test, and scoped around a limitation that was not there.
- On the SEV-SNP host, `vhost_vsock` was not loaded *and* VMware's vsock transport was claiming the stack, so the VMM could not bind its host API. Neither is a dstack problem, and both look like one.
- `/dev/sev` is root-only by default; after fixing group membership, a detached supervisor still held the old groups, so QEMU kept failing after the fix appeared to work.
- `df -h /` said 12 GB free while `/home` was a 7 TB array, which produced a wrong "we are too tight on disk" plan.

None of this is written down anywhere, and the next person on different hardware starts from zero.

## What this adds

`docs/rc-testing-runbook.md` — the order to do things in, and the specific traps, with the commands that actually work.

Beyond host setup it covers the parts that are easy to get wrong or dangerous to get wrong:

- **`~/.dstack-vmm/config.json` defaults `vmm-cli.py` at a production VMM.** On both machines used last round it pointed at a live deployment with credentials. Any `deploy` omitting `--url` lands there. This one is worth reading before touching anything.
- Which tags publish to Docker Hub, so a private-registry test does not accidentally publish.
- That the container Dockerfiles clone from GitHub rather than the working tree, so the commit must be pushed before images are built.
- That `release/**` is protected against force-push and deletion, so a rebase-based workflow will be rejected.
- ACME config lives in the KvStore behind the admin API in 0.6.0; the `CF_API_TOKEN` and `ACME_STAGING` variables still present in `gateway/dstack-app/deploy-to-vmm.sh` are vestigial and do nothing.
- The four places the version number lives, only two of which are cross-checked.

## Two sections worth reading even if the rest is skimmed

**What each verification actually proves.** A run where every quote is accepted cannot distinguish "verification passed" from "verification never ran". Last round supplied the negative case by accident — the AMD CVMs produced 7 rejections alongside 6 grants in the same KMS log — but if everything passes, the rejection needs to be arranged deliberately. The table says what each check buys.

**How to read DNS evidence without fooling yourself.** `dig +short` prints nothing for both NODATA and timeout, which are usually the two hypotheses being separated; certbot deletes the challenge record after issuing, so its later absence is cleanup rather than a fault; and Cloudflare needs more than ten seconds to serve a new record from its own authoritative edge. Each of these produced a wrong reading during the last round before being caught. The section also covers running a control through the same path as the test — four public proxies were tried for an independent view of AMD KDS and every one returned the same error for `github.com` as for the target, which without the control reads as evidence about AMD.

## AMD SEV-SNP

Section 8 recommends provisioning host certificates as part of setup rather than relying on AMD KDS. `kdsintf.amd.com` is a single global endpoint with no mirror, is aggressively rate-limited, and was entirely unreachable during this round — TCP timeouts and 100% ICMP loss from five vantage points across four autonomous systems and two continents, while everything else answered normally and DNS stayed healthy. dstack already reads ASK and VCEK from the SNP extended report's certificate table, and AMD's own specification recommends host-side caching, so a provisioned host removes the dependency entirely.

## Verification

`prek run --files docs/rc-testing-runbook.md` passes. `docs/**/*.md` is already covered by `REUSE.toml`, so no licensing registration was needed.

Every command in the document was run during the 0.6.0-rc0 round; the host-capability checks in section 1 were re-run against both hosts while writing it rather than transcribed from memory.