### PR TITLE
fix(os): drop guest kernel drivers no CVM can reach

### DIFF
--- a/os/mkosi/components/kernel/kernel.config
+++ b/os/mkosi/components/kernel/kernel.config
@@ -302,3 +302,38 @@ CONFIG_NETFILTER_XT_TARGET_CHECKSUM=m
 # No IP6_NF_* counterpart to dstack-docker.cfg's: this image has no legacy
 # tables at all, so there is no legacy ip6tables to complete. The nftables
 # frontend synthesises the IPv6 nat table Incus lists, with no module behind it.
+
+# Devices that cannot exist in a CVM. x86_64_defconfig builds these for bare
+# metal, but a dstack guest only ever sees virtio, plus GVE on GCP and ENA on
+# AWS, both enabled above. Leaving the rest in means a host that presents the
+# matching PCI IDs can steer the guest into driver code no deployment uses.
+# Passing a ConnectX NIC through later is an addition here -- CONFIG_MLX5_CORE
+# and the INFINIBAND stack -- not a relaxation of these.
+CONFIG_TIGON3=n
+CONFIG_E100=n
+CONFIG_E1000=n
+CONFIG_E1000E=n
+CONFIG_SKY2=n
+CONFIG_FORCEDETH=n
+CONFIG_8139TOO=n
+CONFIG_R8169=n
+CONFIG_NET_TULIP=n
+
+# Buses and platform glue with no counterpart in a virtual machine.
+CONFIG_PCCARD=n
+CONFIG_AGP=n
+CONFIG_MACINTOSH_DRIVERS=n
+CONFIG_NVRAM=n
+
+# Early-boot debug paths that exist to give an external device access to memory
+# before the kernel is up. PROVIDE_OHCI1394_DMA_INIT enables FireWire DMA
+# specifically so a machine can be debugged over the bus, which is the same
+# primitive an untrusted host would want; EARLY_PRINTK_DBGP is the USB debug
+# port equivalent. Neither is reachable from anything a tenant needs.
+CONFIG_PROVIDE_OHCI1394_DMA_INIT=n
+CONFIG_EARLY_PRINTK_DBGP=n
+
+# NETCONSOLE ships the kernel log to a UDP peer. Inside a CVM that is an
+# egress channel for whatever the log happens to contain, configurable at
+# runtime by root, and nothing in the image uses it.
+CONFIG_NETCONSOLE=n

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
@@ -103,3 +103,27 @@ CONFIG_FUSE_FS=y
 CONFIG_CUSE=y
 CONFIG_TCG_TPM=y
 CONFIG_TCG_VTPM_PROXY=y
+
+# Devices that cannot exist in a CVM. The linux-yocto baseline builds these for
+# bare metal, but a dstack guest only ever sees virtio, plus gVNIC on GCP and
+# ENA on AWS. Leaving them in means a host that presents the matching PCI IDs
+# can steer the guest into driver code no deployment uses. Kept in step with
+# os/mkosi/components/kernel/kernel.config so both guest kernels carry the same
+# device policy. Passing a ConnectX NIC through later is an addition here --
+# CONFIG_MLX5_CORE and the INFINIBAND stack -- not a relaxation of these.
+CONFIG_TIGON3=n
+CONFIG_E100=n
+CONFIG_E1000=n
+CONFIG_E1000E=n
+CONFIG_SKY2=n
+CONFIG_FORCEDETH=n
+CONFIG_8139TOO=n
+CONFIG_R8169=n
+CONFIG_NET_TULIP=n
+CONFIG_PCCARD=n
+CONFIG_AGP=n
+CONFIG_MACINTOSH_DRIVERS=n
+CONFIG_NVRAM=n
+CONFIG_PROVIDE_OHCI1394_DMA_INIT=n
+CONFIG_EARLY_PRINTK_DBGP=n
+CONFIG_NETCONSOLE=n


### PR DESCRIPTION
## Why

Both guest kernels inherit a bare-metal device set from their baselines — `x86_64_defconfig` for mkosi, the linux-yocto machine config for yocto — and neither fragment says anything about it. So both images currently ship:

```
CONFIG_TIGON3   CONFIG_E100   CONFIG_E1000   CONFIG_E1000E
CONFIG_SKY2     CONFIG_FORCEDETH   CONFIG_8139TOO   CONFIG_R8169
CONFIG_PCCARD   CONFIG_AGP    CONFIG_MACINTOSH_DRIVERS   CONFIG_NVRAM
```

None of these can appear in a CVM. A dstack guest sees virtio, plus gVNIC on GCP and ENA on AWS — all three already enabled deliberately. Everything else is driver code that a host presenting the matching PCI IDs can steer the guest into, through ordinary enumeration.

This matters because **the kernel config is the only device allowlist this project actually has.** Intel's `authorize_allow_devs` device filter lives in the out-of-tree `ccc-linux-guest-hardening` patchset and is TDX-only (`arch/x86/kernel/tdx-filter.c` does not exist upstream), while dstack supports TDX and SEV-SNP from one image. `CONFIG_*` is enforced at link time — the code is not present at all — and applies to both.

The fragments already do this well for whole subsystems (`WLAN`, `BT`, `USB_SUPPORT`, `SCSI`, `ATA`, `SOUND`, `INPUT`, `KEXEC`, `HIBERNATION`, …). This extends the same policy to what the baseline drags in underneath.

## Beyond the drivers

Three entries are harder to justify than the rest and are worth calling out:

- **`PROVIDE_OHCI1394_DMA_INIT`** exists to give a FireWire device access to memory before the kernel is up. That is the primitive an untrusted host would want, not a feature a tenant needs.
- **`EARLY_PRINTK_DBGP`** is the USB debug port equivalent.
- **`NETCONSOLE`** ships the kernel log to a UDP peer, configurable at runtime by root, and nothing in the image uses it.

## Testing

Each backend's own kconfig flow, run against linux 6.18.39:

**mkosi** — `make x86_64_defconfig`, `merge_config.sh`, `make olddefconfig`, then the repo's own `check-kernel-config.sh` over the fragment:

```
defconfig ok / merge ok / olddefconfig ok
check 退出码=0
```

All sixteen symbols end up unset.

**yocto** — `bitbake -c configure virtual/kernel`, then the resulting `.config`: same sixteen unset.

Unaffected in both: `CONFIG_VIRTIO_NET=y`, `CONFIG_GVE=y`, `CONFIG_ENA_ETHERNET=y`, `CONFIG_DRM=y`, `CONFIG_NET_VENDOR_GOOGLE=y`, `CONFIG_NET_VENDOR_AMAZON=y`.

Verification mattered here rather than being a formality: `check-kernel-config.sh` fails the build when a fragment line does not survive `olddefconfig`, so a symbol something else selects back on would have broken CI rather than silently doing nothing.

## Future RDMA passthrough

Both fragments carry a note that passing a ConnectX NIC into the guest later is an **addition** — `CONFIG_MLX5_CORE`, `CONFIG_MLX5_INFINIBAND`, `CONFIG_INFINIBAND`, `CONFIG_INFINIBAND_USER_ACCESS` — and not a relaxation of anything here. Those symbols are absent from both baselines today, so the two are orthogonal.

## Note for review

`os/yocto`'s `dstack.cfg` is **not** gated by `check-kernel-config.sh`: `export-artifacts.sh` only gates `dstack-docker.cfg`, because `dstack.cfg` carries six lines the build does not satisfy (`HOTPLUG_CPU`/`SCSI`/`INPUT` forced back on by machine-level features, and `TLS`/`CRYPTO_GCM`/`CRYPTO_CHACHA20POLY1305` not asserted). So the yocto half of this rests on the configure run above rather than on CI. Gating it — which also means resolving those six — is worth a follow-up.