### PR TITLE
ci(mkosi): title guest OS releases after the product, not the backend

### DIFF
--- a/.github/workflows/mkosi-build.yml
+++ b/.github/workflows/mkosi-build.yml
@@ -364,11 +364,15 @@ jobs:
           # experimental, and its packages are Debian rather than Yocto even
           # though the release contract is shared. Drop the flag once the
           # backend is declared stable.
+          #
+          # The title names the product, not the build backend: the tag prefix
+          # only exists to keep this workflow's trigger distinct from the Yocto
+          # one, and it should not leak into the release listing.
           gh release create "$TAG" \
             "dist/dstack-$VERSION.tar.gz" \
             "dist/dstack-$VERSION-uki.tar.gz" \
             dist/image-hashes.txt \
-            --title "$TAG" \
+            --title "dstack OS v$VERSION" \
             --notes-file release-notes.md \
             --verify-tag \
             --prerelease


### PR DESCRIPTION
## Problem

The mkosi release job publishes with `--title "$TAG"`, and the tag is `mkosi-os-v<version>`. That prefix exists only so this workflow's tag trigger cannot collide with the Yocto guest-OS one — it is a CI implementation detail, not a product name. It nevertheless ends up as the release name users read on the releases page, next to entries like `Verifier Release v0.5.11` and `dstack-sdk 0.1.3`:

```
mkosi-os-v0.6.0-rc0   Pre-release   mkosi-os-v0.6.0-rc0
```

The last release had to be renamed by hand afterwards to read as a dstack guest OS release, which is not something a publish path should require.

## Fix

Title the release `dstack OS v$VERSION` instead of echoing the tag. The tag itself is unchanged, so the trigger, the `mkosi-os-v*` tag-format check and `docs/rc-testing-runbook.md` all stay as they are.

`VERSION` is the build job's output, read from `os/mkosi/versions.env`, and the preceding validation step already fails the job unless the tag equals `mkosi-os-v$DSTACK_VERSION`. So the title cannot drift from the tag or from the image's own `metadata.json` version.

## Verification

- `gh release list` on this repo confirms the current title is the raw tag and that no other release advertises a build backend.
- Parsed the edited workflow with `yaml.safe_load` and re-read the `Create the release` step; the diff is the `--title` value plus a comment.
- Expanded the new title with the released version: `VERSION=0.6.0` → `dstack OS v0.6.0`.

Release-notes body, assets, `--verify-tag` and `--prerelease` are untouched.