### PR TITLE
fix(os/image): enable MMCONFIG so Blackwell GPUs can be probed

### DIFF
--- a/os/image/kernel-cmdline.sh
+++ b/os/image/kernel-cmdline.sh
@@ -13,6 +13,23 @@
 # one would have produced measurements describing a command line the guest
 # never booted with -- and every existing check would still have passed.
 
+# `pci=nommconf` is deliberately absent. It confines PCI config space access to
+# the legacy CF8h/CFCh port I/O path, which physically cannot reach past the
+# first 256 bytes, so `pci_find_ext_capability()` short-circuits on
+# `dev->cfg_size <= PCI_CFG_SPACE_SIZE` and the whole PCIe extended config space
+# (offset >= 0x100) becomes unreadable. Blackwell GPU drivers walk that space to
+# find NVIDIA's vendor DVSEC; with MMCONFIG off the reads return 0xFFFFFFFF, the
+# driver asserts on every probe, and every later cuInit() fails with
+# CUDA_ERROR_SYSTEM_NOT_READY (802). There is no substitute mechanism, so GPU
+# passthrough requires MMCONFIG.
+#
+# `pci=noearly` is kept. It gates a different mechanism -- early type 1 scanning,
+# which runs before ACPI is parsed and dispatches into vendor fixups keyed on the
+# vendor/device/class triple read straight out of a host-controlled config space.
+# GPU drivers bind during normal PCI enumeration and do not depend on it, and
+# Intel's confidential-computing guest hardening names early PCI code as
+# something to disable, so it stays off.
+
 # Emit the guest kernel command line.
 #   $1 dm-verity root hash
 #   $2 rootfs data size in bytes
@@ -20,7 +37,7 @@ dstack_kernel_cmdline() {
     local root_hash=${1:?root hash required}
     local data_size=${2:?data size required}
     echo "console=ttyS0 init=/init panic=1 net.ifnames=0 biosdevname=0" \
-         "mce=off oops=panic pci=noearly pci=nommconf random.trust_cpu=y" \
+         "mce=off oops=panic pci=noearly random.trust_cpu=y" \
          "random.trust_bootloader=n tsc=reliable no-kvmclock" \
          "dstack.rootfs_hash=$root_hash dstack.rootfs_size=$data_size"
 }

--- a/os/yocto/layers/meta-dstack/recipes-core/images/dstack-uki.bb
+++ b/os/yocto/layers/meta-dstack/recipes-core/images/dstack-uki.bb
@@ -22,8 +22,11 @@ KERNEL_IMAGETYPE = "bzImage"
 # Do NOT embed per-app dstack.mr_config_id here: AWS app/config binding is
 # measured from the shared-disk MrConfigV3 into NitroTPM PCR8 at guest setup,
 # so the UKI/AMI stays app-independent (PCR4 is OS-only).
+# Keep in sync with dstack_kernel_cmdline() in os/image/kernel-cmdline.sh, which
+# documents why pci=nommconf is absent (Blackwell needs PCIe extended config
+# space) and why pci=noearly stays.
 UKI_CMDLINE_BASE = "console=ttyS0 init=/init panic=1 net.ifnames=0 biosdevname=0 \
-mce=off oops=panic pci=noearly pci=nommconf random.trust_cpu=y random.trust_bootloader=n \
+mce=off oops=panic pci=noearly random.trust_cpu=y random.trust_bootloader=n \
 tsc=reliable no-kvmclock"
 
 # Flavor settings (should match dstack-rootfs.bb, set via multiconfig)


### PR DESCRIPTION
## Why

`pci=nommconf` confines PCI config space access to the legacy CF8h/CFCh port I/O path, which physically cannot reach past the first 256 bytes. `pci_find_ext_capability()` then short-circuits on `dev->cfg_size <= PCI_CFG_SPACE_SIZE`, so the whole PCIe extended config space (offset >= `0x100`) is unreadable.

Blackwell GPU drivers walk that space to find NVIDIA's vendor DVSEC. With MMCONFIG off the reads return `0xFFFFFFFF`, the driver asserts on every probe, and every later `cuInit()` fails with `CUDA_ERROR_SYSTEM_NOT_READY` (802). No other mechanism reaches extended config space, so GPU passthrough cannot work without MMCONFIG. This is a property of the access method, not a driver bug.

## What changed

Dropped `pci=nommconf` from the guest kernel command line, in both places it is stated — the shared mkosi definition (`os/image/kernel-cmdline.sh`) and the yocto UKI recipe (`dstack-uki.bb`) — plus a comment recording why it must not come back.

## What deliberately did not change

`pci=noearly` stays. It gates a different mechanism: early type 1 scanning, which runs before ACPI is parsed and dispatches into vendor fixups keyed on a vendor/device/class triple read straight out of host-controlled config space. `early_quirks()` is the only caller of the `early_qrk[]` handlers, so disabling it removes that code path rather than deferring it. GPU drivers bind during normal PCI enumeration and do not depend on it, and Intel's confidential-computing guest hardening names early PCI code as something to disable.

If a B300 bring-up turns out to need `pci=noearly` removed as well, that should be a separate change with its own evidence — this PR is the minimal one that is provably required.

## Security note

Restoring MMCONFIG re-exposes ~15 extended-capability parsers (SR-IOV, AER, ACS, DOE, Resizable BAR, ...) to host-controlled data. Scoping that honestly:

- Not a new attack surface class. The first 256 bytes are already fully host-controlled and already parsed (MSI, MSI-X, PM, VPD).
- The extended capability walker is bounded — `PCI_FIND_NEXT_EXT_CAP` caps at `(4096-256)/8` iterations and `PCI_EXT_CAP_NEXT()` masks offsets to `0xffc`, so no loop and no out-of-bounds read.
- MCFG itself is covered by attestation: `dstack-mr` independently regenerates the QEMU ACPI tables and measures `loader`/`rsdp`/`tables` into RTMR0, so a host lying about the ECAM base is detectable — provided the verifier compares against the computed expectation rather than replaying the guest event log.

## Testing

- `bash -n` and `shellcheck` on `kernel-cmdline.sh`.
- Verified the two backends still emit an identical token set (diffed the generated command line against `UKI_CMDLINE_BASE`).

## Impact

**This changes the measured guest command line.** The UKI PE section digests, `metadata.json` and the derived RTMRs all shift, so attestation baselines have to be refreshed with the image that ships this.

## Follow-up

The command line is stated independently in the two image backends and only the mkosi path is guarded by the "must not be restated" check in `os/mkosi/tests/acceptance.sh`. This PR had to edit both by hand. A cross-backend consistency check would be worth adding separately.