### PR TITLE
docs: cover gateway clustering and the proxy modes left untested

### DIFF
--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -191,7 +191,80 @@ instead of the return value.
 
 ---
 
-## 6. What to verify, and what each check actually proves
+## 6. Gateway cluster
+
+Worth doing: it exercises WaveKV replication, which a single node never touches
+even though sync is running.
+
+**Sync turns itself on when `NODE_ID > 0`** (`entrypoint.sh`:
+`SYNC_ENABLED=$([ "$NODE_ID" -gt 0 ] && ...)`). A single node with `NODE_ID=1` is
+therefore already running WaveKV as local storage — you will see `WaveKV:
+detected certificate changes` in its log — but nothing has ever replicated. Do
+not read those lines as evidence that clustering works.
+
+### Every node must deploy under the same `--name`
+
+Cluster members authenticate each other over RA-TLS and **require the peer's
+`app_id` to equal their own** (`gateway/src/kv/https_client.rs`). That is
+deliberate: it keeps WaveKV replication inside instances of one authorized
+compose rather than letting any CVM join.
+
+`app_id` is the compose hash, and **`name` is part of it**. Deploying a second
+node under a different name produces:
+
+```
+bootnode discovery retry failed: failed to fetch peers from bootnode
+  app_id mismatch: expected c90cc75a6ceb…, got aa04b7bd7875…
+```
+
+which looks like a networking or trust problem and is neither. Per-node values —
+`NODE_ID`, `WG_IP`, `WG_RESERVED_NET`, `WG_CLIENT_RANGE`, `WG_ENDPOINT`,
+`MY_URL`, `BOOTNODE_URL`, `ADMIN_API_TOKEN` — belong in `--env-file`, whose
+**values are encrypted at deploy time and are not part of the compose hash**;
+only the key names are recorded, as `allowed_envs`.
+
+So: same `--docker-compose`, same `--name`, different `--env-file`. Confirm
+before deploying —
+
+```bash
+sha256sum node1-app-compose.json node2-app-compose.json   # must match
+```
+
+### Allocate per-node resources
+
+WireGuard subnets follow `SUBNET_INDEX`: node *n* gets `10.8.<n*64>.0/18`, so
+index 0 is `10.8.0.0/18` and index 1 is `10.8.64.0/18`. Overlapping them breaks
+routing in ways that are tedious to unpick. Each node also needs its own RPC,
+admin, proxy and WireGuard ports, and its own `MY_URL` hostname — a wildcard A
+record covers `gw.<domain>` and `gw2.<domain>` without extra DNS work.
+
+`BOOTNODE_URL` only speeds up discovery; peers are also found through incoming
+connections.
+
+### What proves the cluster actually works
+
+Peer lists agreeing is the weakest of the three checks. Do all of them:
+
+```bash
+# 1. Both nodes list both peers
+curl -H "Authorization: Bearer $TOK" .../prpc/Admin.Status?json | jq '.nodes'
+
+# 2. The app registered on node1 appears on node2 — registration state replicated
+curl -H "Authorization: Bearer $TOK2" .../prpc/Admin.Status?json | jq '.hosts'
+
+# 3. node2 serves the wildcard certificate it never requested — cert replicated
+echo | openssl s_client -connect 127.0.0.1:<node2-proxy> \
+  -servername "<instance>-80.<domain>" | openssl x509 -noout -issuer -subject
+
+# 4. Traffic through node2 reaches an app whose tunnel terminates on node1
+curl -k --connect-to "<instance>-80.<domain>:<node2-proxy>:127.0.0.1:<node2-proxy>" \
+  "https://<instance>-80.<domain>:<node2-proxy>/"
+```
+
+The fourth is the one that matters: it shows what replicated is usable routing
+state, not just metadata that happens to agree.
+
+## 7. What to verify, and what each check actually proves
 
 | Check | Why it is worth doing |
 |---|---|
@@ -200,13 +273,36 @@ instead of the return value.
 | Boot all three CVMs to `boot_progress: done` | `done` is only reachable after `GetAppKey` succeeds, so it implies attestation worked |
 | `Admin.Status` lists the app with a WireGuard IP | Gateway verified the CVM's RA-TLS quote |
 | **A rejected quote in the KMS log** | The one check that proves verification is not a no-op |
-| `curl` through the proxy to the app | End to end, including TLS termination and routing |
+| `curl` through the proxy to the app | End to end, but only for one of several proxy modes — see below |
 | `/prpc/v1/Info` and `/prpc/Worker.Info` both answer | v1 works and pre-0.6 clients are not broken |
 
 That fifth row is the one people skip. A run where every quote is accepted cannot
 distinguish "verification passed" from "verification never ran". Last time the
 AMD CVMs supplied it for free — 6 grants and 7 rejections in the same KMS log —
 but if everything passes, arrange a failure deliberately.
+
+### One `curl` does not cover the proxy
+
+Ingress maps as `<id>[-[<port>][s|g]].<base_domain>`, and the suffixes select
+genuinely different code paths:
+
+| Suffix | Mode | Path |
+|---|---|---|
+| none | TLS terminated, forwarded as TCP | the common case |
+| `s` | TLS passthrough | `proxy/tls_passthough.rs`, SNI-routed, needs a `_dstack-app-address` TXT record |
+| `g` | HTTP/2 with TLS termination | gRPC |
+
+The 0.6.0-rc0 round exercised only the no-suffix path, single-node and then
+across a cluster. Passthrough and gRPC were never tried, and neither was anything
+beyond a small request — no sustained transfer, long-lived connection or
+streaming. If those matter for the release, test them explicitly; a green
+no-suffix `curl` says nothing about them.
+
+Passthrough in particular has its own resolution mechanism: the gateway looks up
+`_dstack-app-address.<sni>`, falling back to `_dstack-app-address-wildcard.<parent>`,
+for a TXT record of the form `<app_id>:<port>`. Seeing a passthrough-resolution
+error while testing the *terminated* path usually means the gateway had no
+certificate and fell through to SNI routing — fix the certificate, not the DNS.
 
 **`dstack-mr` binary name collision:** `-p dstack-mr` and `-p dstack-mr-cli` both
 produce `target/release/dstack-mr` and overwrite each other. Build only
@@ -219,7 +315,7 @@ your URL, not a broken agent.
 
 ---
 
-## 7. Reading DNS evidence without fooling yourself
+## 8. Reading DNS evidence without fooling yourself
 
 Three ways to misread a DNS result, all of which happened:
 
@@ -240,7 +336,7 @@ control, those errors read as evidence about AMD.
 
 ---
 
-## 8. AMD SEV-SNP: provision host certificates first
+## 9. AMD SEV-SNP: provision host certificates first
 
 The most valuable thing to do before an AMD run.
 
@@ -271,7 +367,7 @@ the per-chip VCEK.
 
 ---
 
-## 9. Fixed in 0.6.0-rc0 testing — do not re-diagnose
+## 10. Fixed in 0.6.0-rc0 testing — do not re-diagnose
 
 - **KMS image had no CA certificates** and could not start at all
   ([#1128](https://github.com/Dstack-TEE/dstack/pull/1128)). Failed at
@@ -295,7 +391,7 @@ If you hit any of these on a build that predates the fixes, that is why.
 
 ---
 
-## 10. Housekeeping
+## 11. Housekeeping
 
 - **Keep an inventory as you go**: CVMs, ufw rules, DNS records, host module and
   permission changes, registry tags. Comment ufw rules so they can be found later
@@ -304,6 +400,14 @@ If you hit any of these on a build that predates the fixes, that is why.
   blacklist) **revert on reboot**. Decide whether to persist them; either is fine,
   but know which you chose.
 - Remove test ZtDomains and stray `_acme-challenge` TXT records when finished.
+- A cluster run leaves a WireGuard interface per node and a second set of ufw
+  rules and ports; both outlive the CVMs.
+- **Do not poll with `pgrep -f` on a pattern your own commands contain.** A
+  waiter looping on `pgrep -f "build-image.sh ..."` never exits while you check
+  progress with a command whose own command line includes that string — checking
+  keeps it waiting. The same self-match reports a finished build as still
+  running, and a bare `pgrep -af qemu-system` matches the grep itself. Check for
+  the artifact (`docker image inspect`, a file, a port) rather than the process.
 - When doing an A/B across dependency versions, **restore `Cargo.lock` along with
   `Cargo.toml`.** Editing the manifest and running cargo rewrites the lockfile;
   restoring only the manifest leaves them inconsistent. CI will not catch it

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -439,14 +439,6 @@ from five vantage points across four autonomous systems and two continents, whil
 every other external service answered normally. DNS was healthy and unchanged
 throughout, so this was the service, not a migration.
 
-Verification needs the ASK and VCEK certificates. By default they are fetched
-from `https://kdsintf.amd.com`, which is a **single global endpoint with no
-mirror**, is aggressively rate-limited (one identical request per ~10s), and was
-completely unreachable during the last round — TCP timeouts and 100% ICMP loss
-from five vantage points across four autonomous systems and two continents, while
-every other external service answered normally. DNS was healthy and unchanged
-throughout, so this was the service, not a migration.
-
 The rate limit is not theoretical: back-to-back negative tests against the same
 chip hit `HTTP status client error (429)` on the VCEK URL, which reads exactly
 like a verification failure until you notice the status code. Space repeat
@@ -456,6 +448,23 @@ dstack already supports the alternative: `normalize_kernel_cert_table` reads ASK
 and VCEK from the SNP extended report's certificate table, so a host that has
 been provisioned needs no KDS access at all. AMD's own specification recommends
 caching at the host for exactly this reason.
+
+**There is no KDS cache service in this repo, and nothing to point one at.** The
+only caching is in-process: `AmdKdsClient` holds a `moka` cache of 16 CA chains
+and 1024 VCEKs, bounded by capacity with no TTL and no persistence, so it is warm
+only for the lifetime of a single KMS or verifier process. A one-shot
+`dstack-verifier --verify` starts cold every time, which is exactly how the 429
+above was earned. `[core.attestation.urls] amd_kds` accepts any KDS-compatible
+base URL, so a mirror would drop in — but you would have to write it. Compare
+`nvidia-attest-proxy`, which is the persistent, on-disk, PCCS-like cache the
+NVIDIA collateral got and AMD did not. (`crates/mock-attestation` serves
+KDS-shaped routes but is a test fixture with fake collateral, not a mirror.)
+
+The guest side of the cert-table path needs nothing configured: `sev-snp-attest`
+reads `certs`, `cert_chain` or `auxblob` from the configfs TSM report, falling
+back to the extended-report ioctl, and passes whatever it finds up with the
+quote. An unprovisioned host simply yields an empty chain, and the verifier then
+goes to KDS — which is what happened here.
 
 **So: provision the host certificate chain (`snphost` / `sevctl`) as part of
 setup.** It is a one-time fetch and it removes an unreliable dependency from

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -429,7 +429,7 @@ certificate** — the onboarded KMS re-issues its own cert, so the PEM differs
 while `openssl x509 -pubkey` is identical. A KMS that bootstrapped independently
 differs in both.
 
-### 9.4 KDS is on the critical path, and stays there
+### 9.4 KDS is on the critical path
 
 Verification needs the ASK and VCEK certificates. They come from
 `https://kdsintf.amd.com`, a **single global endpoint with no mirror**, rate
@@ -446,9 +446,58 @@ them ~25s apart.
 Caching is in-process only. `AmdKdsClient` keeps a `moka` cache of 16 CA chains
 and 1024 VCEKs, capacity-bounded, no TTL, no persistence — warm for the life of
 one KMS or verifier process and cold in every one-shot `dstack-verifier --verify`.
-There is no KDS cache service in this repo; `[core.attestation.urls] amd_kds`
-would accept a mirror, but nothing implements one. (Compare `nvidia-attest-proxy`,
-the persistent on-disk cache the NVIDIA collateral got and AMD did not.)
+There is no KDS cache service in this repo — compare `nvidia-attest-proxy`, the
+persistent on-disk cache the NVIDIA collateral got and AMD did not — but
+`[core.attestation.urls] amd_kds` accepts any KDS-compatible base URL, and putting
+a caching proxy there works. Four consecutive cold-process `dstack-verifier
+--verify` runs of one attestation pass through a mirror; the same sequence run
+directly against KDS fails on the second. A KMS configured the same way released
+keys to an AMD guest end to end.
+
+Three things decide whether such a proxy is correct, and all three are easy to get
+wrong:
+
+```js
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (request.method !== "GET" || !url.pathname.startsWith("/vcek/v1/")) {
+      return new Response("not found", { status: 404 });
+    }
+    const cache = caches.default;
+    const key = new Request(url.toString());   // query string carries the TCB SPLs
+    const hit = await cache.match(key);
+    if (hit) return hit;
+
+    // 1. AMD answers 403 to an unexpected Host header, so do not forward it.
+    const upstream = await fetch("https://kdsintf.amd.com" + url.pathname + url.search,
+                                 { headers: { accept: "*/*" } });
+    const body = await upstream.arrayBuffer();
+
+    // 2. Only success is cacheable. A cached 429 turns a rate limit into an outage.
+    if (!upstream.ok) {
+      return new Response(body, { status: upstream.status,
+                                  headers: { "cache-control": "no-store" } });
+    }
+
+    // 3. Every KDS response says `Cache-Control: no-cache`; override it.
+    const res = new Response(body, { headers: {
+      "content-type": "application/octet-stream",
+      "cache-control": "public, max-age=2592000",
+    }});
+    ctx.waitUntil(cache.put(key, res.clone()));
+    return res;
+  },
+};
+```
+
+Caching is safe here because the collateral is signature-verified downstream and
+the ARK is compiled in, so a mirror can withhold or replay genuine certificates
+but cannot forge one. Two fetches of one VCEK URL return different bytes — AMD
+re-issues rather than serving a fixed object — but any valid copy is as good as
+another, and a VCEK is valid for seven years. Bound the TTL anyway: dstack checks
+no CRL and no certificate validity dates, and an unbounded cache would make that
+permanent rather than merely current.
 
 Do not plan on serving the certificates from the host instead. The verifier side
 supports it — `normalize_kernel_cert_table` reads ASK and VCEK from the SNP

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -429,87 +429,40 @@ certificate** — the onboarded KMS re-issues its own cert, so the PEM differs
 while `openssl x509 -pubkey` is identical. A KMS that bootstrapped independently
 differs in both.
 
-### 9.4 Provision host certificates first
+### 9.4 KDS is on the critical path, and stays there
 
-Verification needs the ASK and VCEK certificates. By default they are fetched
-from `https://kdsintf.amd.com`, which is a **single global endpoint with no
-mirror**, is aggressively rate-limited (one identical request per ~10s), and was
-completely unreachable for an entire test round — TCP timeouts and 100% ICMP loss
-from five vantage points across four autonomous systems and two continents, while
-every other external service answered normally. DNS was healthy and unchanged
-throughout, so this was the service, not a migration.
+Verification needs the ASK and VCEK certificates. They come from
+`https://kdsintf.amd.com`, a **single global endpoint with no mirror**, rate
+limited to roughly one identical request per 10s, and unreachable for an entire
+test round — TCP timeouts and 100% ICMP loss from five vantage points across four
+autonomous systems and two continents, while every other external service
+answered normally and DNS stayed healthy throughout.
 
-The rate limit is not theoretical: back-to-back negative tests against the same
-chip hit `HTTP status client error (429)` on the VCEK URL, which reads exactly
-like a verification failure until you notice the status code. Space repeat
-verifications ~25s apart, or provision the host.
+The rate limit is the one that will bite you mid-test: back-to-back verifications
+of the same chip return `HTTP status client error (429)` on the VCEK URL, which
+reads exactly like a verification failure until you notice the status code. Space
+them ~25s apart.
 
-dstack already supports the alternative: `normalize_kernel_cert_table` reads ASK
-and VCEK from the SNP extended report's certificate table, so a host that has
-been provisioned needs no KDS access at all. AMD's own specification recommends
-caching at the host for exactly this reason.
+Caching is in-process only. `AmdKdsClient` keeps a `moka` cache of 16 CA chains
+and 1024 VCEKs, capacity-bounded, no TTL, no persistence — warm for the life of
+one KMS or verifier process and cold in every one-shot `dstack-verifier --verify`.
+There is no KDS cache service in this repo; `[core.attestation.urls] amd_kds`
+would accept a mirror, but nothing implements one. (Compare `nvidia-attest-proxy`,
+the persistent on-disk cache the NVIDIA collateral got and AMD did not.)
 
-**There is no KDS cache service in this repo, and nothing to point one at.** The
-only caching is in-process: `AmdKdsClient` holds a `moka` cache of 16 CA chains
-and 1024 VCEKs, bounded by capacity with no TTL and no persistence, so it is warm
-only for the lifetime of a single KMS or verifier process. A one-shot
-`dstack-verifier --verify` starts cold every time, which is exactly how the 429
-above was earned. `[core.attestation.urls] amd_kds` accepts any KDS-compatible
-base URL, so a mirror would drop in — but you would have to write it. Compare
-`nvidia-attest-proxy`, which is the persistent, on-disk, PCCS-like cache the
-NVIDIA collateral got and AMD did not. (`crates/mock-attestation` serves
-KDS-shaped routes but is a test fixture with fake collateral, not a mirror.)
+Do not plan on serving the certificates from the host instead. The verifier side
+supports it — `normalize_kernel_cert_table` reads ASK and VCEK from the SNP
+extended report's certificate table — and so does the guest, but nothing can put
+them there: `sev-snp-guest` in stock QEMU has no `certs-path`-style property, and
+the host-side `SNP_SET_EXT_CONFIG` ioctl is not in upstream `psp-sev.h`. Guests
+ask via `SNP_GET_EXT_REPORT` and get an empty table, which is why every
+verification in this round went to KDS.
 
-The guest side of the cert-table path needs nothing configured: `sev-snp-attest`
-reads `certs`, `cert_chain` or `auxblob` from the configfs TSM report, falling
-back to the extended-report ioctl, and passes whatever it finds up with the
-quote. An unprovisioned host simply yields an empty chain, and the verifier then
-goes to KDS — which is what happened here.
-
-**Check that your VMM can actually deliver those certificates before planning
-around it.** On the host used for this round it cannot, and the earlier revision
-of this section recommended provisioning without checking.
-
-The tooling half is fine. `snphost` (virtee) is the SEV-SNP host CLI:
-`snphost fetch ca [der|pem] DIR` and `snphost fetch vek [der|pem] DIR` pull the
-CA chain and the VCEK from KDS, and `snphost import DIR CERT-FILE` packs them
-into the GHCB-formatted blob that, in its own words, "can then be provided to
-QEMU to perform extended attestation on guests". (`sevctl` is *not* part of this
-— it manages the pre-SNP SEV platform and its OCA certificate chain. A previous
-revision of this section listed the two together; that was wrong.)
-
-The delivery half is the problem. Providing that blob to QEMU needs a
-`certs-path`-style property on the `sev-snp-guest` object, and stock QEMU does
-not have one:
-
-```
-$ qemu-system-x86_64 -object sev-snp-guest,help     # QEMU 10.2.1
-sev-snp-guest options:
-  author-key-enabled=<bool>   guest-visible-workarounds=<string>
-  host-data=<string>          id-auth=<string>
-  id-block=<string>           kernel-hashes=<bool>
-  policy=<uint64>             sev-device=<string>
-  vcek-disabled=<bool>
-```
-
-`strings` on the binary confirms it — no `certs-path` anywhere. The host-side
-`SNP_SET_EXT_CONFIG` ioctl, the other way certificates used to be staged, is
-absent from upstream `linux/psp-sev.h` as well; it lived in AMD's out-of-tree
-fork. The guest half is present and working — `linux/sev-guest.h` still has
-`SNP_GET_EXT_REPORT` and its `certs_address` — so the guest asks and gets an
-empty table back.
-
-Which is exactly what was observed: `sev-snp-attest` found no `certs`,
-`cert_chain` or `auxblob` content, so the attestation travelled with an empty
-chain and the verifier went to KDS every time.
-
-**So, on a stock Ubuntu/Debian QEMU, KDS is not optional.** The realistic
-mitigations are the boring ones: keep a long-lived KMS so its in-process cache
-stays warm, and space repeat verifications out. Removing the dependency properly
-means either a QEMU that can carry the cert blob, or a KDS mirror behind
-`[core.attestation.urls] amd_kds`. Both are work, not configuration. And note
-the bootstrap problem either way — obtaining the VCEK requires KDS access once,
-from a network that can reach it.
+A note for whoever touches this code: the ARK is already compiled in, and the ARK
+fetched from KDS is discarded (`let (_fetched_ark, ask) = ...`). The network
+request exists only to obtain the ASK, which is equally static per product family.
+Bundling it would remove the `cert_chain` request entirely, leaving only the
+per-chip VCEK.
 
 ### 9.5 Reaching the API that holds the keys
 
@@ -538,12 +491,6 @@ One more encoding trap, shared with `dstack-verifier --verify`: `bytes` fields i
 these JSON bodies are **hex strings**, not base64 and not byte arrays. Base64
 fails with `Invalid character 'w' at position 5`, which names the symptom and not
 the cause.
-
-A related note for whoever touches this code: the ARK is already compiled in, and
-the ARK fetched from KDS is discarded (`let (_fetched_ark, ask) = ...`). The
-network request exists only to obtain the ASK, which is equally static per product
-family. Bundling it would remove the `cert_chain` request entirely, leaving only
-the per-chip VCEK.
 
 ---
 

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -466,11 +466,50 @@ back to the extended-report ioctl, and passes whatever it finds up with the
 quote. An unprovisioned host simply yields an empty chain, and the verifier then
 goes to KDS — which is what happened here.
 
-**So: provision the host certificate chain (`snphost` / `sevctl`) as part of
-setup.** It is a one-time fetch and it removes an unreliable dependency from
-every subsequent run. Note the bootstrap problem — obtaining the VCEK to install
-requires KDS access once, so do it from a network that can reach it and carry the
-file over.
+**Check that your VMM can actually deliver those certificates before planning
+around it.** On the host used for this round it cannot, and the earlier revision
+of this section recommended provisioning without checking.
+
+The tooling half is fine. `snphost` (virtee) is the SEV-SNP host CLI:
+`snphost fetch ca [der|pem] DIR` and `snphost fetch vek [der|pem] DIR` pull the
+CA chain and the VCEK from KDS, and `snphost import DIR CERT-FILE` packs them
+into the GHCB-formatted blob that, in its own words, "can then be provided to
+QEMU to perform extended attestation on guests". (`sevctl` is *not* part of this
+— it manages the pre-SNP SEV platform and its OCA certificate chain. A previous
+revision of this section listed the two together; that was wrong.)
+
+The delivery half is the problem. Providing that blob to QEMU needs a
+`certs-path`-style property on the `sev-snp-guest` object, and stock QEMU does
+not have one:
+
+```
+$ qemu-system-x86_64 -object sev-snp-guest,help     # QEMU 10.2.1
+sev-snp-guest options:
+  author-key-enabled=<bool>   guest-visible-workarounds=<string>
+  host-data=<string>          id-auth=<string>
+  id-block=<string>           kernel-hashes=<bool>
+  policy=<uint64>             sev-device=<string>
+  vcek-disabled=<bool>
+```
+
+`strings` on the binary confirms it — no `certs-path` anywhere. The host-side
+`SNP_SET_EXT_CONFIG` ioctl, the other way certificates used to be staged, is
+absent from upstream `linux/psp-sev.h` as well; it lived in AMD's out-of-tree
+fork. The guest half is present and working — `linux/sev-guest.h` still has
+`SNP_GET_EXT_REPORT` and its `certs_address` — so the guest asks and gets an
+empty table back.
+
+Which is exactly what was observed: `sev-snp-attest` found no `certs`,
+`cert_chain` or `auxblob` content, so the attestation travelled with an empty
+chain and the verifier went to KDS every time.
+
+**So, on a stock Ubuntu/Debian QEMU, KDS is not optional.** The realistic
+mitigations are the boring ones: keep a long-lived KMS so its in-process cache
+stays warm, and space repeat verifications out. Removing the dependency properly
+means either a QEMU that can carry the cert blob, or a KDS mirror behind
+`[core.attestation.urls] amd_kds`. Both are work, not configuration. And note
+the bootstrap problem either way — obtaining the VCEK requires KDS access once,
+from a network that can reach it.
 
 ### 9.5 Reaching the API that holds the keys
 

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -275,11 +275,20 @@ state, not just metadata that happens to agree.
 | **A rejected quote in the KMS log** | The one check that proves verification is not a no-op |
 | `curl` through the proxy to the app | End to end, but only for one of several proxy modes — see below |
 | `/prpc/v1/Info` and `/prpc/Worker.Info` both answer | v1 works and pre-0.6 clients are not broken |
+| `dstack-verifier --verify` on a captured attestation, then again on a one-byte-flipped copy | Verification is checked by something other than the KMS, and the crypto is live rather than short-circuited |
 
 That fifth row is the one people skip. A run where every quote is accepted cannot
 distinguish "verification passed" from "verification never ran". Last time the
 AMD CVMs supplied it for free — 6 grants and 7 rejections in the same KMS log —
 but if everything passes, arrange a failure deliberately.
+
+The last row is the cheapest way to arrange one. `dstack-verifier --verify
+req.json`, with `req.json` holding `{"attestation": "<hex>"}` captured from
+`/v1/Attest`, gives a full result offline. Flip one byte and re-run: a flip
+inside the report signature or the launch measurement must come back
+`VEK does not sign the attestation report`. Choose the byte deliberately —
+flipping into the outer CBOR framing instead fails at decode, which proves only
+that the parser works.
 
 ### One `curl` does not cover the proxy
 
@@ -336,9 +345,61 @@ control, those errors read as evidence about AMD.
 
 ---
 
-## 9. AMD SEV-SNP: provision host certificates first
+## 9. AMD SEV-SNP
 
-The most valuable thing to do before an AMD run.
+An AMD run was completed end to end: guest SEV-SNP attestation, KMS key release,
+independent quote verification, gateway registration and public traffic. Four
+things below cost real time; none of them are guessable from the code.
+
+### 9.1 Turn on the KMS release gate before anything else
+
+`sev_snp_key_release` defaults to `false`, and a guest that trips it reboots in a
+loop with
+
+```
+Request failed with status=400 Bad Request, error={
+  "error": "amd sev-snp key release is not enabled"
+}
+```
+
+The gate sits *after* full quote verification, so a passing quote still yields
+nothing. Only two variants are gated this way — `dstack-amd-sev-snp` via
+`sev_snp_key_release` and `dstack-aws-nitro-tpm` via `aws_nitro_tpm_key_release`.
+TDX, GCP TDX and Nitro Enclave have no such switch, which is why nobody notices
+the gate until the first AMD boot.
+
+### 9.2 Do not edit a running KMS's compose to flip that flag
+
+The local key provider seals to
+`SHA-256(SGX sealing key || MRTD || RTMR0 || RTMR1 || RTMR2 || RTMR3)`, and
+**RTMR3 carries the compose hash**. Changing one line of a bootstrapped KMS's
+config gives it a different sealing key, and its root CA is gone with the disk.
+
+Use onboarding instead: deploy a second KMS with `auto_bootstrap_domain = ""`,
+then
+
+```
+curl -X POST http://<new-kms>/prpc/Onboard \
+  -H 'Content-Type: application/json' \
+  -d '{"source_url":"https://<old-kms>","domain":"<domain>"}'
+curl -X POST http://<new-kms>/prpc/Finish -d '{}' -H 'Content-Type: application/json'
+```
+
+The new KMS inherits the root key, so apps it serves are still trusted by a
+gateway registered against the old one. **Compare the CA public key, not the CA
+certificate** — the onboarded KMS re-issues its own cert, so the PEM differs
+while `openssl x509 -pubkey` is identical. A KMS that bootstrapped independently
+differs in both.
+
+### 9.3 Provision host certificates first
+
+Verification needs the ASK and VCEK certificates. By default they are fetched
+from `https://kdsintf.amd.com`, which is a **single global endpoint with no
+mirror**, is aggressively rate-limited (one identical request per ~10s), and was
+completely unreachable for an entire test round — TCP timeouts and 100% ICMP loss
+from five vantage points across four autonomous systems and two continents, while
+every other external service answered normally. DNS was healthy and unchanged
+throughout, so this was the service, not a migration.
 
 Verification needs the ASK and VCEK certificates. By default they are fetched
 from `https://kdsintf.amd.com`, which is a **single global endpoint with no
@@ -347,6 +408,11 @@ completely unreachable during the last round — TCP timeouts and 100% ICMP loss
 from five vantage points across four autonomous systems and two continents, while
 every other external service answered normally. DNS was healthy and unchanged
 throughout, so this was the service, not a migration.
+
+The rate limit is not theoretical: back-to-back negative tests against the same
+chip hit `HTTP status client error (429)` on the VCEK URL, which reads exactly
+like a verification failure until you notice the status code. Space repeat
+verifications ~25s apart, or provision the host.
 
 dstack already supports the alternative: `normalize_kernel_cert_table` reads ASK
 and VCEK from the SNP extended report's certificate table, so a host that has
@@ -358,6 +424,34 @@ setup.** It is a one-time fetch and it removes an unreliable dependency from
 every subsequent run. Note the bootstrap problem — obtaining the VCEK to install
 requires KDS access once, so do it from a network that can reach it and carry the
 file over.
+
+### 9.4 Reaching the API that holds the keys
+
+`GetKey` and `Attest` are **not** on the guest agent's external port. That
+listener serves `Info`, `Version` and `Health` only, by design — anyone who can
+route to the CVM reaches it. Everything else lives on
+`/var/run/dstack.sock` inside the guest, mounted at `/`, `/v0` and `/v1` with
+**no `/prpc` prefix**: the internal path is `/v1/GetKey`, not `/prpc/v1/GetKey`.
+
+To reach it from the host during a test, add a socat sidecar to the app compose:
+
+```yaml
+  sockproxy:
+    image: alpine/socat
+    command: TCP-LISTEN:8091,fork,reuseaddr UNIX-CONNECT:/var/run/dstack.sock
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    ports:
+      - "8091:8091"
+```
+
+That exposes app key material to the host, so it belongs in a lab and nowhere
+else.
+
+One more encoding trap, shared with `dstack-verifier --verify`: `bytes` fields in
+these JSON bodies are **hex strings**, not base64 and not byte arrays. Base64
+fails with `Invalid character 'w' at position 5`, which names the symptom and not
+the cause.
 
 A related note for whoever touches this code: the ARK is already compiled in, and
 the ARK fetched from KDS is discarded (`let (_fetched_ark, ask) = ...`). The
@@ -402,6 +496,9 @@ If you hit any of these on a build that predates the fixes, that is why.
 - Remove test ZtDomains and stray `_acme-challenge` TXT records when finished.
 - A cluster run leaves a WireGuard interface per node and a second set of ufw
   rules and ports; both outlive the CVMs.
+- An AMD run adds a KMS per release-gate variation. Each is a full CVM with its
+  own disk and port; the ones that only served as a stepping stone are safe to
+  delete once the onboarded KMS works, but nothing cleans them up for you.
 - **Do not poll with `pgrep -f` on a pattern your own commands contain.** A
   waiter looping on `pgrep -f "build-image.sh ..."` never exits while you check
   progress with a command whose own command line includes that string — checking

--- a/docs/rc-testing-runbook.md
+++ b/docs/rc-testing-runbook.md
@@ -348,10 +348,45 @@ control, those errors read as evidence about AMD.
 ## 9. AMD SEV-SNP
 
 An AMD run was completed end to end: guest SEV-SNP attestation, KMS key release,
-independent quote verification, gateway registration and public traffic. Four
-things below cost real time; none of them are guessable from the code.
+independent quote verification, gateway registration and public traffic. Host
+prerequisites are in section 1; what follows is everything after the host boots.
+None of it is guessable from the code.
 
-### 9.1 Turn on the KMS release gate before anything else
+### 9.1 The settings an AMD run needs
+
+One of these must change or the run cannot succeed; the rest are listed because
+their defaults are the ones you want and it is useful to know that before you
+start changing things.
+
+| Setting | File | Default | For an AMD run |
+|---|---|---|---|
+| `[cvm] platform` | `vmm.toml` (host) | `"auto"` | `"auto"` picks SEV-SNP when the host CPU flags contain `sev_snp`; set `"amd-sev-snp"` to be explicit and to fail loudly on the wrong host |
+| `sev_snp_key_release` | `kms.toml`, `[core]` | `false` | **`true`**, or no AMD guest ever gets a key |
+| `aws_nitro_tpm_key_release` | `kms.toml`, `[core]` | `false` | leave off; listed because it is the only other gate of this shape |
+| `[core.attestation.urls] amd_kds` | `kms.toml`, `dstack-verifier.toml` | `https://kdsintf.amd.com/vcek/v1` | override only to point at a cache or mirror |
+| `[core.attestation.root_ca] sev_snp_milan` / `_genoa` / `_turin` | same | unset — vendor ARK compiled in | leave unset unless you are testing against a non-production root |
+| `insecure_allow_external_trust_anchors` | same, `[core.attestation]` | `false` | must be `true` if *any* `root_ca` path above is set |
+
+The KMS side, in full, is two lines:
+
+```toml
+[core]
+sev_snp_key_release = true
+```
+
+Setting a `root_ca` path without the escape hatch is a startup failure, not a
+silent fallback:
+
+```
+external attestation trust anchors are configured but
+insecure_allow_external_trust_anchors is false
+```
+
+The whole `[core.attestation]` block has the same shape in `kms.toml` and
+`dstack-verifier.toml`, so a KDS mirror or a test root configured for one can be
+copied verbatim into the other.
+
+### 9.2 What the release gate looks like when it is off
 
 `sev_snp_key_release` defaults to `false`, and a guest that trips it reboots in a
 loop with
@@ -362,13 +397,16 @@ Request failed with status=400 Bad Request, error={
 }
 ```
 
-The gate sits *after* full quote verification, so a passing quote still yields
-nothing. Only two variants are gated this way — `dstack-amd-sev-snp` via
-`sev_snp_key_release` and `dstack-aws-nitro-tpm` via `aws_nitro_tpm_key_release`.
-TDX, GCP TDX and Nitro Enclave have no such switch, which is why nobody notices
-the gate until the first AMD boot.
+The gate sits *after* full quote verification (`ensure_key_release_allowed`), so
+a perfectly good quote still yields nothing — the message is about local policy
+and says nothing about the attestation. Only two variants are gated this way:
+`dstack-amd-sev-snp` and `dstack-aws-nitro-tpm`. TDX, GCP TDX and Nitro Enclave
+have no such switch, which is why nobody notices the gate until the first AMD
+boot. The stated reason for NitroTPM is that it is not confidential compute at
+all — the AWS hypervisor is inside the TCB — so both need an explicit operator
+opt-in on top of whatever the external auth policy decides.
 
-### 9.2 Do not edit a running KMS's compose to flip that flag
+### 9.3 Do not edit a running KMS's compose to flip that flag
 
 The local key provider seals to
 `SHA-256(SGX sealing key || MRTD || RTMR0 || RTMR1 || RTMR2 || RTMR3)`, and
@@ -391,7 +429,7 @@ certificate** — the onboarded KMS re-issues its own cert, so the PEM differs
 while `openssl x509 -pubkey` is identical. A KMS that bootstrapped independently
 differs in both.
 
-### 9.3 Provision host certificates first
+### 9.4 Provision host certificates first
 
 Verification needs the ASK and VCEK certificates. By default they are fetched
 from `https://kdsintf.amd.com`, which is a **single global endpoint with no
@@ -425,7 +463,7 @@ every subsequent run. Note the bootstrap problem — obtaining the VCEK to insta
 requires KDS access once, so do it from a network that can reach it and carry the
 file over.
 
-### 9.4 Reaching the API that holds the keys
+### 9.5 Reaching the API that holds the keys
 
 `GetKey` and `Attest` are **not** on the guest agent's external port. That
 listener serves `Info`, `Version` and `Health` only, by design — anyone who can


### PR DESCRIPTION
Follow-up to #1134. I tested a two-node gateway cluster after that merged; this adds what it turned up and corrects a claim the first version made about proxy coverage.

## Gateway clustering (new section 6)

Two things about clustering are easy to get wrong and hard to diagnose.

**Sync is already on in a single-node run.** `entrypoint.sh` sets `SYNC_ENABLED=$([ "$NODE_ID" -gt 0 ] && ...)`, so a node with `NODE_ID=1` logs `WaveKV: detected certificate changes` and looks clustered while nothing has ever replicated. I had assumed the opposite — that sync was off in my single-node runs — and said so before checking the entrypoint. Neither reading is safe without looking, so the section says which it is and why the log line is not evidence.

**Every node must deploy under the same `--name`.** Cluster members require the peer's `app_id` to equal their own (`kv/https_client.rs`), which is deliberate — it confines WaveKV replication to instances of one authorized compose rather than letting any CVM join. `app_id` is the compose hash and `name` is part of it, so a second node deployed under a different name fails discovery with:

```
bootnode discovery retry failed: failed to fetch peers from bootnode
  app_id mismatch: expected c90cc75a6ceb…, got aa04b7bd7875…
```

That reads like a trust or connectivity fault and is neither. Per-node values (`NODE_ID`, WireGuard addressing, ports, `MY_URL`, `BOOTNODE_URL`) belong in `--env-file`, whose values are encrypted at deploy time and excluded from the hash — only the key names are recorded, as `allowed_envs`. Diffing the two compose files showed `name` as the only differing field, which is what made the cause obvious; the section suggests comparing the two hashes before deploying.

The section also lists what actually proves a cluster works, because agreeing peer lists are the weakest of the available signals. The one that matters is traffic entering node2 and reaching an app whose WireGuard tunnel terminates on node1 — that shows what replicated is usable routing state, not metadata that happens to match.

## Correction to what is now section 7

The merged version listed "`curl` through the proxy to the app — end to end, including TLS termination and routing". That is true but invites the reading that the proxy is covered, and it is not.

Ingress maps as `<id>[-[<port>][s|g]].<base_domain>`, and the suffixes select different code paths: `s` is TLS passthrough through `proxy/tls_passthough.rs` with its own `_dstack-app-address` TXT resolution, `g` is HTTP/2. The 0.6.0-rc0 round exercised only the no-suffix path, single-node and then across a cluster, and only with a small request — no sustained transfer, long-lived connection or streaming. The table row now says so and a subsection spells out what remains untested.

One diagnostic note went in alongside it: a passthrough-resolution error while testing the *terminated* path usually means the gateway had no certificate and fell through to SNI routing. I spent a while treating that as a DNS problem when the missing certificate was upstream of it.

## Housekeeping

Added the `pgrep -f` self-match trap, which cost more time than anything else in the run despite being the least interesting thing in it. A waiter looping on `pgrep -f "build-image.sh ..."` never exits while you check progress with a command whose own command line contains that string — **checking kept it waiting**, and an image that had been ready for half an hour sat unpushed. The same self-match reported a finished build as still running and, earlier, made a bare `pgrep -af qemu-system` match the grep itself and report a VM that did not exist. The advice is to check for the artifact rather than the process.

Also noted that a cluster run leaves a WireGuard interface per node plus a second set of ufw rules and ports, all of which outlive the CVMs.

## Verification

`prek run --files docs/rc-testing-runbook.md` passes. Every command and error message quoted here came from the two-node cluster brought up on the TDX host, not from reading the code.