### PR TITLE
fix(os/mkosi): ship the xmlsec1 OpenSSL runtime that nvattest links against

### DIFF
--- a/os/mkosi/mkosi.conf
+++ b/os/mkosi/mkosi.conf
@@ -77,6 +77,13 @@ Packages=
         systemd-boot-efi
         acpid
         numactl
+        # nvattest links against xmlsec1 and its OpenSSL crypto backend, but
+        # only libxmlsec1-dev was listed, under BuildPackages -- so the binary
+        # shipped without libxmlsec1-openssl.so.1 and every GPU CVM failed at
+        # boot with "error while loading shared libraries", which
+        # dstack-prepare treats as fatal.
+        libxmlsec1t64-openssl
+        libxmlsec1t64
 RemoveFiles=
         /var/lib/containerd/.dstack-keep
         /var/lib/docker/.dstack-keep


### PR DESCRIPTION
nvattest links against xmlsec1 and its OpenSSL crypto backend, but `os/mkosi/mkosi.conf` lists `libxmlsec1-dev` under **BuildPackages only**. The binary therefore ships in the rootfs without `libxmlsec1-openssl.so.1` ever being installed, and every GPU CVM dies during guest preparation:

```
nvattest: /usr/bin/nvattest: error while loading shared libraries:
          libxmlsec1-openssl.so.1: cannot open shared object file
Error: Failed to measure app info
  1: nvattest exited with exit status: 127
```

`dstack-prepare` treats a failed app-info measurement as fatal, so the guest reboot-loops. It affects any GPU CVM on the unified image regardless of GPU count, and 0.6 has no separate GPU profile — `mkosi.profiles/` holds only `dev` and `prod` — so the runtime libraries belong in the main `Packages` list.

Debian **trixie**, which this image pins (snapshot `20260721T000000Z`), names these `libxmlsec1t64` and `libxmlsec1t64-openssl`; the pre-t64 `libxmlsec1-openssl` does not exist there. Verified against the snapshot's own `Packages` index before building.

## Verification

Rebuilt `dstack-0.6.0-rc0` with this change on an 8x NVIDIA B200 Intel TDX host and deployed CVMs with 1, 2, 4 and 8 GPUs attached. All of them:

- boot without the reboot loop (`nvattest` runs and app-info measurement succeeds)
- report `CC status: ON` and `Confidential Compute GPUs Ready state: ready`
- come up with a full `NV18` NVLink mesh (8x8 at eight GPUs)

and inside a CC-on guest a 1 MiB `cuMemcpyPeer` between two GPUs completes with the bytes verified identical on the receiving GPU.

Note for anyone reproducing on the same hardware: a GPU CVM also needs `--secure-time` on its app-compose, otherwise `nvattest` runs before chrony has stepped the clock and NVIDIA's OCSP response is rejected as `status not yet valid` (exit 201). That is a deploy-side flag, not an image problem, and `gateway/dstack-app/deploy-to-vmm.sh` already passes it.
