### PR TITLE
fix(certbot): enable the rustls ring provider

### DIFF
--- a/dstack/certbot/cli/Cargo.toml
+++ b/dstack/certbot/cli/Cargo.toml
@@ -23,5 +23,5 @@ serde.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml_edit.workspace = true
 tracing-subscriber.workspace = true
-rustls.workspace = true
+rustls = { workspace = true, features = ["ring"] }
 or-panic.workspace = true


### PR DESCRIPTION
## Summary

- enable the rustls `ring` feature for `certbot-cli`
- restore compilation of the CLI

## Testing

- `cargo test --locked -p certbot-cli`

This product-code fix was found while validating PR #841 on `tdxlab`.