### PR TITLE
feat(vmm): rebuild the nvswitch partition table on each vm start

### DIFF
--- a/docs/tutorials/vmm-configuration.md
+++ b/docs/tutorials/vmm-configuration.md
@@ -141,6 +141,9 @@ exclude = []
 include = []
 allow_attach_all = false
 
+[cvm.gpu.nvswitch]
+enabled = false
+
 [gateway]
 base_domain = "dstack.yourdomain.com"              # Your gateway domain
 port = 8082
@@ -319,6 +322,47 @@ not listed: the `all` attach mode finds GPUs and switches by PCI class instead.
 - IOMMU enabled in BIOS
 - VFIO driver configured
 - GPU not in use by host
+
+### NVSwitch Partitions
+
+On an HGX/DGX host, the NVIDIA fabric manager can only activate NVLink
+partitions that already exist in its partition definition file, and it reads
+that file once, at startup. Its built-in table hard-codes a fixed set of GPU
+groupings, so handing an arbitrary subset of the free GPUs to a new CVM is not
+expressible. Let dstack-vmm own the file instead:
+
+```toml
+[cvm.gpu.nvswitch]
+enabled = true
+partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
+apply_command = ["/usr/local/bin/dstack-apply-fabric-partitions"]
+apply_timeout_ms = 60000
+
+[cvm.gpu.nvswitch.module_ids]
+"0000:1b:00.0" = 1
+"0000:43:00.0" = 2
+# ... one entry per attachable GPU
+```
+
+Every VM start then rewrites the file with one partition per GPU-attached VM
+that is running or starting. A VM keeps the partition id it was assigned on its
+first start, so a rewrite never redefines the partition a running VM sits on,
+and the file is rewritten — and `apply_command` run — only when the partitions
+actually changed.
+
+`module_ids` maps each attachable GPU's PCI address to its fabric module id,
+which `nvidia-smi -q` reports as `Module ID` on the host. `apply_command` is
+what makes the fabric manager take the new table; it receives
+`DSTACK_NVSWITCH_PARTITION_FILE` and `DSTACK_NVSWITCH_PARTITION_IDS` in its
+environment, so a site script can restart the fabric manager and activate
+partitions the way that deployment needs.
+
+**Requirements:**
+- `SHARED_PARTITION_DEFINITION_FILE` in `fabricmanager.cfg` points at
+  `partition_file`
+- The NVSwitches stay on the host — a VM that also passes NVSwitch bridges
+  through is rejected while this is enabled
+- dstack-vmm may write `partition_file` and run `apply_command`
 
 ---
 

--- a/docs/tutorials/vmm-configuration.md
+++ b/docs/tutorials/vmm-configuration.md
@@ -351,11 +351,40 @@ and the file is rewritten — and `apply_command` run — only when the partitio
 actually changed.
 
 `module_ids` maps each attachable GPU's PCI address to its fabric module id,
-which `nvidia-smi -q` reports as `Module ID` on the host. `apply_command` is
-what makes the fabric manager take the new table; it receives
-`DSTACK_NVSWITCH_PARTITION_FILE` and `DSTACK_NVSWITCH_PARTITION_IDS` in its
-environment, so a site script can restart the fabric manager and activate
-partitions the way that deployment needs.
+which `nvidia-smi -q` reports as `Module ID` on the host.
+
+#### The apply command
+
+`apply_command` owns the whole way from a rewritten file to a partition the
+guest can use, **activation included**. When it exits 0, dstack-vmm attaches the
+GPUs and boots the VM; it has no way to check whether the partition is really
+live, so an incomplete command fails silently at the point where the guest finds
+no NVLink.
+
+The command gets two variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `DSTACK_NVSWITCH_PARTITION_FILE` | Path of the file just written. |
+| `DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS` | The ids that must be live when the command returns, and the only ones that may be. |
+
+The second is a goal, not a report. The table only ever holds VMs that are
+running or starting, so its ids are exactly the ids that belong active — the
+command's job is to converge the fabric to that set:
+
+```sh
+#!/bin/sh
+set -e
+systemctl restart nvidia-fabricmanager   # reload the table; does not activate
+for id in $DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS; do
+    fmpm -a "$id"
+done
+```
+
+Restarting the fabric manager on its own only makes it re-read the file. It
+leaves every partition *defined but inactive*, which is why there is no default
+`apply_command`: a host that sets `managed = true` has to state how its table
+becomes effective, and dstack-vmm refuses to start otherwise.
 
 **Requirements:**
 - `SHARED_PARTITION_DEFINITION_FILE` in `fabricmanager.cfg` points at

--- a/docs/tutorials/vmm-configuration.md
+++ b/docs/tutorials/vmm-configuration.md
@@ -142,7 +142,7 @@ include = []
 allow_attach_all = false
 
 [cvm.gpu.nvswitch]
-enabled = false
+managed = false
 
 [gateway]
 base_domain = "dstack.yourdomain.com"              # Your gateway domain
@@ -333,7 +333,7 @@ expressible. Let dstack-vmm own the file instead:
 
 ```toml
 [cvm.gpu.nvswitch]
-enabled = true
+managed = true
 partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
 apply_command = ["/usr/local/bin/dstack-apply-fabric-partitions"]
 apply_timeout_ms = 60000
@@ -361,7 +361,7 @@ partitions the way that deployment needs.
 - `SHARED_PARTITION_DEFINITION_FILE` in `fabricmanager.cfg` points at
   `partition_file`
 - The NVSwitches stay on the host — a VM that also passes NVSwitch bridges
-  through is rejected while this is enabled
+  through is rejected while this is managed
 - dstack-vmm may write `partition_file` and run `apply_command`
 
 ---

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -9,6 +9,7 @@ use crate::{
         self, InterfaceIdentity, PrepareBridgeRequest, PrepareMacvtapRequest,
         Request as NetdRequest,
     },
+    nvswitch::{self, FabricClaim, Nvswitch},
 };
 
 use anyhow::{bail, Context, Result};
@@ -297,6 +298,7 @@ pub(crate) enum PullStatus {
 pub struct App {
     pub config: Arc<Config>,
     pub supervisor: SupervisorClient,
+    nvswitch: Arc<Nvswitch>,
     state: Arc<Mutex<AppState>>,
     /// Pull status for registry images: tag → status.
     pub(crate) pull_status: Arc<Mutex<std::collections::HashMap<String, PullStatus>>>,
@@ -318,19 +320,22 @@ impl App {
         Ok(VmWorkDir::new(self.config.run_path.join(id)))
     }
 
-    pub fn new(config: Config, supervisor: SupervisorClient) -> Self {
+    pub fn new(config: Config, supervisor: SupervisorClient) -> Result<Self> {
         let cid_start = config.cvm.cid_start;
         let cid_end = cid_start.saturating_add(config.cvm.cid_pool_size);
         let cid_pool = IdPool::new(cid_start, cid_end);
-        Self {
+        let nvswitch = Nvswitch::new(&config.cvm.gpu.nvswitch)
+            .context("invalid nvswitch partition configuration")?;
+        Ok(Self {
             supervisor: supervisor.clone(),
+            nvswitch: Arc::new(nvswitch),
             state: Arc::new(Mutex::new(AppState {
                 cid_pool,
                 vms: HashMap::new(),
             })),
             config: Arc::new(config),
             pull_status: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        }
+        })
     }
 
     pub async fn load_vm(
@@ -456,6 +461,7 @@ impl App {
 
             let mut runtime_networks = resolved_networks(&vm_config.manifest, &self.config.cvm);
             let devices = self.try_allocate_gpus(&vm_config.manifest)?;
+            self.reconcile_nvswitch_partitions().await?;
             let gpu_host_config = self.config.cvm.gpu.clone();
             let devices_to_sanitize = devices.clone();
             tokio::task::spawn_blocking(move || {
@@ -1341,6 +1347,92 @@ impl App {
             return Ok(GpuConfig::default());
         }
         Ok(manifest.gpus.clone().unwrap_or_default())
+    }
+
+    /// Rebuild the fabric manager NVLink partition table for the VMs that are
+    /// running or starting, and hand it to the fabric manager.
+    ///
+    /// The whole cycle runs under the fabric lock: a concurrent VM start that
+    /// snapshotted the VM list before this one persisted its partition id would
+    /// otherwise rewrite the table without that VM's partition.
+    async fn reconcile_nvswitch_partitions(&self) -> Result<()> {
+        if !self.config.cvm.gpu.enabled || !self.nvswitch.enabled() {
+            return Ok(());
+        }
+        let _guard = self.nvswitch.lock().await;
+        let claims = self.fabric_claims()?;
+        let partitions = nvswitch::plan(claims)?;
+        for partition in &partitions {
+            self.work_dir(&partition.vm_id)?
+                .set_nvswitch_partition_id(partition.partition_id)
+                .context("failed to persist the nvswitch partition id")?;
+        }
+        let nvswitch = self.nvswitch.clone();
+        tokio::task::spawn_blocking(move || nvswitch.apply(&partitions))
+            .await
+            .context("nvswitch partition task failed")?
+            .context("failed to apply the nvswitch partition table")
+    }
+
+    /// One fabric claim per VM that is running or starting.
+    ///
+    /// `started` is written before the launch begins and cleared on stop, so it
+    /// covers a VM whose QEMU process is not up yet as well as one that the
+    /// auto-restart loop is about to bring back.
+    fn fabric_claims(&self) -> Result<Vec<FabricClaim>> {
+        let vms = self
+            .lock()
+            .iter_vms()
+            .map(|vm| {
+                (
+                    vm.config.manifest.id.clone(),
+                    vm.config.manifest.gpus.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut claims = Vec::new();
+        for (vm_id, gpus) in vms {
+            let Some(gpus) = gpus else { continue };
+            let work_dir = self.work_dir(&vm_id)?;
+            match work_dir.started() {
+                Ok(false) => continue,
+                Ok(true) => {}
+                Err(err) => {
+                    // A VM whose state is unreadable is left out rather than
+                    // failing every later start, but it must not pass silently:
+                    // if it is running, its partition is about to disappear.
+                    warn!(
+                        vm_id,
+                        "skipping nvswitch partition, unreadable state: {err:?}"
+                    );
+                    continue;
+                }
+            }
+            if !gpus.bridges.is_empty() {
+                bail!(
+                    "vm {vm_id} passes NVSwitch bridges through, which the host fabric manager \
+                     owns while cvm.gpu.nvswitch is enabled"
+                );
+            }
+            let module_ids = if gpus.attach_mode.is_all() {
+                self.nvswitch.all_module_ids()
+            } else {
+                gpus.gpus
+                    .iter()
+                    .map(|gpu| self.nvswitch.module_id(&gpu.slot))
+                    .collect::<Result<_>>()
+                    .with_context(|| format!("failed to map the gpus of vm {vm_id}"))?
+            };
+            let partition_id = work_dir
+                .nvswitch_partition_id()
+                .context("failed to read the nvswitch partition id")?;
+            claims.push(FabricClaim {
+                vm_id,
+                module_ids,
+                partition_id,
+            });
+        }
+        Ok(claims)
     }
 
     pub(crate) async fn list_gpus(&self) -> Result<Vec<GpuInfo>> {

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -1356,7 +1356,7 @@ impl App {
     /// snapshotted the VM list before this one persisted its partition id would
     /// otherwise rewrite the table without that VM's partition.
     async fn reconcile_nvswitch_partitions(&self) -> Result<()> {
-        if !self.config.cvm.gpu.enabled || !self.nvswitch.enabled() {
+        if !self.config.cvm.gpu.enabled || !self.nvswitch.managed() {
             return Ok(());
         }
         let _guard = self.nvswitch.lock().await;
@@ -1411,7 +1411,7 @@ impl App {
             if !gpus.bridges.is_empty() {
                 bail!(
                     "vm {vm_id} passes NVSwitch bridges through, which the host fabric manager \
-                     owns while cvm.gpu.nvswitch is enabled"
+                     owns while cvm.gpu.nvswitch.managed is set"
                 );
             }
             let module_ids = if gpus.attach_mode.is_all() {

--- a/dstack/vmm/src/app/workdir.rs
+++ b/dstack/vmm/src/app/workdir.rs
@@ -15,6 +15,7 @@ use dstack_types::{
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
+use tracing::warn;
 
 use crate::{app::Manifest, config::Networking};
 
@@ -28,9 +29,14 @@ pub struct InstanceInfo {
     pub app_id: Vec<u8>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 struct State {
     started: bool,
+    /// Partition id the VM owns in the fabric manager NVLink partition table.
+    /// Absent unless `[cvm.gpu.nvswitch]` is enabled; kept across rewrites so a
+    /// running VM's partition is never redefined under it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nvswitch_partition_id: Option<u32>,
 }
 
 pub struct VmWorkDir {
@@ -83,21 +89,43 @@ impl VmWorkDir {
         fs::write(manifest_path, serde_json::to_string(&value)?).context("failed to write manifest")
     }
 
-    pub fn started(&self) -> Result<bool> {
+    fn state(&self) -> Result<State> {
         let state_path = self.state_path();
         if !state_path.exists() {
-            return Ok(false);
+            return Ok(State::default());
         }
-        let state: State =
-            serde_json::from_str(&fs::read_to_string(state_path).context("failed to read state")?)
-                .context("failed to parse state")?;
-        Ok(state.started)
+        serde_json::from_str(&fs::read_to_string(state_path).context("failed to read state")?)
+            .context("failed to parse state")
+    }
+
+    fn put_state(&self, state: &State) -> Result<()> {
+        fs::write(self.state_path(), serde_json::to_string(state)?).context("failed to write state")
+    }
+
+    pub fn started(&self) -> Result<bool> {
+        Ok(self.state()?.started)
     }
 
     pub fn set_started(&self, started: bool) -> Result<()> {
-        let state_path = self.state_path();
-        fs::write(state_path, serde_json::to_string(&State { started })?)
-            .context("failed to write state")
+        let mut state = self.state().unwrap_or_else(|err| {
+            warn!("failed to read vm state, resetting it: {err:#}");
+            State::default()
+        });
+        state.started = started;
+        self.put_state(&state)
+    }
+
+    pub fn nvswitch_partition_id(&self) -> Result<Option<u32>> {
+        Ok(self.state()?.nvswitch_partition_id)
+    }
+
+    pub fn set_nvswitch_partition_id(&self, partition_id: u32) -> Result<()> {
+        let mut state = self.state()?;
+        if state.nvswitch_partition_id == Some(partition_id) {
+            return Ok(());
+        }
+        state.nvswitch_partition_id = Some(partition_id);
+        self.put_state(&state)
     }
 
     pub fn shared_dir(&self) -> PathBuf {

--- a/dstack/vmm/src/app/workdir.rs
+++ b/dstack/vmm/src/app/workdir.rs
@@ -15,7 +15,6 @@ use dstack_types::{
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
-use tracing::warn;
 
 use crate::{app::Manifest, config::Networking};
 
@@ -29,14 +28,19 @@ pub struct InstanceInfo {
     pub app_id: Vec<u8>,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 struct State {
     started: bool,
-    /// Partition id the VM owns in the fabric manager NVLink partition table.
-    /// Absent unless `[cvm.gpu.nvswitch]` is enabled; kept across rewrites so a
-    /// running VM's partition is never redefined under it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    nvswitch_partition_id: Option<u32>,
+}
+
+/// Partition the VM owns in the fabric manager NVLink partition table.
+///
+/// Written only while `[cvm.gpu.nvswitch] managed` is set, and kept in its own
+/// file so the deploy-time `started` flag and this fabric bookkeeping never have
+/// to be read or rewritten for each other's sake.
+#[derive(Deserialize, Serialize)]
+struct NvswitchPartition {
+    partition_id: u32,
 }
 
 pub struct VmWorkDir {
@@ -89,43 +93,48 @@ impl VmWorkDir {
         fs::write(manifest_path, serde_json::to_string(&value)?).context("failed to write manifest")
     }
 
-    fn state(&self) -> Result<State> {
+    pub fn started(&self) -> Result<bool> {
         let state_path = self.state_path();
         if !state_path.exists() {
-            return Ok(State::default());
+            return Ok(false);
         }
-        serde_json::from_str(&fs::read_to_string(state_path).context("failed to read state")?)
-            .context("failed to parse state")
-    }
-
-    fn put_state(&self, state: &State) -> Result<()> {
-        fs::write(self.state_path(), serde_json::to_string(state)?).context("failed to write state")
-    }
-
-    pub fn started(&self) -> Result<bool> {
-        Ok(self.state()?.started)
+        let state: State =
+            serde_json::from_str(&fs::read_to_string(state_path).context("failed to read state")?)
+                .context("failed to parse state")?;
+        Ok(state.started)
     }
 
     pub fn set_started(&self, started: bool) -> Result<()> {
-        let mut state = self.state().unwrap_or_else(|err| {
-            warn!("failed to read vm state, resetting it: {err:#}");
-            State::default()
-        });
-        state.started = started;
-        self.put_state(&state)
+        let state_path = self.state_path();
+        fs::write(state_path, serde_json::to_string(&State { started })?)
+            .context("failed to write state")
     }
 
+    pub fn nvswitch_partition_path(&self) -> PathBuf {
+        self.workdir.join("nvswitch-partition.json")
+    }
+
+    /// The partition id assigned on an earlier start, if the VM has one.
+    ///
+    /// An unreadable file is an error rather than "no id": silently treating it
+    /// as a fresh VM would hand a running VM a different partition id, which is
+    /// exactly what this file exists to prevent.
     pub fn nvswitch_partition_id(&self) -> Result<Option<u32>> {
-        Ok(self.state()?.nvswitch_partition_id)
+        let path = self.nvswitch_partition_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+        let partition: NvswitchPartition = serde_json::from_str(
+            &fs::read_to_string(path).context("failed to read the partition")?,
+        )
+        .context("failed to parse the partition")?;
+        Ok(Some(partition.partition_id))
     }
 
     pub fn set_nvswitch_partition_id(&self, partition_id: u32) -> Result<()> {
-        let mut state = self.state()?;
-        if state.nvswitch_partition_id == Some(partition_id) {
-            return Ok(());
-        }
-        state.nvswitch_partition_id = Some(partition_id);
-        self.put_state(&state)
+        let serialized = serde_json::to_vec(&NvswitchPartition { partition_id })?;
+        safe_write::safe_write(self.nvswitch_partition_path(), serialized)
+            .context("failed to write the partition")
     }
 
     pub fn shared_dir(&self) -> PathBuf {

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -475,9 +475,11 @@ pub struct GpuConfig {
 /// definition file so that any free subset of GPUs can form a partition.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct NvswitchConfig {
-    /// Whether dstack-vmm rewrites the partition definition file on VM start.
+    /// Whether dstack-vmm owns the partition definition file and rewrites it
+    /// on VM start. The NVSwitches themselves are not dstack-vmm's to enable,
+    /// so this names the ownership rather than the hardware.
     #[serde(default)]
-    pub enabled: bool,
+    pub managed: bool,
     /// Path of the file named by `SHARED_PARTITION_DEFINITION_FILE` in
     /// `fabricmanager.cfg`.
     #[serde(default)]

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -466,6 +466,32 @@ pub struct GpuConfig {
     pub sanitize_on_attach: bool,
     /// Shared deadline for all GPUs to become VFIO-ready after SBR.
     pub sbr_timeout_ms: u64,
+    /// Ownership of the fabric manager NVLink partition definition file.
+    #[serde(default)]
+    pub nvswitch: NvswitchConfig,
+}
+
+/// Lets dstack-vmm own the fabric manager's shared NVSwitch partition
+/// definition file so that any free subset of GPUs can form a partition.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NvswitchConfig {
+    /// Whether dstack-vmm rewrites the partition definition file on VM start.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Path of the file named by `SHARED_PARTITION_DEFINITION_FILE` in
+    /// `fabricmanager.cfg`.
+    #[serde(default)]
+    pub partition_file: PathBuf,
+    /// Command that makes the fabric manager pick up a rewritten file.
+    #[serde(default)]
+    pub apply_command: Vec<String>,
+    /// Deadline for the apply command.
+    #[serde(default)]
+    pub apply_timeout_ms: u64,
+    /// PCI address of every attachable GPU mapped to its fabric module id, as
+    /// reported by `nvidia-smi -q` ("Module ID") on the host.
+    #[serde(default)]
+    pub module_ids: BTreeMap<String, u32>,
 }
 
 impl GpuConfig {

--- a/dstack/vmm/src/gpu_reset.rs
+++ b/dstack/vmm/src/gpu_reset.rs
@@ -257,6 +257,7 @@ mod tests {
             allow_attach_all: true,
             sanitize_on_attach: true,
             sbr_timeout_ms: 10_000,
+            nvswitch: Default::default(),
         };
         let devices = GpuConfig {
             attach_mode: AttachMode::Listed,

--- a/dstack/vmm/src/main.rs
+++ b/dstack/vmm/src/main.rs
@@ -31,6 +31,7 @@ mod logrotate;
 mod main_routes;
 mod main_service;
 mod netd;
+mod nvswitch;
 mod one_shot;
 mod openapi;
 mod vm_launcher;
@@ -335,7 +336,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to supervisor")?
     };
-    let state = app::App::new(config, supervisor);
+    let state = app::App::new(config, supervisor)?;
     state.reload_vms().await.context("Failed to reload VMs")?;
     tokio::spawn(auto_restart_task(state.clone()));
     tokio::spawn(log_rotation_task(state.clone()));

--- a/dstack/vmm/src/nvswitch.rs
+++ b/dstack/vmm/src/nvswitch.rs
@@ -10,7 +10,7 @@
 //! host that hands out arbitrary subsets of its free GPUs cannot express the
 //! group a new CVM needs.
 //!
-//! When `[cvm.gpu.nvswitch] enabled` is set, dstack-vmm owns the file instead:
+//! When `[cvm.gpu.nvswitch] managed` is set, dstack-vmm owns the file instead:
 //! every VM start recomputes one partition per GPU-attached VM that is running
 //! or starting, and then runs the operator's apply command so the fabric
 //! manager picks the file up. Two properties keep that from disturbing tenants
@@ -111,16 +111,16 @@ impl Nvswitch {
     /// Rejects an incomplete `[cvm.gpu.nvswitch]` section at startup rather
     /// than at the first GPU deployment.
     pub(crate) fn new(config: &NvswitchConfig) -> Result<Self> {
-        if config.enabled {
+        if config.managed {
             if config.partition_file.as_os_str().is_empty() {
-                bail!("cvm.gpu.nvswitch.partition_file is required when nvswitch is enabled");
+                bail!("cvm.gpu.nvswitch.partition_file is required when cvm.gpu.nvswitch.managed is set");
             }
             if config.apply_command.is_empty() {
-                bail!("cvm.gpu.nvswitch.apply_command is required when nvswitch is enabled");
+                bail!("cvm.gpu.nvswitch.apply_command is required when cvm.gpu.nvswitch.managed is set");
             }
             if config.module_ids.is_empty() {
                 bail!(
-                    "cvm.gpu.nvswitch.module_ids is required when nvswitch is enabled"
+                    "cvm.gpu.nvswitch.module_ids is required when cvm.gpu.nvswitch.managed is set"
                 );
             }
             let mut seen = BTreeMap::new();
@@ -136,8 +136,8 @@ impl Nvswitch {
         })
     }
 
-    pub(crate) fn enabled(&self) -> bool {
-        self.config.enabled
+    pub(crate) fn managed(&self) -> bool {
+        self.config.managed
     }
 
     /// Hold the fabric lock for a whole reconcile cycle.
@@ -442,7 +442,7 @@ mod tests {
     #[test]
     fn rejects_an_incomplete_config() {
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             ..Default::default()
         };
         assert!(Nvswitch::new(&config).is_err());
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn rejects_a_module_id_shared_by_two_gpus() {
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             partition_file: "/tmp/customPartition.json".into(),
             apply_command: vec!["true".to_string()],
             apply_timeout_ms: 1000,
@@ -469,7 +469,7 @@ mod tests {
     #[test]
     fn looks_up_module_ids_by_short_or_full_pci_address() {
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             partition_file: "/tmp/customPartition.json".into(),
             apply_command: vec!["true".to_string()],
             apply_timeout_ms: 1000,
@@ -486,7 +486,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("applied");
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             partition_file: dir.path().join("customPartition.json"),
             apply_command: vec![
                 "sh".to_string(),
@@ -526,7 +526,7 @@ mod tests {
         let marker = dir.path().join("applied");
         let partition_file = dir.path().join("customPartition.json");
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             partition_file: partition_file.clone(),
             apply_command: vec![
                 "sh".to_string(),
@@ -561,7 +561,7 @@ mod tests {
     fn fails_the_start_when_the_apply_command_fails() {
         let dir = tempfile::tempdir().unwrap();
         let config = NvswitchConfig {
-            enabled: true,
+            managed: true,
             partition_file: dir.path().join("customPartition.json"),
             apply_command: vec!["false".to_string()],
             apply_timeout_ms: 10_000,

--- a/dstack/vmm/src/nvswitch.rs
+++ b/dstack/vmm/src/nvswitch.rs
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: © 2024-2026 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Ownership of the fabric manager's shared NVSwitch partition definition file.
+//!
+//! The NVIDIA fabric manager can only activate NVLink partitions that already
+//! exist in its partition definition file, and it reads that file once, when it
+//! starts. The built-in table hard-codes a fixed set of GPU groupings, so a
+//! host that hands out arbitrary subsets of its free GPUs cannot express the
+//! group a new CVM needs.
+//!
+//! When `[cvm.gpu.nvswitch] enabled` is set, dstack-vmm owns the file instead:
+//! every VM start recomputes one partition per GPU-attached VM that is running
+//! or starting, and then runs the operator's apply command so the fabric
+//! manager picks the file up. Two properties keep that from disturbing tenants
+//! that are already running:
+//!
+//! * A VM keeps the partition id it was assigned on its first start — the id is
+//!   persisted with the rest of its VM state — so a rewrite never redefines a
+//!   partition that a running VM sits on.
+//! * The file is rewritten, and the apply command run, only when the set of
+//!   partitions actually changed. Restarting a VM that is already in the table
+//!   touches nothing.
+//!
+//! Activating a partition (`fmpm -a`) is deliberately left to the apply
+//! command: the fabric manager's activation semantics differ between driver
+//! releases and multitenancy modes, so the mapping from table to activation is
+//! the operator's to define. The command receives the plan through the
+//! environment (see [`Nvswitch::apply`]).
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    process::{Command, Stdio},
+    time::{Duration, SystemTime},
+};
+
+use anyhow::{bail, Context, Result};
+use fs_err as fs;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, MutexGuard};
+use tracing::{info, warn};
+use wait_timeout::ChildExt;
+
+use crate::config::NvswitchConfig;
+
+/// Partition sizes with a documented multicast-slot quota on B200/B300 systems
+/// (8 GPUs get every slot, 4 GPUs up to 50%, 2 GPUs up to 25%, 1 GPU none).
+/// Other sizes are still emitted, but their quota is undefined by NVIDIA.
+const DOCUMENTED_PARTITION_SIZES: [usize; 4] = [1, 2, 4, 8];
+
+/// One VM's claim on the fabric.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FabricClaim {
+    /// The VM holding the GPUs.
+    pub vm_id: String,
+    /// Fabric module ids of the GPUs attached to the VM.
+    pub module_ids: BTreeSet<u32>,
+    /// Partition id assigned by an earlier reconcile, if the VM has one.
+    pub partition_id: Option<u32>,
+}
+
+/// A VM and the partition id it owns in the rendered table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedPartition {
+    pub vm_id: String,
+    pub partition_id: u32,
+    pub module_ids: BTreeSet<u32>,
+}
+
+/// An entry of the fabric manager partition definition file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PartitionInfo {
+    #[serde(rename = "partitionId")]
+    partition_id: u32,
+    #[serde(rename = "gpuModuleIds")]
+    gpu_module_ids: Vec<u32>,
+}
+
+/// The fabric manager partition definition file.
+///
+/// The layout is NVIDIA's, not ours: `version`, `name` and `time` are
+/// informational, and `partitionInfo` is the part the fabric manager acts on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PartitionTable {
+    version: u32,
+    name: String,
+    time: String,
+    #[serde(rename = "partitionInfo")]
+    partition_info: Vec<PartitionInfo>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Nvswitch {
+    config: NvswitchConfig,
+    /// Serializes the read-plan-write-apply cycle across concurrent VM starts.
+    /// Without it, a start that snapshotted the VM list first could drop the
+    /// partition of a VM that started in the meantime.
+    lock: Mutex<()>,
+}
+
+impl Nvswitch {
+    /// Validate the configuration and build the manager.
+    ///
+    /// Rejects an incomplete `[cvm.gpu.nvswitch]` section at startup rather
+    /// than at the first GPU deployment.
+    pub(crate) fn new(config: &NvswitchConfig) -> Result<Self> {
+        if config.enabled {
+            if config.partition_file.as_os_str().is_empty() {
+                bail!("cvm.gpu.nvswitch.partition_file is required when nvswitch is enabled");
+            }
+            if config.apply_command.is_empty() {
+                bail!("cvm.gpu.nvswitch.apply_command is required when nvswitch is enabled");
+            }
+            if config.module_ids.is_empty() {
+                bail!("cvm.gpu.nvswitch.module_ids is required when nvswitch is enabled");
+            }
+            let mut seen = BTreeMap::new();
+            for (slot, module_id) in &config.module_ids {
+                if let Some(other) = seen.insert(*module_id, slot) {
+                    bail!("gpu module id {module_id} is mapped to both {other} and {slot}");
+                }
+            }
+        }
+        Ok(Self {
+            config: config.clone(),
+            lock: Mutex::new(()),
+        })
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Hold the fabric lock for a whole reconcile cycle.
+    pub(crate) async fn lock(&self) -> MutexGuard<'_, ()> {
+        self.lock.lock().await
+    }
+
+    /// The fabric module id of a GPU, by PCI address.
+    pub(crate) fn module_id(&self, slot: &str) -> Result<u32> {
+        let slot = normalize_slot(slot);
+        self.config
+            .module_ids
+            .get(&slot)
+            .copied()
+            .with_context(|| format!("no cvm.gpu.nvswitch.module_ids entry for gpu {slot}"))
+    }
+
+    /// Every module id the host knows about, for VMs that take all GPUs.
+    pub(crate) fn all_module_ids(&self) -> BTreeSet<u32> {
+        self.config.module_ids.values().copied().collect()
+    }
+
+    /// Write the table and run the apply command, unless the partitions are
+    /// already the ones on disk.
+    ///
+    /// The apply command is spawned with:
+    ///
+    /// * `DSTACK_NVSWITCH_PARTITION_FILE` — path of the file just written.
+    /// * `DSTACK_NVSWITCH_PARTITION_IDS` — space-separated ids in the table.
+    ///
+    /// so a site script can restart the fabric manager and activate the
+    /// partitions without dstack-vmm encoding either step.
+    pub(crate) fn apply(&self, partitions: &[PlannedPartition]) -> Result<()> {
+        let partition_info = render_partitions(partitions);
+        if partition_info == current_partitions(&self.config.partition_file) {
+            return Ok(());
+        }
+        let table = PartitionTable {
+            version: 0,
+            name: "dstack-vmm".to_string(),
+            time: humantime::format_rfc3339_seconds(SystemTime::now()).to_string(),
+            partition_info,
+        };
+        let path = &self.config.partition_file;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).context("failed to create partition file directory")?;
+        }
+        let body = serde_json::to_vec_pretty(&table).context("failed to serialize the table")?;
+        safe_write::safe_write(path, &body).context("failed to write the partition file")?;
+        info!(
+            partitions = table.partition_info.len(),
+            file = %path.display(),
+            "rewrote the nvswitch partition table"
+        );
+        self.run_apply_command(&table)
+    }
+
+    fn run_apply_command(&self, table: &PartitionTable) -> Result<()> {
+        let (program, args) = self
+            .config
+            .apply_command
+            .split_first()
+            .context("empty apply command")?;
+        let ids = table
+            .partition_info
+            .iter()
+            .map(|partition| partition.partition_id.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let timeout = Duration::from_millis(self.config.apply_timeout_ms);
+        let mut child = Command::new(program)
+            .args(args)
+            .env(
+                "DSTACK_NVSWITCH_PARTITION_FILE",
+                &self.config.partition_file,
+            )
+            .env("DSTACK_NVSWITCH_PARTITION_IDS", &ids)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to execute {program}"))?;
+        if child.wait_timeout(timeout)?.is_none() {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!("{program} timed out after {timeout:?}");
+        }
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            bail!("{program} failed: {}", error.trim());
+        }
+        info!(command = program, ids = %ids, "applied the nvswitch partition table");
+        Ok(())
+    }
+}
+
+/// Assign a partition id to every claim.
+///
+/// Claims that already carry an id keep it, so the entry a running VM depends
+/// on is byte-identical across rewrites; the rest take the lowest free ids.
+pub(crate) fn plan(mut claims: Vec<FabricClaim>) -> Result<Vec<PlannedPartition>> {
+    claims.retain(|claim| !claim.module_ids.is_empty());
+    // The caller iterates a hash map, so sort for a stable id assignment.
+    claims.sort_by(|left, right| left.vm_id.cmp(&right.vm_id));
+
+    let mut owner_of_module = BTreeMap::new();
+    for claim in &claims {
+        for module_id in &claim.module_ids {
+            if let Some(other) = owner_of_module.insert(*module_id, &claim.vm_id) {
+                bail!(
+                    "gpu module {module_id} is claimed by both vm {other} and vm {}",
+                    claim.vm_id
+                );
+            }
+        }
+    }
+
+    let mut taken = BTreeSet::new();
+    let mut planned = Vec::with_capacity(claims.len());
+    for claim in &claims {
+        let Some(partition_id) = claim.partition_id else {
+            continue;
+        };
+        if !taken.insert(partition_id) {
+            // Two VMs recorded the same id, which only happens if the state
+            // files were tampered with or restored from another host. Drop the
+            // duplicate into the second pass instead of emitting a table the
+            // fabric manager would reject.
+            warn!(
+                vm_id = claim.vm_id,
+                partition_id, "duplicate nvswitch partition id, reassigning"
+            );
+            continue;
+        }
+        planned.push(PlannedPartition {
+            vm_id: claim.vm_id.clone(),
+            partition_id,
+            module_ids: claim.module_ids.clone(),
+        });
+    }
+
+    let mut next_id = 0;
+    for claim in &claims {
+        if planned.iter().any(|entry| entry.vm_id == claim.vm_id) {
+            continue;
+        }
+        while !taken.insert(next_id) {
+            next_id += 1;
+        }
+        planned.push(PlannedPartition {
+            vm_id: claim.vm_id.clone(),
+            partition_id: next_id,
+            module_ids: claim.module_ids.clone(),
+        });
+    }
+
+    for partition in &planned {
+        let size = partition.module_ids.len();
+        if !DOCUMENTED_PARTITION_SIZES.contains(&size) {
+            warn!(
+                vm_id = partition.vm_id,
+                size, "nvswitch partition size has no documented multicast slot quota"
+            );
+        }
+    }
+
+    planned.sort_by_key(|partition| partition.partition_id);
+    Ok(planned)
+}
+
+/// Normalize a PCI address to the `0000:1b:00.0` form used as the module id key.
+fn normalize_slot(slot: &str) -> String {
+    if slot.matches(':').count() == 1 {
+        format!("0000:{slot}")
+    } else {
+        slot.to_owned()
+    }
+}
+
+fn render_partitions(partitions: &[PlannedPartition]) -> Vec<PartitionInfo> {
+    partitions
+        .iter()
+        .map(|partition| PartitionInfo {
+            partition_id: partition.partition_id,
+            gpu_module_ids: partition.module_ids.iter().copied().collect(),
+        })
+        .collect()
+}
+
+/// The partitions currently on disk, or none when the file is missing or was
+/// not written by us.
+fn current_partitions(path: &Path) -> Vec<PartitionInfo> {
+    let Ok(body) = fs::read(path) else {
+        return Vec::new();
+    };
+    match serde_json::from_slice::<PartitionTable>(&body) {
+        Ok(table) => table.partition_info,
+        Err(err) => {
+            warn!(
+                file = %path.display(),
+                "unreadable nvswitch partition table, rewriting it: {err:#}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claim(vm_id: &str, module_ids: &[u32], partition_id: Option<u32>) -> FabricClaim {
+        FabricClaim {
+            vm_id: vm_id.to_string(),
+            module_ids: module_ids.iter().copied().collect(),
+            partition_id,
+        }
+    }
+
+    #[test]
+    fn assigns_the_lowest_free_ids_to_new_vms() {
+        let planned = plan(vec![
+            claim("vm-b", &[3, 4], None),
+            claim("vm-a", &[1, 2], None),
+        ])
+        .unwrap();
+        assert_eq!(planned[0].vm_id, "vm-a");
+        assert_eq!(planned[0].partition_id, 0);
+        assert_eq!(planned[1].vm_id, "vm-b");
+        assert_eq!(planned[1].partition_id, 1);
+    }
+
+    #[test]
+    fn keeps_the_ids_of_running_vms() {
+        let planned = plan(vec![
+            claim("vm-running", &[5, 6], Some(0)),
+            claim("vm-new", &[1, 2], None),
+        ])
+        .unwrap();
+        let running = planned.iter().find(|p| p.vm_id == "vm-running").unwrap();
+        let new = planned.iter().find(|p| p.vm_id == "vm-new").unwrap();
+        assert_eq!(running.partition_id, 0);
+        assert_eq!(new.partition_id, 1);
+    }
+
+    #[test]
+    fn fills_the_hole_left_by_a_stopped_vm() {
+        // vm-a stopped, so id 0 is free again while vm-b keeps id 1.
+        let planned = plan(vec![
+            claim("vm-b", &[3, 4], Some(1)),
+            claim("vm-c", &[1, 2], None),
+        ])
+        .unwrap();
+        assert_eq!(planned[0].vm_id, "vm-c");
+        assert_eq!(planned[0].partition_id, 0);
+        assert_eq!(planned[1].vm_id, "vm-b");
+        assert_eq!(planned[1].partition_id, 1);
+    }
+
+    #[test]
+    fn reassigns_a_duplicated_id() {
+        let planned = plan(vec![
+            claim("vm-a", &[1, 2], Some(3)),
+            claim("vm-b", &[3, 4], Some(3)),
+        ])
+        .unwrap();
+        assert_eq!(planned.len(), 2);
+        let ids: BTreeSet<u32> = planned.iter().map(|p| p.partition_id).collect();
+        assert_eq!(ids, BTreeSet::from([0, 3]));
+    }
+
+    #[test]
+    fn rejects_two_vms_claiming_one_gpu() {
+        let error = plan(vec![
+            claim("vm-a", &[1, 2], None),
+            claim("vm-b", &[2, 3], None),
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("gpu module 2"), "{error}");
+    }
+
+    #[test]
+    fn drops_vms_without_gpus() {
+        let planned = plan(vec![claim("vm-a", &[], None), claim("vm-b", &[1], None)]).unwrap();
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].vm_id, "vm-b");
+    }
+
+    #[test]
+    fn rejects_an_incomplete_config() {
+        let config = NvswitchConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        assert!(Nvswitch::new(&config).is_err());
+        let disabled = NvswitchConfig::default();
+        assert!(Nvswitch::new(&disabled).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_module_id_shared_by_two_gpus() {
+        let config = NvswitchConfig {
+            enabled: true,
+            partition_file: "/tmp/customPartition.json".into(),
+            apply_command: vec!["true".to_string()],
+            apply_timeout_ms: 1000,
+            module_ids: BTreeMap::from([
+                ("0000:1b:00.0".to_string(), 1),
+                ("0000:1c:00.0".to_string(), 1),
+            ]),
+        };
+        let error = Nvswitch::new(&config).unwrap_err();
+        assert!(error.to_string().contains("module id 1"), "{error}");
+    }
+
+    #[test]
+    fn looks_up_module_ids_by_short_or_full_pci_address() {
+        let config = NvswitchConfig {
+            enabled: true,
+            partition_file: "/tmp/customPartition.json".into(),
+            apply_command: vec!["true".to_string()],
+            apply_timeout_ms: 1000,
+            module_ids: BTreeMap::from([("0000:1b:00.0".to_string(), 7)]),
+        };
+        let nvswitch = Nvswitch::new(&config).unwrap();
+        assert_eq!(nvswitch.module_id("1b:00.0").unwrap(), 7);
+        assert_eq!(nvswitch.module_id("0000:1b:00.0").unwrap(), 7);
+        assert!(nvswitch.module_id("0000:1c:00.0").is_err());
+    }
+
+    #[test]
+    fn applies_only_when_the_partitions_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("applied");
+        let config = NvswitchConfig {
+            enabled: true,
+            partition_file: dir.path().join("customPartition.json"),
+            apply_command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("echo x >> {}", marker.display()),
+            ],
+            apply_timeout_ms: 10_000,
+            module_ids: BTreeMap::from([("0000:1b:00.0".to_string(), 1)]),
+        };
+        let nvswitch = Nvswitch::new(&config).unwrap();
+        let partitions = plan(vec![claim("vm-a", &[1, 2], None)]).unwrap();
+
+        nvswitch.apply(&partitions).unwrap();
+        nvswitch.apply(&partitions).unwrap();
+        assert_eq!(fs::read_to_string(&marker).unwrap().lines().count(), 1);
+
+        let grown = plan(vec![
+            claim("vm-a", &[1, 2], None),
+            claim("vm-b", &[3], None),
+        ])
+        .unwrap();
+        nvswitch.apply(&grown).unwrap();
+        assert_eq!(fs::read_to_string(&marker).unwrap().lines().count(), 2);
+
+        let table: serde_json::Value =
+            serde_json::from_slice(&fs::read(&config.partition_file).unwrap()).unwrap();
+        assert_eq!(table["partitionInfo"][0]["partitionId"], 0);
+        assert_eq!(
+            table["partitionInfo"][0]["gpuModuleIds"],
+            serde_json::json!([1, 2])
+        );
+    }
+
+    #[test]
+    fn fails_the_start_when_the_apply_command_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = NvswitchConfig {
+            enabled: true,
+            partition_file: dir.path().join("customPartition.json"),
+            apply_command: vec!["false".to_string()],
+            apply_timeout_ms: 10_000,
+            module_ids: BTreeMap::from([("0000:1b:00.0".to_string(), 1)]),
+        };
+        let nvswitch = Nvswitch::new(&config).unwrap();
+        let partitions = plan(vec![claim("vm-a", &[1], None)]).unwrap();
+        assert!(nvswitch.apply(&partitions).is_err());
+    }
+}

--- a/dstack/vmm/src/nvswitch.rs
+++ b/dstack/vmm/src/nvswitch.rs
@@ -23,11 +23,13 @@
 //!   partitions actually changed. Restarting a VM that is already in the table
 //!   touches nothing.
 //!
-//! Activating a partition (`fmpm -a`) is deliberately left to the apply
-//! command: the fabric manager's activation semantics differ between driver
-//! releases and multitenancy modes, so the mapping from table to activation is
-//! the operator's to define. The command receives the plan through the
-//! environment (see [`Nvswitch::apply`]).
+//! The apply command owns everything between the file and a partition a guest
+//! can use, activation included: the fabric manager's activation semantics
+//! differ between driver releases and multitenancy modes, and none of that is
+//! verifiable from here. dstack-vmm states the goal declaratively — these
+//! partition ids, and only these, must be live — and the command converges to
+//! it (see [`Nvswitch::apply`]). There is deliberately no default: a host that
+//! sets `managed` must say how its table becomes effective.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -166,10 +168,16 @@ impl Nvswitch {
     /// The apply command is spawned with:
     ///
     /// * `DSTACK_NVSWITCH_PARTITION_FILE` — path of the file just written.
-    /// * `DSTACK_NVSWITCH_PARTITION_IDS` — space-separated ids in the table.
+    /// * `DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS` — space-separated ids that must
+    ///   be live once the command returns, and the only ones that may be.
     ///
-    /// so a site script can restart the fabric manager and activate the
-    /// partitions without dstack-vmm encoding either step.
+    /// The second is a goal, not a log line: the table only ever holds the VMs
+    /// that are running or starting, so its ids are exactly the ids that belong
+    /// active. Reloading the fabric manager is one step towards that goal, not
+    /// the goal itself — a command that only restarts the fabric manager leaves
+    /// the partitions defined but inactive, and dstack-vmm cannot tell the
+    /// difference: a zero exit status is taken as the goal being met, and the
+    /// VM proceeds to attach its GPUs.
     pub(crate) fn apply(&self, partitions: &[PlannedPartition]) -> Result<()> {
         let partition_info = render_partitions(partitions);
         if partition_info == current_partitions(&self.config.partition_file) {
@@ -214,7 +222,7 @@ impl Nvswitch {
                 "DSTACK_NVSWITCH_PARTITION_FILE",
                 &self.config.partition_file,
             )
-            .env("DSTACK_NVSWITCH_PARTITION_IDS", &ids)
+            .env("DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS", &ids)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/dstack/vmm/src/nvswitch.rs
+++ b/dstack/vmm/src/nvswitch.rs
@@ -50,6 +50,11 @@ use crate::config::NvswitchConfig;
 /// Other sizes are still emitted, but their quota is undefined by NVIDIA.
 const DOCUMENTED_PARTITION_SIZES: [usize; 4] = [1, 2, 4, 8];
 
+/// Written into the table's `name` field to mark the file as ours. A file
+/// carrying any other name is replaced on the first reconcile, so taking
+/// ownership always runs the apply command once.
+const TABLE_NAME: &str = "dstack-vmm";
+
 /// One VM's claim on the fabric.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FabricClaim {
@@ -114,7 +119,9 @@ impl Nvswitch {
                 bail!("cvm.gpu.nvswitch.apply_command is required when nvswitch is enabled");
             }
             if config.module_ids.is_empty() {
-                bail!("cvm.gpu.nvswitch.module_ids is required when nvswitch is enabled");
+                bail!(
+                    "cvm.gpu.nvswitch.module_ids is required when nvswitch is enabled"
+                );
             }
             let mut seen = BTreeMap::new();
             for (slot, module_id) in &config.module_ids {
@@ -170,7 +177,7 @@ impl Nvswitch {
         }
         let table = PartitionTable {
             version: 0,
-            name: "dstack-vmm".to_string(),
+            name: TABLE_NAME.to_string(),
             time: humantime::format_rfc3339_seconds(SystemTime::now()).to_string(),
             partition_info,
         };
@@ -321,14 +328,26 @@ fn render_partitions(partitions: &[PlannedPartition]) -> Vec<PartitionInfo> {
         .collect()
 }
 
-/// The partitions currently on disk, or none when the file is missing or was
-/// not written by us.
+/// The partitions currently on disk, or none when the file is missing, does not
+/// parse, or was not written by us.
+///
+/// Returning none forces a rewrite, which is what taking over a file another
+/// tool wrote should do: matching partitions are not evidence that the fabric
+/// manager ever loaded them.
 fn current_partitions(path: &Path) -> Vec<PartitionInfo> {
     let Ok(body) = fs::read(path) else {
         return Vec::new();
     };
     match serde_json::from_slice::<PartitionTable>(&body) {
-        Ok(table) => table.partition_info,
+        Ok(table) if table.name == TABLE_NAME => table.partition_info,
+        Ok(table) => {
+            info!(
+                file = %path.display(),
+                name = table.name,
+                "taking over a foreign nvswitch partition table"
+            );
+            Vec::new()
+        }
         Err(err) => {
             warn!(
                 file = %path.display(),
@@ -499,6 +518,43 @@ mod tests {
             table["partitionInfo"][0]["gpuModuleIds"],
             serde_json::json!([1, 2])
         );
+    }
+
+    #[test]
+    fn takes_over_a_foreign_table_even_when_the_partitions_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("applied");
+        let partition_file = dir.path().join("customPartition.json");
+        let config = NvswitchConfig {
+            enabled: true,
+            partition_file: partition_file.clone(),
+            apply_command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("echo x >> {}", marker.display()),
+            ],
+            apply_timeout_ms: 10_000,
+            module_ids: BTreeMap::from([("0000:1b:00.0".to_string(), 1)]),
+        };
+        let nvswitch = Nvswitch::new(&config).unwrap();
+        let partitions = plan(vec![claim("vm-a", &[1, 2], None)]).unwrap();
+        fs::write(
+            &partition_file,
+            serde_json::to_vec(&PartitionTable {
+                version: 0,
+                name: "some other tool".to_string(),
+                time: "now".to_string(),
+                partition_info: render_partitions(&partitions),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        nvswitch.apply(&partitions).unwrap();
+        assert_eq!(fs::read_to_string(&marker).unwrap().lines().count(), 1);
+        // Now the file is ours, so an unchanged plan is a no-op.
+        nvswitch.apply(&partitions).unwrap();
+        assert_eq!(fs::read_to_string(&marker).unwrap().lines().count(), 1);
     }
 
     #[test]

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -219,6 +219,32 @@ sanitize_on_attach = true
 # Maximum time for all reset GPUs to become continuously VFIO-ready.
 sbr_timeout_ms = 10000
 
+# Ownership of the NVIDIA fabric manager's shared NVSwitch partition definition
+# file. The fabric manager can only activate NVLink partitions that are already
+# in that file and it reads the file once, at startup, so the built-in table
+# limits a host to a fixed set of GPU groupings. When enabled, dstack-vmm
+# rewrites the file on every VM start with one partition per GPU-attached VM
+# that is running or starting, keeping the partition id of VMs that already run,
+# and only reapplies it when the partitions actually changed.
+#
+# Host requirements: point SHARED_PARTITION_DEFINITION_FILE in fabricmanager.cfg
+# at `partition_file`, keep the NVSwitches on the host (a VM that also passes
+# NVSwitch bridges through is rejected in this mode), and make sure dstack-vmm
+# may write the file and run `apply_command`.
+[cvm.gpu.nvswitch]
+enabled = false
+partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
+# Run after the file changed. The command decides how the fabric manager takes
+# the new table (restart, and any partition activation the deployment needs). It
+# gets DSTACK_NVSWITCH_PARTITION_FILE and DSTACK_NVSWITCH_PARTITION_IDS in its
+# environment.
+apply_command = ["systemctl", "restart", "nvidia-fabricmanager"]
+apply_timeout_ms = 60000
+# PCI address of each attachable GPU mapped to the fabric module id reported by
+# `nvidia-smi -q` ("Module ID"). Required when enabled.
+# [cvm.gpu.nvswitch.module_ids]
+# "0000:1b:00.0" = 1
+
 [gateway]
 base_domain = "localhost"
 port = 8082

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -222,7 +222,7 @@ sbr_timeout_ms = 10000
 # Ownership of the NVIDIA fabric manager's shared NVSwitch partition definition
 # file. The fabric manager can only activate NVLink partitions that are already
 # in that file and it reads the file once, at startup, so the built-in table
-# limits a host to a fixed set of GPU groupings. When enabled, dstack-vmm
+# limits a host to a fixed set of GPU groupings. When managed, dstack-vmm
 # rewrites the file on every VM start with one partition per GPU-attached VM
 # that is running or starting, keeping the partition id of VMs that already run,
 # and only reapplies it when the partitions actually changed.
@@ -232,7 +232,9 @@ sbr_timeout_ms = 10000
 # NVSwitch bridges through is rejected in this mode), and make sure dstack-vmm
 # may write the file and run `apply_command`.
 [cvm.gpu.nvswitch]
-enabled = false
+# dstack-vmm owns the partition definition file. The NVSwitches themselves are
+# not dstack-vmm's to enable, so this names the ownership, not the hardware.
+managed = false
 partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
 # Run after the file changed. The command decides how the fabric manager takes
 # the new table (restart, and any partition activation the deployment needs). It
@@ -241,7 +243,7 @@ partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
 apply_command = ["systemctl", "restart", "nvidia-fabricmanager"]
 apply_timeout_ms = 60000
 # PCI address of each attachable GPU mapped to the fabric module id reported by
-# `nvidia-smi -q` ("Module ID"). Required when enabled.
+# `nvidia-smi -q` ("Module ID"). Required when managed.
 # [cvm.gpu.nvswitch.module_ids]
 # "0000:1b:00.0" = 1
 

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -236,11 +236,19 @@ sbr_timeout_ms = 10000
 # not dstack-vmm's to enable, so this names the ownership, not the hardware.
 managed = false
 partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
-# Run after the file changed. The command decides how the fabric manager takes
-# the new table (restart, and any partition activation the deployment needs). It
-# gets DSTACK_NVSWITCH_PARTITION_FILE and DSTACK_NVSWITCH_PARTITION_IDS in its
-# environment.
-apply_command = ["systemctl", "restart", "nvidia-fabricmanager"]
+# Run after the file changed, to make the new table effective. Its contract is
+# the whole way from file to usable partition, activation included: when it
+# returns 0, dstack-vmm attaches the GPUs and boots the guest.
+#
+# It gets DSTACK_NVSWITCH_PARTITION_FILE and DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS
+# in its environment. The second one is a goal, not a report: those ids, and only
+# those, must be live when the command returns. Restarting the fabric manager
+# only reloads the table -- on its own it leaves every partition defined but
+# inactive -- so a command that stops there is not enough.
+#
+# There is no default on purpose: a host that sets managed = true has to say how
+# its table becomes effective, and dstack-vmm refuses to start otherwise.
+apply_command = []
 apply_timeout_ms = 60000
 # PCI address of each attachable GPU mapped to the fabric module id reported by
 # `nvidia-smi -q` ("Module ID"). Required when managed.


### PR DESCRIPTION
## Problem

On an HGX/DGX host the NVIDIA fabric manager only activates NVLink partitions
that already exist in its partition definition file, and it reads that file
exactly once, when it starts. The built-in table hard-codes a fixed set of GPU
groupings (`fmpm -l` on an 8-GPU baseboard lists 15 of them), so the grouping a
deployment needs — "give this CVM any N of the M GPUs that are free right now" —
is simply not expressible. There is no reload entry point: no SIGHUP, no `fmpm`
verb, no `libnvfm` call that adds a candidate partition at runtime.

dstack-vmm already picks which GPUs a VM gets, so it is the component that knows
the answer the fabric manager is missing.

## Fix

New opt-in `[cvm.gpu.nvswitch]` section. When `managed` is set, dstack-vmm owns
the partition definition file: on every VM start it recomputes one partition per
GPU-attached VM that is running or starting, writes the file, and runs the
operator's `apply_command` so the fabric manager picks it up.

Two properties keep this from disturbing tenants that are already running:

- **Partition ids are stable.** A VM's id is persisted in its own
  `nvswitch-partition.json` on the first start and reused on every later
  rewrite, so the entry a running VM sits on is byte-identical across rewrites
  and survives a dstack-vmm restart. A stopped VM's id is freed and reused by
  the next VM.
- **Rewrites are conditional.** The file is written, and `apply_command` run,
  only when the set of partitions actually changed. Restarting a VM that is
  already in the table touches nothing. A table dstack-vmm did not write (no
  `name` marker) is always replaced, since matching partitions in a foreign file
  are not evidence that the fabric manager ever loaded them.

The whole read-plan-write-apply cycle runs under a lock, so a start that
snapshotted the VM list first cannot drop the partition of a VM that started
concurrently.

```toml
[cvm.gpu.nvswitch]
managed = true
partition_file = "/usr/share/nvidia/nvswitch/customPartition.json"
apply_command = ["/usr/local/bin/dstack-apply-fabric-partitions"]
apply_timeout_ms = 60000

[cvm.gpu.nvswitch.module_ids]
"0000:1b:00.0" = 1
"0000:43:00.0" = 2
```

`module_ids` maps each attachable GPU's PCI address to its fabric module id
(`nvidia-smi -q`, `Module ID`), which is the identifier the partition file uses.
The flag is `managed`, not `enabled`: the NVSwitches are not dstack-vmm's to
enable, what it turns on is dstack-vmm owning the file.

### Why the apply step is a command

Activation (`fmpm -a`) is deliberately not encoded here — activation semantics
differ across driver releases and multitenancy modes, and none of that is
verifiable without an HGX host to drain. But it is not optional either: a table
the fabric manager reloaded is still *defined but inactive*, and a zero exit
status is all dstack-vmm can check before it attaches the GPUs and boots the
guest.

So `apply_command` owns the whole way from file to usable partition, stated
declaratively. It receives `DSTACK_NVSWITCH_PARTITION_FILE` and
`DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS` — the second being a goal, not a report:
those ids, and only those, must be live when the command returns. The table only
ever holds VMs that are running or starting, so its ids are exactly the ids that
belong active, and the command converges the fabric to that set:

```sh
#!/bin/sh
set -e
systemctl restart nvidia-fabricmanager   # reload the table; does not activate
for id in $DSTACK_NVSWITCH_ACTIVE_PARTITION_IDS; do
    fmpm -a "$id"
done
```

There is no default `apply_command`: a bare fabric manager restart is exactly
the incomplete case, so shipping it as the default would have made the silent
failure the out-of-the-box behavior. A host that sets `managed = true` has to
state how its table becomes effective, and dstack-vmm refuses to start
otherwise.

### Design notes

- **Only running VMs are in the table.** An alternative is to predefine every
  subset up front (107 entries for 1/2/4/8-GPU groups on 8 GPUs) and never
  rewrite. That trades an undocumented limit — NVIDIA does not publish a maximum
  entry count — for the rewrite. Emitting only the partitions in use keeps the
  table at most one entry per VM.
- **Partition sizes.** On B200/B300, multicast slots are shared across
  partitions with a fixed quota per size (8 GPUs: all slots, 4: 50%, 2: 25%, 1:
  none). Sizes outside {1, 2, 4, 8} have no documented quota, so they are
  emitted with a warning rather than rejected.
- **NVSwitch passthrough is rejected in this mode.** A VM that passes NVSwitch
  bridges through and a host fabric manager that owns the switches are two
  mutually exclusive models; starting such a VM fails with an explicit error
  instead of leaving two sources of truth for the routing state.
- **Overlapping GPU claims now fail.** dstack-vmm does not otherwise detect two
  VMs listing the same BDF. Planning a table makes the overlap explicit, so the
  start is rejected rather than emitting a table the fabric manager would refuse.

## Verification

- `cargo test -p dstack-vmm` — 140 passed, including 13 new tests in
  `vmm/src/nvswitch.rs` covering id assignment (lowest free id for a new VM,
  preserved id for a running VM, reuse of a stopped VM's id), duplicate-id
  recovery, rejection of overlapping claims and of a `module_ids` map with a
  duplicated module id, PCI address normalization, and the apply path (writes the
  file, runs the command once, skips the command when the partitions are
  unchanged, reruns it when a partition is added, replaces a foreign table even
  when its partitions match, fails the start when the command fails).
- `cargo clippy -p dstack-vmm --all-targets` — clean.
- **Not verified on hardware.** No HGX/DGX host was available to drain, so the
  premise that restarting the fabric manager leaves already-running partitions
  forwarding is assumed, not measured. That premise, and NVIDIA's maximum
  partition-table size, are what a hardware pass should check before this is
  enabled anywhere real. The feature defaults to off and every existing config
  parses unchanged.

## Not in this change

- `dstack-vmm one-shot` bypasses `App` entirely and does not manage the table.
- dstack-vmm never calls `fmpm` itself, and does not verify that
  `apply_command` really made the partitions live; see above.
