### PR TITLE
fix(os/yocto): gate dstack.cfg on the built kernel config

### DIFF
--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
@@ -41,12 +41,9 @@ CONFIG_KPROBES=y
 CONFIG_PM=n
 CONFIG_SUSPEND=n
 CONFIG_PM_SLEEP=n
-CONFIG_HOTPLUG_CPU=n
 CONFIG_HOTPLUG_PCI=n
 CONFIG_BT=n
 CONFIG_MMC=n
-CONFIG_SCSI=n
-CONFIG_INPUT=n
 CONFIG_WLAN=n
 
 # dm-verity verifies the rootfs in the initramfs (no modules loaded yet), so the
@@ -127,3 +124,17 @@ CONFIG_NVRAM=n
 CONFIG_PROVIDE_OHCI1394_DMA_INIT=n
 CONFIG_EARLY_PRINTK_DBGP=n
 CONFIG_NETCONSOLE=n
+
+
+# CONFIG_SCSI, CONFIG_INPUT and CONFIG_HOTPLUG_CPU are deliberately absent even
+# though the mkosi guest kernel turns all three off. KERNEL_FEATURES for the
+# dstack machine pulls in features/scsi/disk.scc, and the machine's own feature
+# set brings the other two, so a =n here loses the merge and the built kernel
+# has them enabled regardless. Asserting them was worse than not asserting
+# them: the three lines were the only reason this whole file could not be
+# checked, which left the other seventy assertions unverified as well.
+#
+# Whether the yocto image can actually drop SCSI -- the mkosi one does, so the
+# two guest kernels differ here -- needs a boot test on GCP and AWS, where the
+# root disk may be virtio-scsi rather than virtio-blk. That belongs in its own
+# change.

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg
@@ -126,13 +126,26 @@ CONFIG_EARLY_PRINTK_DBGP=n
 CONFIG_NETCONSOLE=n
 
 
-# CONFIG_SCSI, CONFIG_INPUT and CONFIG_HOTPLUG_CPU are deliberately absent even
-# though the mkosi guest kernel turns all three off. KERNEL_FEATURES for the
-# dstack machine pulls in features/scsi/disk.scc, and the machine's own feature
-# set brings the other two, so a =n here loses the merge and the built kernel
-# has them enabled regardless. Asserting them was worse than not asserting
-# them: the three lines were the only reason this whole file could not be
-# checked, which left the other seventy assertions unverified as well.
+# CONFIG_SCSI, CONFIG_INPUT and CONFIG_HOTPLUG_CPU are deliberately absent.
+# Each was asserted =n here and each came out y in the built kernel, for a
+# different reason:
+#
+#   HOTPLUG_CPU is `def_bool y, depends on SMP` in arch/x86/Kconfig, with no
+#   prompt. No fragment anywhere can set it. The mkosi guest kernel has it
+#   enabled too; it simply never claimed otherwise.
+#
+#   INPUT only gets a prompt `if EXPERT`, and CONFIG_EXPERT is not set for this
+#   machine, so it falls back to its `default y`. CONFIG_VT=y also selects it.
+#   The mkosi kernel manages to turn it off because it has EXPERT=y *and* VT=n
+#   -- neither alone would be enough.
+#
+#   SCSI is pulled in sideways: KERNEL_FEATURES appends features/scsi/disk.scc
+#   for the dstack machine, whose disk.cfg sets CONFIG_BLK_DEV_SD=y, and
+#   BLK_DEV_SD depends on SCSI.
+#
+# Asserting them was worse than leaving them out: these three were the only
+# reason this whole file could not be checked, which left the other seventy
+# assertions unverified along with them.
 #
 # Whether the yocto image can actually drop SCSI -- the mkosi one does, so the
 # two guest kernels differ here -- needs a boot test on GCP and AWS, where the

--- a/os/yocto/scripts/export-artifacts.sh
+++ b/os/yocto/scripts/export-artifacts.sh
@@ -113,10 +113,11 @@ fi
 # quietly lacks an asserted capability is the failure this guards against.
 #
 # Both fragments are gated. dstack.cfg used to be exempt because three of its
-# lines were not satisfied by the build -- CONFIG_SCSI, CONFIG_INPUT and
-# CONFIG_HOTPLUG_CPU lose to machine-level KERNEL_FEATURES -- and those three
-# kept the other seventy assertions unchecked along with them. They have been
-# dropped from the fragment, which now says only what the build actually does.
+# lines were not satisfied by the build: CONFIG_HOTPLUG_CPU has no prompt to
+# set, CONFIG_INPUT has none either without EXPERT, and CONFIG_SCSI is pulled
+# in by the SCSI disk driver that KERNEL_FEATURES enables. Those three kept the
+# other seventy assertions unchecked along with them; the fragment documents
+# each case and now says only what the build actually does.
 KERNEL_CONFIG_FILE="$COMMON_IMG_DIR/kernel-config"
 if [ -f "$KERNEL_CONFIG_FILE" ]; then
     "$REPO_ROOT/os/common/scripts/check-kernel-config.sh" \

--- a/os/yocto/scripts/export-artifacts.sh
+++ b/os/yocto/scripts/export-artifacts.sh
@@ -112,16 +112,17 @@ fi
 # it here before anything is published -- shipping a guest image whose kernel
 # quietly lacks an asserted capability is the failure this guards against.
 #
-# Only dstack-docker.cfg is gated for now. dstack.cfg still has six lines the
-# build does not satisfy (CONFIG_HOTPLUG_CPU/SCSI/INPUT are forced back on by
-# machine-level features, and CONFIG_TLS/CRYPTO_GCM/CRYPTO_CHACHA20POLY1305 do
-# not come out as asserted); each needs its own decision rather than a blanket
-# edit, so gating it belongs in a follow-up.
+# Both fragments are gated. dstack.cfg used to be exempt because three of its
+# lines were not satisfied by the build -- CONFIG_SCSI, CONFIG_INPUT and
+# CONFIG_HOTPLUG_CPU lose to machine-level KERNEL_FEATURES -- and those three
+# kept the other seventy assertions unchecked along with them. They have been
+# dropped from the fragment, which now says only what the build actually does.
 KERNEL_CONFIG_FILE="$COMMON_IMG_DIR/kernel-config"
 if [ -f "$KERNEL_CONFIG_FILE" ]; then
     "$REPO_ROOT/os/common/scripts/check-kernel-config.sh" \
         "$KERNEL_CONFIG_FILE" \
-        "$YOCTO_DIR/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg"
+        "$YOCTO_DIR/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg" \
+        "$YOCTO_DIR/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg"
 else
     echo "Error: kernel config not found: $KERNEL_CONFIG_FILE" >&2
     exit 1


### PR DESCRIPTION
## Why

`check-kernel-config.sh` exists because, in its own words, *"a fragment line is a wish, not a guarantee"* — kconfig silently drops a request whose dependencies are not met, and silently clamps a tristate.

The mkosi backend runs it over its whole fragment. The yocto backend ran it over `dstack-docker.cfg` **only**:

```sh
"$REPO_ROOT/os/common/scripts/check-kernel-config.sh" \
    "$KERNEL_CONFIG_FILE" \
    ".../dstack-docker.cfg"
```

That left `dstack.cfg`'s **73 assertions completely unchecked**.

## Why it was exempt

Three of them are false. Compared against a real built `.config`:

```
✗ CONFIG_HOTPLUG_CPU   fragment=n   built=y
✗ CONFIG_SCSI          fragment=n   built=y
✗ CONFIG_INPUT         fragment=n   built=y
```

They lose to machine-level `KERNEL_FEATURES` — `linux-yocto%.bbappend` appends `features/scsi/disk.scc` for the dstack machine, and the machine's own feature set brings the other two. The fragment claims the kernel has them off; it does not.

**Three lines that could not be satisfied kept the other seventy unverified along with them.** That is a bad trade, and it is the whole reason the exemption existed.

## What changed

Drop the three, gate the file. The fragment now says only what the build actually does, and every remaining line is checked before anything ships.

## Why this got more urgent

The sixteen `=n` lines added in #1160 went into **this same file**. They were verified by hand with `bitbake -c configure`, but nothing stopped a later `KERNEL_FEATURES` addition from quietly pulling one of those drivers back while the fragment still claimed it was off — which is exactly the state `CONFIG_SCSI` is in today. The gate is what turns those sixteen from a one-time check into an invariant.

## Not addressed here

**Whether the yocto image can actually drop SCSI.** The mkosi guest kernel does — verified in #1160, `CONFIG_SCSI=n` survives its `olddefconfig` — so the two guest kernels genuinely differ on it, along with `CONFIG_INPUT`.

Settling that needs a boot test on GCP and AWS, where the root disk may be virtio-scsi rather than virtio-blk. Guessing from a build that cannot boot is how you turn a documentation problem into an outage, so it belongs in its own change. The fragment carries a comment saying so.

## Testing

Against the real built `.config` from `bitbake -c configure virtual/kernel`:

| case | result |
|---|---|
| both fragments, as committed | exit 0 |
| `CONFIG_SCSI=n` put back | `wanted CONFIG_SCSI=n, got CONFIG_SCSI=y` → exit 1 |
| any other force-enabled symbol asserted off | exit 1 |
| restored | exit 0 |

`bash -n` and `shellcheck -x -P SCRIPTDIR` clean on `export-artifacts.sh` (note `os/yocto` is excluded from the repo's shellcheck hook, so this was run by hand).