### PR TITLE
feat(vmm): list the Hopper and Blackwell GPUs dstack runs on

### DIFF
--- a/docs/tutorials/vmm-configuration.md
+++ b/docs/tutorials/vmm-configuration.md
@@ -305,8 +305,7 @@ To enable GPU passthrough for AI/ML workloads:
 ```toml
 [cvm.gpu]
 enabled = true
-# Defaults to the Hopper and Blackwell data center SKUs; narrow it to what the
-# host actually holds if you want discovery to reject anything else.
+# Example: narrow this list to what the host actually holds if you want discovery to reject anything else.
 listing = ["10de:2335", "10de:3182"]   # H200 SXM, B300 SXM6
 allow_attach_all = true
 ```

--- a/docs/tutorials/vmm-configuration.md
+++ b/docs/tutorials/vmm-configuration.md
@@ -305,9 +305,16 @@ To enable GPU passthrough for AI/ML workloads:
 ```toml
 [cvm.gpu]
 enabled = true
-listing = ["10de:2335"]          # NVIDIA GPU product IDs
+# Defaults to the Hopper and Blackwell data center SKUs; narrow it to what the
+# host actually holds if you want discovery to reject anything else.
+listing = ["10de:2335", "10de:3182"]   # H200 SXM, B300 SXM6
 allow_attach_all = true
 ```
+
+A card whose product ID is not in `listing` is never offered for passthrough,
+so the shipped default names every Hopper and Blackwell SKU dstack runs on —
+see `[cvm.gpu]` in `dstack/vmm/vmm.toml` for the annotated list. NVSwitches are
+not listed: the `all` attach mode finds GPUs and switches by PCI class instead.
 
 **Requirements:**
 - IOMMU enabled in BIOS

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -166,9 +166,27 @@ check_interval_secs = 5
 
 [cvm.gpu]
 enabled = false
-# The product IDs of the GPUs to discover
-# H200: 10de:2335
-listing = ["10de:2335"]
+# The product IDs of the GPUs to discover. A card whose ID is missing here is
+# not offered for passthrough at all, so the list has to name every SKU a
+# deployment might hold. IDs are from pci.ids; the names are its labels.
+#
+# NVSwitches do not belong here. The "all" attach mode finds GPUs and switches
+# by PCI class rather than through this list, which only gates GPU discovery.
+listing = [
+    # Hopper
+    "10de:2330", # GH100 [H100 SXM5 80GB]
+    "10de:2331", # GH100 [H100 PCIe]
+    "10de:2337", # GH100 [H100 SXM5 64GB]
+    "10de:2338", # GH100 [H100 SXM5 96GB]
+    "10de:2339", # GH100 [H100 SXM5 94GB]
+    "10de:2321", # GH100 [H100L 94GB], sold as H100 NVL
+    "10de:2335", # GH100 [H200 SXM 141GB]
+    "10de:233b", # GH100 [H200 NVL]
+    # Blackwell
+    "10de:2901", # GB100 [B200]
+    "10de:2909", # GB100 [HGX B200 168GB]
+    "10de:3182", # GB110 [B300 SXM6]
+]
 # The PCI addresses of the cards to exclude
 exclude = []
 # The PCI addresses of the cards to include


### PR DESCRIPTION
## Why

`[cvm.gpu] listing` shipped one entry:

```toml
# H200: 10de:2335
listing = ["10de:2335"]
```

`GpuConfig::list_devices()` filters on this list, so a card whose product ID is missing is **never offered for passthrough**. The shipped default therefore refuses every GPU dstack supports except the H200 SXM — including B300, whose `10de:3182` is what prompted this.

## What changed

The list now names each Hopper and Blackwell data center SKU with its `pci.ids` label:

```toml
listing = [
    # Hopper
    "10de:2330", # GH100 [H100 SXM5 80GB]
    "10de:2331", # GH100 [H100 PCIe]
    "10de:2337", # GH100 [H100 SXM5 64GB]
    "10de:2338", # GH100 [H100 SXM5 96GB]
    "10de:2339", # GH100 [H100 SXM5 94GB]
    "10de:2321", # GH100 [H100L 94GB], sold as H100 NVL
    "10de:2335", # GH100 [H200 SXM 141GB]
    "10de:233b", # GH100 [H200 NVL]
    # Blackwell
    "10de:2901", # GB100 [B200]
    "10de:2909", # GB100 [HGX B200 168GB]
    "10de:3182", # GB110 [B300 SXM6]
]
```

Coverage follows NVIDIA's **Secure AI compatibility matrix** — the thing that decides whether a GPU can run confidential workloads at all. Every H100 SXM5 capacity, H100 PCIe, H100 NVL, H200 SXM, H200 NVL, B200 and B300 entry in that matrix now has an ID here.

IDs come from the upstream `pci.ids` database rather than from memory. `10de:2901` is independently corroborated by the `lspci` output NVIDIA prints in the Confidential Computing Deployment Guide (`# Example for DGX B200: 1b:00.0 0302: 10de:2901`).

## Deliberately left out

- **NVSwitches.** `resolve_gpus()` in `main_service.rs` handles the `all` attach mode by filtering on vendor `10de` and classifying by PCI class (`3D controller` → GPU, `Bridge` → NVSwitch). It never consults `listing`. Adding switch IDs here would imply a coupling that does not exist.
- **H800, H20, and RTX PRO 6000 Blackwell Server Edition.** The matrix covers them, but no deployment has asked for them yet, and the H20 variants (`2328` H20B, `2329` H20, `232c` H20 HBM3e, `230c`/`230e` H20 NVL16) do not map cleanly onto the matrix's "HGX H20 141GB HBM3e" and "HGX H20A HBM3 96GB" entries. Guessing an ID into a passthrough allowlist is worse than leaving it out. Say the word and I will add whichever of these you want.

## Docs

`docs/tutorials/vmm-configuration.md` carried its own `listing = ["10de:2335"]` example. Updated, with a note that the shipped default already covers the supported SKUs and that NVSwitches are found by class rather than listed.

## Testing

`cargo test -p dstack-vmm` — 128 passed. The file is compiled in through `include_str!` as `DEFAULT_CONFIG`, so a TOML error would fail the build; also parsed independently to confirm 11 entries, no duplicates, all matching `10de:[0-9a-f]{4}`.