### PR TITLE
fix(os): ship systemd drop-ins as vendor config, not into /etc

### DIFF
--- a/os/mkosi/components/dstack-rust/dstack-rust-build.sh
+++ b/os/mkosi/components/dstack-rust/dstack-rust-build.sh
@@ -7,8 +7,8 @@ DEST=$(realpath -m "$DEST")
 FLAVOR=${2:-prod}
 install -d "$DEST/usr/bin" "$DEST/usr/lib/systemd/system" \
   "$DEST/etc/systemd/journald.conf.d" "$DEST/etc/systemd/resolved.conf.d" \
-  "$DEST/etc/systemd/system/docker.service.d" \
-  "$DEST/etc/systemd/system/containerd.service.d" "$DEST/etc/sysctl.d"
+  "$DEST/usr/lib/systemd/system/docker.service.d" \
+  "$DEST/usr/lib/systemd/system/containerd.service.d" "$DEST/etc/sysctl.d"
 for s in dstack-prepare ephemeral-docker app-compose; do
   install -m0755 "$ROOT/os/common/rootfs/$s.sh" "$DEST/usr/bin/$s.sh"
 done
@@ -18,10 +18,11 @@ install -m0644 "$ROOT/os/common/rootfs/journald.conf" "$DEST/etc/systemd/journal
 install -m0644 "$ROOT/os/common/rootfs/llmnr.conf" "$DEST/etc/systemd/resolved.conf.d/dstack.conf"
 install -m0644 "$ROOT/os/common/rootfs/tdx-attest.conf" "$DEST/etc/"
 install -m0644 "$ROOT/os/common/rootfs/sysctl.d/99-dstack.conf" "$DEST/etc/sysctl.d/"
+# Vendor drop-ins go beside the units, not into the operator's /etc layer.
 install -m0644 "$ROOT/os/common/rootfs/docker.service.d/"* \
-  "$DEST/etc/systemd/system/docker.service.d/"
+  "$DEST/usr/lib/systemd/system/docker.service.d/"
 install -m0644 "$ROOT/os/common/rootfs/containerd.service.d/"* \
-  "$DEST/etc/systemd/system/containerd.service.d/"
+  "$DEST/usr/lib/systemd/system/containerd.service.d/"
 
 # Cargo.lock and --locked pin every registry/git dependency. The hermetic
 # mkosi build root may fetch missing inputs but cannot update the lock file.
@@ -77,7 +78,7 @@ if [[ ${DSTACK_SKIP_RUST:-0} != 1 ]]; then
     # else systemd never reads it and dstack-prepare loses its ordering against
     # the simulator that has to publish the TEE ABI first.
     install -Dm0644 "$ROOT/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/files/tee-simulator.conf" \
-      "$DEST/etc/systemd/system/dstack-prepare.service.d/tee-simulator.conf"
+      "$DEST/usr/lib/systemd/system/dstack-prepare.service.d/tee-simulator.conf"
   fi
 fi
 find "$DEST" -print0 | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH:?}"

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -85,7 +85,7 @@
   "dev_only_paths": [
     "usr/bin/dstack-tee-simulator",
     "usr/bin/swtpm",
-    "etc/systemd/system/dstack-prepare.service.d/tee-simulator.conf",
+    "usr/lib/systemd/system/dstack-prepare.service.d/tee-simulator.conf",
     "usr/bin/strace",
     "usr/bin/gdb",
     "usr/sbin/sshd",
@@ -142,7 +142,7 @@
   "prod_forbidden_paths": [
     "usr/bin/dstack-tee-simulator",
     "usr/bin/swtpm",
-    "etc/systemd/system/dstack-prepare.service.d/tee-simulator.conf",
+    "usr/lib/systemd/system/dstack-prepare.service.d/tee-simulator.conf",
     "usr/bin/strace",
     "usr/bin/gdb",
     "usr/sbin/sshd",

--- a/os/yocto/layers/meta-dstack/recipes-core/dstack-guest/dstack-guest.bb
+++ b/os/yocto/layers/meta-dstack/recipes-core/dstack-guest/dstack-guest.bb
@@ -88,18 +88,21 @@ do_install() {
         install -m 0644 ${DSTACK_ROOTFS_FILES}/dstack-gateway-checker.service ${D}${systemd_system_unitdir}
         install -m 0644 ${DSTACK_ROOTFS_FILES}/dstack-guest-agent.socket ${D}${systemd_system_unitdir}
         install -m 0644 ${DSTACK_ROOTFS_FILES}/llmnr.conf ${D}${sysconfdir}/systemd/resolved.conf.d
-        install -d ${D}${sysconfdir}/systemd/system/docker.service.d
-        install -m 0644 ${DSTACK_ROOTFS_FILES}/docker.service.d/* ${D}${sysconfdir}/systemd/system/docker.service.d/
+        # Drop-ins the image ships are vendor configuration, so they belong
+        # beside the units in ${systemd_system_unitdir}. /etc is the operator's
+        # layer and `systemctl revert` deletes <unit>.d/ below it wholesale.
+        install -d ${D}${systemd_system_unitdir}/docker.service.d
+        install -m 0644 ${DSTACK_ROOTFS_FILES}/docker.service.d/* ${D}${systemd_system_unitdir}/docker.service.d/
 
-        install -d ${D}${sysconfdir}/systemd/system/containerd.service.d
-        install -m 0644 ${DSTACK_ROOTFS_FILES}/containerd.service.d/* ${D}${sysconfdir}/systemd/system/containerd.service.d/
+        install -d ${D}${systemd_system_unitdir}/containerd.service.d
+        install -m 0644 ${DSTACK_ROOTFS_FILES}/containerd.service.d/* ${D}${systemd_system_unitdir}/containerd.service.d/
     fi
 }
 
 FILES:${PN} += " \
-    ${sysconfdir}/systemd/system/docker.service.d/dstack-guest-agent.conf \
-    ${sysconfdir}/systemd/system/docker.service.d/dstack-prepare.conf \
-    ${sysconfdir}/systemd/system/containerd.service.d/dstack-prepare.conf \
+    ${systemd_system_unitdir}/docker.service.d/dstack-guest-agent.conf \
+    ${systemd_system_unitdir}/docker.service.d/dstack-prepare.conf \
+    ${systemd_system_unitdir}/containerd.service.d/dstack-prepare.conf \
 "
 
 # Cargo embeds build paths into binaries; allow TMPDIR references.

--- a/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/dstack-tee-simulator.bb
+++ b/os/yocto/layers/meta-dstack/recipes-core/dstack-tee-simulator/dstack-tee-simulator.bb
@@ -52,9 +52,9 @@ do_install() {
     install -m 0644 ${THISDIR}/files/dstack-tee-simulator.service \
         ${D}${systemd_system_unitdir}
 
-    install -d ${D}${sysconfdir}/systemd/system/dstack-prepare.service.d
+    install -d ${D}${systemd_system_unitdir}/dstack-prepare.service.d
     install -m 0644 ${THISDIR}/files/tee-simulator.conf \
-        ${D}${sysconfdir}/systemd/system/dstack-prepare.service.d/tee-simulator.conf
+        ${D}${systemd_system_unitdir}/dstack-prepare.service.d/tee-simulator.conf
 }
 
 # Unit/drop-in live next to this recipe; include them in task checksums.
@@ -63,7 +63,7 @@ do_install[file-checksums] += "\
     ${THISDIR}/files/tee-simulator.conf:True \
 "
 
-FILES:${PN} += "${sysconfdir}/systemd/system/dstack-prepare.service.d/tee-simulator.conf"
+FILES:${PN} += "${systemd_system_unitdir}/dstack-prepare.service.d/tee-simulator.conf"
 
 # Cargo embeds build paths into binaries; allow TMPDIR references.
 INSANE_SKIP:${PN} += "buildpaths"


### PR DESCRIPTION
## Why

The image stages its systemd drop-ins into `/etc/systemd/system/<unit>.d/`. That is the **administrator's** layer, and `systemctl(1)` is explicit about what living there means:

> `revert UNIT…` removes drop-in configuration files that modify the specified units […] the matching directories `foo.service.d/` with all their contained files are removed, both below the persistent and runtime configuration directories (i.e. below **/etc/systemd/system** and /run/systemd/system)

So a perfectly ordinary `systemctl revert docker` **deletes** `dstack-prepare.conf` and `dstack-guest-agent.conf`, and docker loses its ordering against `dstack-prepare.service` and `dstack-guest-agent.service`. Same for containerd, and for the simulator's ordering drop-in on `dstack-prepare.service`.

None of these are operator configuration. They are ordering the image itself depends on:

```ini
[Unit]
Wants=dstack-prepare.service
After=dstack-prepare.service
```

The inconsistency was already visible **inside a single drop-in directory** — `dstack-prepare.service.d/` holds `10-nvidia-gpu-ordering.conf` under `${systemd_system_unitdir}` and `tee-simulator.conf` under `${sysconfdir}`.

## What changed

Four drop-ins move from `/etc/systemd/system/` to `/usr/lib/systemd/system/`, in both image backends:

| drop-in | unit |
|---|---|
| `dstack-guest-agent.conf` | `docker.service` |
| `dstack-prepare.conf` | `docker.service` |
| `dstack-prepare.conf` | `containerd.service` |
| `tee-simulator.conf` | `dstack-prepare.service` |

`parity.json` is updated so the backend comparison tracks the new paths.

## Nothing is lost

Drop-ins from **every** search directory are applied, ordered lexically by filename across directories, so `systemctl edit` still wins with its `override.conf`. The image simply stops occupying the namespace reserved for whoever operates it — and gains the property that `systemctl revert` restores the vendor state instead of destroying it.

There is no measurement consequence either way: dstack overlays `/etc`, `/usr` and `/bin` alike, with measured content in the lower layer and writes in a tmpfs that resets each boot.

## Testing

Rebuilt both affected recipes against the vendored yocto tree. `bitbake -c package` succeeds and the drop-ins land in the new location:

```
/dstack-guest/usr/lib/systemd/system/docker.service.d/dstack-guest-agent.conf
/dstack-guest/usr/lib/systemd/system/docker.service.d/dstack-prepare.conf
/dstack-guest/usr/lib/systemd/system/containerd.service.d/dstack-prepare.conf
/dstack-tee-simulator/usr/lib/systemd/system/dstack-prepare.service.d/tee-simulator.conf
```

`shellcheck -x -P SCRIPTDIR` clean on the mkosi build script, `parity.json` still parses.

## Scope

The NVIDIA fabric-manager drop-in has the same problem but is fixed in #1157, which already touches that file — this PR deliberately leaves it alone to avoid a conflict. After both land, no image-shipped drop-in remains under `/etc`.