### PR TITLE
feat(size-parser): accept petabytes and the multi-letter unit spellings

### DIFF
--- a/dstack/size-parser/src/lib.rs
+++ b/dstack/size-parser/src/lib.rs
@@ -46,8 +46,8 @@ pub enum MemorySizeError {
     InvalidHex(String),
     #[error("Invalid numeric value: {0}")]
     InvalidNumber(String),
-    #[error("Unknown memory size suffix: {0}")]
-    UnknownSuffix(char),
+    #[error("Unknown memory size unit: {0}")]
+    UnknownUnit(String),
     #[error("Overflow in memory size calculation")]
     Overflow,
 }
@@ -95,13 +95,19 @@ impl MemorySize {
     /// Supports the following formats:
     /// - Plain numbers: "1024", "2048"
     /// - Hexadecimal: "0x1000", "0X2000"
-    /// - With suffixes: "2K", "4M", "1G", "2T" (case-insensitive)
+    /// - With suffixes: "2K", "4M", "1G", "2T", "1P" (case-insensitive)
+    /// - Two- and three-letter spellings of the same units: "4MB", "1GiB",
+    ///   "2TB", "1PiB", and a bare "B" for bytes
     ///
-    /// Suffixes use binary (1024-based) multipliers:
-    /// - K/k: 1024 bytes
-    /// - M/m: 1024^2 bytes
-    /// - G/g: 1024^3 bytes
-    /// - T/t: 1024^4 bytes
+    /// Every suffix is a binary (1024-based) multiplier, including the "B" and
+    /// "iB" spellings. "1KB" is 1024 bytes, not 1000: the crate names sizes the
+    /// way QEMU and the kernel do, and silently switching to powers of ten for
+    /// one spelling would be worse than being consistently binary.
+    /// - K/KB/KiB: 1024 bytes
+    /// - M/MB/MiB: 1024^2 bytes
+    /// - G/GB/GiB: 1024^3 bytes
+    /// - T/TB/TiB: 1024^4 bytes
+    /// - P/PB/PiB: 1024^5 bytes
     pub fn parse(s: &str) -> Result<Self, MemorySizeError> {
         let s = s.trim();
 
@@ -125,22 +131,30 @@ impl MemorySize {
             return Ok(Self::from_bytes(bytes));
         }
 
-        // Handle numbers with suffixes
-        let Some(last_char) = s.chars().last() else {
-            return Err(MemorySizeError::Empty);
-        };
+        // Handle numbers with suffixes. Split at the first non-digit rather
+        // than trimming the trailing character: trim_end_matches removes every
+        // repetition, so "1GG" used to lose both and parse as 1 GiB.
+        let split = s
+            .find(|c: char| !c.is_ascii_digit())
+            .ok_or_else(|| MemorySizeError::InvalidNumber(s.to_string()))?;
+        let (num_part, unit) = s.split_at(split);
+        // No digits at all is a malformed number, not a malformed unit. The
+        // previous implementation classified "abc" by its last character and
+        // called it an unknown suffix, which pointed at the wrong half.
+        if num_part.is_empty() {
+            return Err(MemorySizeError::InvalidNumber(s.to_string()));
+        }
 
-        let multiplier = match last_char.to_ascii_lowercase() {
-            'k' => 1024u64,
-            'm' => 1024u64.saturating_mul(1024),
-            'g' => 1024u64.saturating_mul(1024).saturating_mul(1024),
-            't' => 1024u64
-                .saturating_mul(1024)
-                .saturating_mul(1024)
-                .saturating_mul(1024),
-            _ => return Err(MemorySizeError::UnknownSuffix(last_char)),
+        const KIB: u64 = 1024;
+        let multiplier = match unit.to_ascii_lowercase().as_str() {
+            "b" => 1,
+            "k" | "kb" | "kib" => KIB,
+            "m" | "mb" | "mib" => KIB.pow(2),
+            "g" | "gb" | "gib" => KIB.pow(3),
+            "t" | "tb" | "tib" => KIB.pow(4),
+            "p" | "pb" | "pib" => KIB.pow(5),
+            _ => return Err(MemorySizeError::UnknownUnit(unit.to_string())),
         };
-        let num_part = s.trim_end_matches(last_char);
         let num = num_part
             .parse::<u64>()
             .map_err(|_| MemorySizeError::InvalidNumber(num_part.to_string()))?;
@@ -155,6 +169,7 @@ impl MemorySize {
     /// Format the memory size in a human-readable way
     pub fn format_human(&self) -> String {
         const UNITS: &[(&str, u64)] = &[
+            ("P", 1024u64.pow(5)),
             ("T", 1024u64.pow(4)),
             ("G", 1024u64.pow(3)),
             ("M", 1024u64.pow(2)),
@@ -438,6 +453,43 @@ mod tests {
         assert_eq!(MemorySize::parse("1M").unwrap().bytes(), 1024 * 1024);
         assert_eq!(MemorySize::parse("2m").unwrap().bytes(), 2 * 1024 * 1024);
         assert_eq!(MemorySize::parse("1G").unwrap().bytes(), 1024 * 1024 * 1024);
+        // Petabytes, and the two- and three-letter spellings of every unit.
+        assert_eq!(MemorySize::parse("1P").unwrap().bytes(), 1024u64.pow(5));
+        assert_eq!(MemorySize::parse("1p").unwrap().bytes(), 1024u64.pow(5));
+        assert_eq!(MemorySize::parse("1PB").unwrap().bytes(), 1024u64.pow(5));
+        assert_eq!(MemorySize::parse("1PiB").unwrap().bytes(), 1024u64.pow(5));
+        assert_eq!(MemorySize::parse("1pib").unwrap().bytes(), 1024u64.pow(5));
+        assert_eq!(
+            MemorySize::parse("2TB").unwrap().bytes(),
+            2 * 1024u64.pow(4)
+        );
+        assert_eq!(
+            MemorySize::parse("2TiB").unwrap().bytes(),
+            2 * 1024u64.pow(4)
+        );
+        assert_eq!(
+            MemorySize::parse("4GB").unwrap().bytes(),
+            4 * 1024u64.pow(3)
+        );
+        assert_eq!(
+            MemorySize::parse("4MiB").unwrap().bytes(),
+            4 * 1024u64.pow(2)
+        );
+        assert_eq!(MemorySize::parse("8KB").unwrap().bytes(), 8 * 1024);
+        assert_eq!(MemorySize::parse("512B").unwrap().bytes(), 512);
+        // "KB" is binary here, matching every other spelling in this crate.
+        assert_eq!(MemorySize::parse("1KB").unwrap().bytes(), 1024);
+        // The production pci_hole64_size value, in every accepted spelling.
+        let one_pib = 1125899906842624u64;
+        for spelling in ["1P", "1PiB", "1024T", "0x4000000000000", "1125899906842624"] {
+            assert_eq!(
+                MemorySize::parse(spelling).unwrap().bytes(),
+                one_pib,
+                "{spelling}"
+            );
+        }
+        // A repeated suffix is rejected instead of silently losing a letter.
+        assert!(MemorySize::parse("1GG").is_err());
         assert_eq!(
             MemorySize::parse("2g").unwrap().bytes(),
             2 * 1024 * 1024 * 1024
@@ -455,7 +507,7 @@ mod tests {
         ));
         assert!(matches!(
             MemorySize::parse("abc"),
-            Err(MemorySizeError::UnknownSuffix('c'))
+            Err(MemorySizeError::InvalidNumber(_))
         ));
         assert!(matches!(
             MemorySize::parse("0xgg"),

--- a/dstack/size-parser/src/lib.rs
+++ b/dstack/size-parser/src/lib.rs
@@ -97,7 +97,7 @@ impl MemorySize {
     /// - Hexadecimal: "0x1000", "0X2000"
     /// - With suffixes: "2K", "4M", "1G", "2T", "1P" (case-insensitive)
     /// - Two- and three-letter spellings of the same units: "4MB", "1GiB",
-    ///   "2TB", "1PiB", and a bare "B" for bytes
+    ///   "2TB", "1PiB", and "B" as a bytes suffix (e.g. "512B")
     ///
     /// Every suffix is a binary (1024-based) multiplier, including the "B" and
     /// "iB" spellings. "1KB" is 1024 bytes, not 1000: the crate names sizes the

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -64,10 +64,21 @@ use_mrconfigid = true
 # suffix: "512G", "2T", "1P" -- all binary multipliers, as are the "1PB" and
 # "1PiB" spellings.
 #
-# 0 leaves the hole at QEMU's default, which is far below what GPU passthrough
-# needs: a data center card's VRAM aperture alone is 256 GiB on an H200 SXM and
-# 512 GiB on a B300, so eight of them want 2 to 4 TiB. Hosts running GPUs set
-# this to "1P", which is what Phala's H200 fleet runs today.
+# 0 leaves QEMU's own 32 GiB hole in place, which cannot host a GPU: a data
+# center card's VRAM aperture alone is 256 GiB on an H200 SXM and 512 GiB on a
+# B300, so eight of them want 2 to 4 TiB. A GPU host wants "8T" -- enough for
+# eight B300s twice over, and it keeps the top of the guest address space at 44
+# bits.
+#
+# Going much higher is not free. The hole is global, shared by every guest on
+# the host, and "1P" (what the H200 fleet runs today) puts the top at 51 bits,
+# past the 48-bit ceiling of 4-level paging: every guest then needs 5-level EPT
+# and, on TDX, GPAW=52, including the ones with no GPU attached.
+#
+# The default stays 0 on purpose. This value feeds the ACPI tables and so the
+# RTMRs, so raising it changes the measurements of every guest that was on the
+# default -- an already deployed app would come back from a restart with a
+# different identity and be refused its keys.
 qemu_pci_hole64_size = 0
 qemu_hotplug_off = false
 # TDX attestation/hash scheme policy:

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -60,6 +60,14 @@ use_mrconfigid = true
 #qemu_single_pass_add_pages = false
 #qemu_pic = true
 #qemu_version = ""
+# Size of the 64-bit PCI hole. Accepts a plain byte count, hex, or a unit
+# suffix: "512G", "2T", "1P" -- all binary multipliers, as are the "1PB" and
+# "1PiB" spellings.
+#
+# 0 leaves the hole at QEMU's default, which is far below what GPU passthrough
+# needs: a data center card's VRAM aperture alone is 256 GiB on an H200 SXM and
+# 512 GiB on a B300, so eight of them want 2 to 4 TiB. Hosts running GPUs set
+# this to "1P", which is what Phala's H200 fleet runs today.
 qemu_pci_hole64_size = 0
 qemu_hotplug_off = false
 # TDX attestation/hash scheme policy:


### PR DESCRIPTION
> Stacked on #1161 because both touch `vmm.toml`. Rebase to `next` once that lands.

## Why

`qemu_pci_hole64_size` already goes through `size_parser::human_size`, so it has accepted `"512G"` all along. What it could **not** accept is the value the fleet actually runs:

```toml
# every vmm.toml on the H200 host
qemu_pci_hole64_size = 1125899906842624      # 1 PiB
```

The parser stopped at `T`, so a petabyte had no spelling and every production config writes the raw byte count. A readable form that cannot express the one value anybody sets is not readable — which is presumably why nobody noticed the field was already parsing units.

It also only ever looked at the **final character**, so `"1TB"` failed on the `B` and `"1PiB"` failed likewise.

## What changed

| Now accepted | Value |
|---|---|
| `1P` / `1p` / `1PB` / `1PiB` / `1pib` | 1024⁵ |
| `2TB` / `2TiB` | 2 × 1024⁴ |
| `4GB` / `4MiB` / `8KB` | binary multiples |
| `512B` | 512 |

Every spelling stays a **binary** multiplier, including `1KB` = 1024. This crate names sizes the way QEMU and the kernel do; switching one spelling to powers of ten would be a worse surprise than being consistently binary. Documented on `parse`.

`format_human` learns `P` too, so it round-trips what `parse` now accepts.

## A quiet bug fixed along the way

The old suffix handling was:

```rust
let num_part = s.trim_end_matches(last_char);
```

`trim_end_matches` removes **every** trailing repetition, so `"1GG"` lost both letters and silently parsed as 1 GiB. Splitting at the first non-digit instead rejects it.

## Two error classifications shift

Both internal to this crate, both more accurate:

- Input with no digits is now `InvalidNumber` rather than an unknown suffix. `"abc"` used to be blamed on its last character (`UnknownSuffix('c')`), which pointed at the wrong half of the string.
- `UnknownSuffix(char)` → `UnknownUnit(String)`, so a bad multi-letter unit can be named in full rather than reduced to one character.

The existing `test_parse_errors` cases were updated to match; they are what caught both differences.

## Testing

`cargo test -p size-parser` — 9 unit tests + doctest. New cases cover every spelling above, the `1GG` rejection, and this equivalence:

```rust
for spelling in ["1P", "1PiB", "1024T", "0x4000000000000", "1125899906842624"] {
    assert_eq!(MemorySize::parse(spelling).unwrap().bytes(), 1125899906842624);
}
```

`cargo test -p dstack-vmm -p dstack-types` also pass (both consume the crate). `cargo fmt --check` and `clippy -D warnings` clean.

## vmm.toml

Documented the accepted spellings on `qemu_pci_hole64_size`, plus why a GPU host has to raise it — an H200 SXM's VRAM aperture is **256 GiB** and a B300's is **512 GiB** (measured on hardware, `lspci -v`), so eight cards want 2–4 TiB of hole.

## Deliberately not changed

The shipped default stays `0`, even though every GPU host in production sets `"1P"` and the default cannot run one. `pci_hole64_size` is an input to `dstack-mr`'s `MachineConfig`, so changing it moves the measurement baseline for **every** VM including GPU-less ones. That belongs in its own change with its own baseline refresh.