### PR TITLE
feat(vmm): default the 64-bit PCI hole to 8T

### DIFF
--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -64,11 +64,19 @@ use_mrconfigid = true
 # suffix: "512G", "2T", "1P" -- all binary multipliers, as are the "1PB" and
 # "1PiB" spellings.
 #
-# 0 leaves the hole at QEMU's default, which is far below what GPU passthrough
-# needs: a data center card's VRAM aperture alone is 256 GiB on an H200 SXM and
-# 512 GiB on a B300, so eight of them want 2 to 4 TiB. Hosts running GPUs set
-# this to "1P", which is what Phala's H200 fleet runs today.
-qemu_pci_hole64_size = 0
+# QEMU's own default is far below what GPU passthrough needs: a data center
+# card's VRAM aperture alone is 256 GiB on an H200 SXM and 512 GiB on a B300,
+# so eight of them want 2 to 4 TiB. The hole costs guest address space rather
+# than memory -- it is where firmware and the guest place 64-bit BARs -- so
+# sizing it generously is cheaper than sizing it exactly.
+#
+# 8T covers eight B300s twice over while keeping the top of the guest address
+# space at 44 bits. That matters because the hole is global: a larger one is
+# not free for the GPU-less guests that share this setting. 1P, which the H200
+# fleet runs today, puts the top at 51 bits, past the 48-bit ceiling of 4-level
+# paging -- so every guest, GPU or not, needs 5-level EPT and, on TDX, GPAW=52.
+# Raise it explicitly if a deployment ever needs more than 8 TiB of BARs.
+qemu_pci_hole64_size = "8T"
 qemu_hotplug_off = false
 # TDX attestation/hash scheme policy:
 # - "legacy": digest.txt + legacy verifier


### PR DESCRIPTION
> Stacked on #1163 (which added the comment block this edits) → #1161. Rebase down as they land.

## Why the default is broken

`qemu_pci_hole64_size = 0` leaves QEMU's own 32 GiB hole in place. Measured on real hardware:

| card | VRAM aperture (BAR2) |
|---|---|
| H200 SXM 141GB | **256 GiB** |
| B300 SXM6 | **512 GiB** |

So the shipped default cannot pass through a single GPU, while **every GPU host in production sets the value by hand**. Anyone starting from this repository hits a wall that the fleet solved long ago and never wrote down.

## Why 8T and not the 1P production runs

The hole is **global** — one setting for every guest on the host — and its size decides where the top of the guest address space lands. Measured with QEMU 8.2.2, `-cpu host`, 4 GiB RAM:

| setting | hole end | top of address space |
|---|---|---|
| unset | `0x980000000` | 36 bits |
| **`8T`** | `0x80180000000` | **44 bits** |
| `1P` | `0x4000180000000` | **51 bits** |

51 bits is past the **48-bit ceiling of 4-level paging**. A 1 PiB hole therefore means 5-level EPT for every guest, and on TDX forces GPAW=52 (GPAW=48 cannot address that high). GPU-less guests share this setting and would pay that for nothing — on the fleet host, 7 of the 15 running VMs have no GPU attached.

`8T` keeps the top at 44 bits, under both that ceiling and the 46 physical address bits the hosts report, while still covering the largest supported topology twice over: 8 × B300 × 512 GiB = 4 TiB.

**Caveat, stated plainly:** no performance delta was measured, and 1P is demonstrably workable since the fleet runs it. The argument is structural, not benchmarked. But 1P is 250× more than the largest topology needs, and crossing a paging boundary for that is a poor trade to make on behalf of every guest. Deployments needing more than 8 TiB of BARs can still set it explicitly.

## Measurement impact

This moves the baseline. `pci_hole64_size` feeds `qemu-acpi`'s `MachineConfig`, so the generated tables change and RTMR0 with them.

Verified with the generator itself (`cargo run -p qemu-acpi --example dump`), same topology, only the hole varying:

```
hole=0                  tables sha256[0:16]=09f99e5dcf36b80a
hole=8796093022208 (8T) tables sha256[0:16]=ffeb6ddb6502ece1
hole=1125899906842624   tables sha256[0:16]=e91f0ee691aa77b9
```

Three distinct digests, so the value is modelled correctly at all three sizes — the baseline **shifts rather than breaks**. `cmp` puts the 0 → 8T difference at **four bytes**: the `_CRS` length field.

## Testing

`cargo test -p dstack-vmm` — 128 passed. `vmm.toml` parses and yields `"8T"`; it is compiled in via `include_str!`, so a bad value fails the build.