### PR TITLE
fix(verifier): bind the configured address and port

### DIFF
--- a/dstack/verifier/README.md
+++ b/dstack/verifier/README.md
@@ -95,7 +95,7 @@ You usually don't need to edit the config file. Just using the default is fine, 
 
 ### Configuration Options
 
-- `host`: Server bind address (default: "0.0.0.0")
+- `address`: Server bind address (default: "0.0.0.0")
 - `port`: Server port (default: 8080)
 - `image_cache_dir`: Directory for cached OS images (default: "/tmp/dstack-verifier/cache")
 - `image_download_url`: URL template for downloading OS images (default: dstack official releases URL)
@@ -106,7 +106,7 @@ You usually don't need to edit the config file. Just using the default is fine, 
 ### Example Configuration File
 
 ```toml
-host = "0.0.0.0"
+address = "0.0.0.0"
 port = 8080
 image_cache_dir = "/tmp/dstack-verifier/cache"
 image_download_url = "https://download.dstack.org/os-images/mr_{OS_IMAGE_HASH}.tar.gz"

--- a/dstack/verifier/src/main.rs
+++ b/dstack/verifier/src/main.rs
@@ -92,6 +92,14 @@ fn load_config(figment: &Figment) -> Result<Config> {
     Ok(config)
 }
 
+fn socket_addr(config: &Config) -> Result<std::net::SocketAddr> {
+    let ip = config
+        .address
+        .parse::<IpAddr>()
+        .with_context(|| format!("invalid verifier address: {}", config.address))?;
+    Ok(std::net::SocketAddr::from((ip, config.port)))
+}
+
 #[post("/verify", data = "<request>")]
 async fn verify_cvm(
     verifier: &State<Arc<CvmVerifier>>,
@@ -351,6 +359,10 @@ async fn main() -> Result<()> {
         Arc::new(AttestationVerifier::load(&config.attestation)?),
     ));
 
+    let addr = socket_addr(&config)?;
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind {addr}"))?;
     let rocket_figment = Figment::from(rocket::Config::default()).merge(config_figment);
     rocket::custom(rocket_figment)
         .mount("/", rocket::routes![verify_cvm, health])
@@ -360,7 +372,7 @@ async fn main() -> Result<()> {
                 info!("dstack-verifier started successfully");
             })
         }))
-        .launch()
+        .launch_on(listener)
         .await
         .map_err(|err| anyhow::anyhow!("launch rocket failed: {err:?}"))?;
     Ok(())
@@ -391,6 +403,10 @@ image_download_timeout_secs = 7
         assert_eq!(loaded.address, "127.0.0.1");
         assert_eq!(loaded.port, 18080);
         assert_eq!(loaded.image_download_timeout_secs, 7);
+        assert_eq!(
+            socket_addr(&loaded).unwrap(),
+            "127.0.0.1:18080".parse().unwrap()
+        );
 
         for (name, body, expected) in [
             (


### PR DESCRIPTION
## Problem

`dstack-verifier` reads `address` and `port` from toml / `DSTACK_VERIFIER_*`, validates them, then starts Rocket with `.launch()`.

Rocket 0.6 `DefaultListener` treats `address` as an `Endpoint`. A bare IP such as `0.0.0.0` parses as `tcp:0.0.0.0:8000`. The configured `port` never reaches the listener, so:

```text
DSTACK_VERIFIER_PORT=9090 ./dstack-verifier --config verifier.toml
# Bind(Some(tcp:0.0.0.0:8000), AddrInUse)
```

## Fix

Bind a `tokio::net::TcpListener` from the already-validated `Config` address/port and `launch_on` it, same pattern as guest-agent and supervisor.

## Verification

`cargo test -p dstack-verifier --bin dstack-verifier` — 2 passed, including `socket_addr` from the config file port.