### PR TITLE
docs(verifier): correct the acpi_tables_verified contract

### DIFF
--- a/dstack/dstack-mr/src/tdx.rs
+++ b/dstack/dstack-mr/src/tdx.rs
@@ -103,6 +103,8 @@ fn machine_from_vm_config(vm_config: &VmConfig, ovmf_variant: OvmfVariant) -> cr
 /// otherwise replays the digests the guest reported in its event log, which
 /// makes those three RTMR0 entries self-consistent but unconstrained; comparing
 /// against these expected digests is what turns them into a verified value.
+/// The verifier does exactly that on both TDX paths, and treats a mismatch --
+/// and a VM shape this cannot model -- as fatal rather than unverified.
 pub fn expected_rtmr0_acpi_hashes(
     vm_config: &VmConfig,
     ovmf_variant: OvmfVariant,

--- a/dstack/verifier/src/types.rs
+++ b/dstack/verifier/src/types.rs
@@ -90,10 +90,15 @@ pub struct VerificationDetails {
     pub os_image_hash_verified: bool,
     /// Indicates that TDX ACPI table contents were verified.
     ///
-    /// This is true for the full-image TDX path, where the verifier recomputes
-    /// ACPI tables and checks the resulting RTMRs against the quote. It remains
-    /// false for TDX lite, which replays ACPI DATA digests from the event log
-    /// without validating the table contents.
+    /// Both dstack TDX paths set this. The full-image path recomputes the
+    /// tables and checks the resulting RTMRs against the quote. The lite path
+    /// recomputes the three RTMR0 ACPI DATA digests from the declared VM shape
+    /// and rejects the attestation when they disagree with the ones the guest
+    /// reported, then rebuilds RTMR0 from the recomputed digests, so neither
+    /// path lets host-reported table content reach the expected value.
+    ///
+    /// It stays false where the check does not apply: GCP TDX, which measures
+    /// through the vTPM instead, and the SEV-SNP and Nitro Enclave paths.
     pub acpi_tables_verified: bool,
     /// dev vs prod OS image, from metadata.json (bound to os_image_hash). None if not exposed.
     pub os_image_is_dev: Option<bool>,


### PR DESCRIPTION
## The problem

`VerificationDetails::acpi_tables_verified` documents the opposite of what the code does:

```rust
/// This is true for the full-image TDX path, where the verifier recomputes
/// ACPI tables and checks the resulting RTMRs against the quote. It remains
/// false for TDX lite, which replays ACPI DATA digests from the event log
/// without validating the table contents.
```

TDX lite has validated them since 7f63d5fe03 (*verify TDX lite ACPI tables against the declared VM shape*). `verify_os_image_hash_for_dstack_tdx_lite` reads the three named RTMR0 ACPI DATA digests from the event log, recomputes them with `expected_rtmr0_acpi_hashes()` from the declared VM shape, bails on any mismatch, and then rebuilds RTMR0 from the **recomputed** digests — so host-reported table content never reaches the expected measurement. `verification.rs` sets the flag true on both TDX paths (lines 984 and 1057); only the comment was left behind.

## Why it is worth a PR

This field is part of the verifier's response. It is precisely what someone reads to decide how much a lite attestation proves, and today it tells them the ACPI check is skipped. I hit this myself while auditing the ACPI measurement chain and concluded — wrongly — that `RTMR0`'s ACPI entries were unconstrained under lite.

## What changed

Two doc comments, no code.

- `verifier/src/types.rs` — state that both dstack TDX paths verify, and that the flag is false only where the check does not apply: GCP TDX (measures through the vTPM), SEV-SNP, and Nitro Enclave. Confirmed by tracing every assignment: `verify_os_image_hash_for_dstack_tdx` and `verify_os_image_hash_for_dstack_tdx_lite` set it; `verify_os_image_hash_for_gcp_tdx` and the SNP/Nitro paths do not.
- `dstack-mr/src/tdx.rs` — the note on `expected_rtmr0_acpi_hashes` was accurate but read as if the lite path only ever replays reported digests. Added that the verifier calls it on both paths and treats a mismatch, or a VM shape the generator cannot model, as fatal rather than unverified.

## Testing

`cargo check -p dstack-verifier -p dstack-mr` and `cargo fmt --check` clean. Documentation only; no behaviour change.