### PR TITLE
feat(guest-agent): expose GPU telemetry via GpuInfo RPC

### DIFF
--- a/docs/security/cvm-boundaries.md
+++ b/docs/security/cvm-boundaries.md
@@ -35,7 +35,7 @@ This is the main configuration file for the application in JSON format:
 | local_key_provider_enabled | 0.3.1 | boolean | Use a local key provider |
 | key_provider_id | 0.5.1 | string | Optional pin for the key provider identity (hex-encoded bytes). For `kms` this is the KMS CA public key; for `local` the sealing-provider MR. For `tpm` and `none` it must be an empty string — the TPM app-root public key is instance-specific and is not used as a provider id or measured as one. |
 | public_logs | 0.3.3 | boolean | Whether logs are publicly visible |
-| public_sysinfo | 0.3.3 | boolean | Whether system info is public |
+| public_sysinfo | 0.3.3 | boolean | Whether system info is public. Covers the guest dashboard and `/metrics`, including the `dstack_gpu_*` series (since 0.6.0), which expose each GPU's UUID and PCI bus address alongside utilization, memory, temperature and power. |
 | public_tcbinfo | 0.5.1 | boolean | Whether TCB info is public |
 | allowed_envs | 0.4.2 | array of string | List of allowed environment variable names |
 | no_instance_id | 0.4.2 | boolean | Disable instance ID generation |

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "listenfd",
  "load_config",
  "nvattest",
+ "nvml-wrapper",
  "or-panic",
  "ra-rpc",
  "ra-tls",

--- a/dstack/Cargo.lock
+++ b/dstack/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bollard",
+ "cached-cell",
  "cc-eventlog",
  "cert-client",
  "chrono",
@@ -2023,8 +2024,8 @@ dependencies = [
  "libc",
  "listenfd",
  "load_config",
+ "lspci",
  "nvattest",
- "nvml-wrapper",
  "or-panic",
  "ra-rpc",
  "ra-tls",
@@ -2292,11 +2293,13 @@ dependencies = [
  "ez-hash",
  "fs-err",
  "getrandom 0.3.4",
+ "guest-api",
  "hex",
  "hex_fmt",
  "host-api",
  "k256",
  "libc",
+ "lspci",
  "luks2",
  "nvattest",
  "nvml-wrapper",
@@ -4292,6 +4295,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "insta",
+ "tempfile",
 ]
 
 [[package]]

--- a/dstack/dstack-util/Cargo.toml
+++ b/dstack/dstack-util/Cargo.toml
@@ -42,6 +42,7 @@ tpm-attest.workspace = true
 tpm2.workspace = true
 tpm-qvl = { workspace = true, features = ["crl-download"] }
 host-api = { workspace = true, features = ["client"] }
+guest-api.workspace = true
 cmd_lib.workspace = true
 toml.workspace = true
 dcap-qvl.workspace = true
@@ -60,6 +61,7 @@ sodiumbox.workspace = true
 libc.workspace = true
 luks2.workspace = true
 nvml-wrapper.workspace = true
+lspci.workspace = true
 scopeguard.workspace = true
 tempfile.workspace = true
 ez-hash.workspace = true

--- a/dstack/dstack-util/src/gpu_info.rs
+++ b/dstack/dstack-util/src/gpu_info.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! One-shot NVML sampler behind `dstack-util gpu-info`.
+//!
+//! NVML calls cannot be cancelled: a driver that wedges during a GPU reset or a
+//! CC handshake blocks the calling thread until it decides to return. Running
+//! the sample in a short-lived process lets `dstack-guest-agent` kill it and
+//! move on, and keeps `libnvidia-ml` out of the long-lived agent entirely.
+//!
+//! One process per sample also means `Nvml::init()` runs fresh every time, so a
+//! driver that loads after the agent started is picked up on the next sample
+//! instead of being cached as "no GPU" for the agent's lifetime.
+//!
+//! This command owns collection only. Caching, presence gating and timeouts
+//! belong to the caller.
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use guest_api::{GpuDevice, GpuInfoResponse};
+use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
+use nvml_wrapper::error::NvmlError;
+use nvml_wrapper::{Device, Nvml};
+use tracing::{debug, warn};
+
+/// Per-run state for error log deduplication.
+///
+/// A single run touches each (device, field) pair once, so this only collapses
+/// the repeats that a multi-GPU box would otherwise produce for the same
+/// unsupported counter on every card.
+#[derive(Default)]
+struct Sampler {
+    warned: HashSet<(u32, &'static str)>,
+}
+
+/// Samples every NVIDIA GPU visible to NVML and prints the result as one JSON
+/// object on stdout.
+///
+/// Exits zero even when NVML is unavailable: "no driver" is a result the caller
+/// needs to record, not a failure of this command. A non-zero exit is reserved
+/// for not being able to produce a result at all.
+pub fn cmd_gpu_info() -> Result<()> {
+    let response = collect();
+    serde_json::to_writer(std::io::stdout(), &response)?;
+    println!();
+    Ok(())
+}
+
+fn collect() -> GpuInfoResponse {
+    let nvml = match Nvml::init() {
+        Ok(nvml) => nvml,
+        Err(err) => {
+            // Expected on any guest without an NVIDIA driver. The caller gates
+            // on PCI presence, so reaching here means a card is attached but
+            // the library is missing -- worth a warning.
+            warn!("failed to initialize NVML: {err}");
+            return unavailable(format!("failed to initialize NVML: {err}"));
+        }
+    };
+    sample(&mut Sampler::default(), &nvml)
+}
+
+fn unavailable(error: impl Into<String>) -> GpuInfoResponse {
+    GpuInfoResponse {
+        gpus: vec![],
+        error: error.into(),
+        cc_ready: None,
+        cc_enabled: None,
+        sample_age_ms: None,
+    }
+}
+
+fn sample(sampler: &mut Sampler, nvml: &Nvml) -> GpuInfoResponse {
+    let count = match nvml.device_count() {
+        Ok(count) => count,
+        Err(e) => {
+            let error = format!("failed to get NVML GPU count: {e}");
+            warn!("{error}");
+            return unavailable(error);
+        }
+    };
+
+    // Both CC queries are system-wide despite hanging off `Device`, so ask once
+    // through device 0 rather than once per card.
+    let (cc_ready, cc_enabled) = query_cc_state(sampler, nvml, count);
+    GpuInfoResponse {
+        gpus: (0..count)
+            .map(|index| collect_device(sampler, nvml, index))
+            .collect(),
+        error: String::new(),
+        cc_ready,
+        cc_enabled,
+        sample_age_ms: None,
+    }
+}
+
+/// Reads the system-wide confidential-computing state.
+///
+/// `get_confidential_compute_state` is `nvmlSystemGetConfComputeGpusReadyState`
+/// and `is_cc_enabled` is `nvmlSystemGetConfComputeSettings`; neither uses the
+/// device handle it is called on. Any device will do, so device 0 is used.
+fn query_cc_state(sampler: &mut Sampler, nvml: &Nvml, count: u32) -> (Option<bool>, Option<bool>) {
+    if count == 0 {
+        return (None, None);
+    }
+    let device = match nvml.device_by_index(0) {
+        Ok(device) => device,
+        Err(e) => {
+            log_query_error(sampler, 0, "cc_state", &e);
+            return (None, None);
+        }
+    };
+    let ready = match device.get_confidential_compute_state() {
+        Ok(ready) => Some(ready),
+        Err(e) => {
+            log_query_error(sampler, 0, "cc_ready", &e);
+            None
+        }
+    };
+    let enabled = match device.is_cc_enabled() {
+        Ok(enabled) => Some(enabled),
+        Err(e) => {
+            log_query_error(sampler, 0, "cc_enabled", &e);
+            None
+        }
+    };
+    (ready, enabled)
+}
+
+fn collect_device(sampler: &mut Sampler, nvml: &Nvml, index: u32) -> GpuDevice {
+    match nvml.device_by_index(index) {
+        Ok(device) => collect_device_fields(sampler, index, &device),
+        Err(e) => {
+            log_query_error(sampler, index, "device", &e);
+            GpuDevice {
+                index,
+                errors: vec![format!("device: {e}")],
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn collect_device_fields(sampler: &mut Sampler, index: u32, device: &Device<'_>) -> GpuDevice {
+    let mut errors = Vec::new();
+
+    let uuid = match device.uuid() {
+        Ok(uuid) => uuid,
+        Err(e) => {
+            push_error(sampler, index, "uuid", e, &mut errors);
+            String::new()
+        }
+    };
+    let pci_bus_id = match device.pci_info() {
+        Ok(pci) => pci.bus_id,
+        Err(e) => {
+            push_error(sampler, index, "pci_bus_id", e, &mut errors);
+            String::new()
+        }
+    };
+
+    let (utilization_gpu, utilization_memory) = match device.utilization_rates() {
+        Ok(util) => (Some(util.gpu), Some(util.memory)),
+        Err(e) => {
+            push_error(sampler, index, "utilization", e, &mut errors);
+            (None, None)
+        }
+    };
+
+    let (memory_total_bytes, memory_used_bytes, memory_free_bytes) = match device.memory_info() {
+        Ok(mem) => (Some(mem.total), Some(mem.used), Some(mem.free)),
+        Err(e) => {
+            push_error(sampler, index, "memory", e, &mut errors);
+            (None, None, None)
+        }
+    };
+
+    let temperature_c = match device.temperature(TemperatureSensor::Gpu) {
+        Ok(temp) => Some(temp),
+        Err(e) => {
+            push_error(sampler, index, "temperature", e, &mut errors);
+            None
+        }
+    };
+
+    let power_usage_mw = match device.power_usage() {
+        Ok(power) => Some(power),
+        Err(e) => {
+            push_error(sampler, index, "power", e, &mut errors);
+            None
+        }
+    };
+
+    GpuDevice {
+        index,
+        uuid,
+        pci_bus_id,
+        utilization_gpu,
+        utilization_memory,
+        memory_total_bytes,
+        memory_used_bytes,
+        memory_free_bytes,
+        temperature_c,
+        power_usage_mw,
+        errors,
+    }
+}
+
+fn push_error(
+    sampler: &mut Sampler,
+    index: u32,
+    field: &'static str,
+    err: NvmlError,
+    errors: &mut Vec<String>,
+) {
+    errors.push(format!("{field}: {err}"));
+    log_query_error(sampler, index, field, &err);
+}
+
+fn log_query_error(sampler: &mut Sampler, index: u32, field: &'static str, err: &NvmlError) {
+    let first = sampler.warned.insert((index, field));
+    if matches!(err, NvmlError::NotSupported) {
+        // CC mode disables some counters by design; that is not an incident.
+        debug!("GPU {index} {field} not supported: {err}");
+    } else if first {
+        warn!("failed to query GPU {index} {field}: {err}");
+    } else {
+        debug!("failed to query GPU {index} {field}: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// NVML may or may not be present on the machine running this test.
+    /// Unavailability must be an error with no devices, not a silent empty
+    /// success (which would mean "NVML worked, zero GPUs").
+    #[test]
+    fn collect_reports_nvml_unavailability_without_panicking() {
+        let info = collect();
+        if info.error.is_empty() {
+            return;
+        }
+        assert!(info.gpus.is_empty());
+        assert_eq!(info.cc_ready, None);
+        assert_eq!(info.cc_enabled, None);
+    }
+
+    /// The guest agent parses stdout as one JSON object. A response must
+    /// survive that round trip with `None` distinct from `Some(0)`.
+    #[test]
+    fn response_round_trips_through_json() {
+        let original = GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                index: 0,
+                uuid: "GPU-abc".into(),
+                pci_bus_id: "00000000:01:00.0".into(),
+                utilization_gpu: Some(0),
+                utilization_memory: None,
+                memory_total_bytes: Some(8 << 30),
+                memory_used_bytes: Some(0),
+                memory_free_bytes: None,
+                temperature_c: Some(40),
+                power_usage_mw: None,
+                errors: vec!["power: not supported".into()],
+            }],
+            error: String::new(),
+            cc_ready: Some(true),
+            cc_enabled: Some(true),
+            sample_age_ms: None,
+        };
+        let encoded = serde_json::to_string(&original).expect("encode");
+        assert!(!encoded.contains('\n'), "one JSON line per sample");
+        let decoded: GpuInfoResponse = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, original);
+        assert_eq!(decoded.gpus[0].utilization_gpu, Some(0));
+        assert_eq!(decoded.gpus[0].utilization_memory, None);
+    }
+}

--- a/dstack/dstack-util/src/main.rs
+++ b/dstack/dstack-util/src/main.rs
@@ -32,6 +32,7 @@ use utils::AppKeys;
 mod crypto;
 mod docker_compose;
 mod gateway_checker;
+mod gpu_info;
 mod host_api;
 mod host_shared;
 mod parse_env_file;
@@ -101,6 +102,8 @@ enum Commands {
     Decrypt(DecryptArgs),
     /// Encrypt data for an app using its KMS-provided environment encryption key
     Encrypt(EncryptArgs),
+    /// Sample NVIDIA GPU telemetry through NVML and print it as JSON
+    GpuInfo,
 }
 
 #[derive(Parser)]
@@ -1567,13 +1570,19 @@ async fn cmd_tpm_verify(args: TpmVerifyArgs) -> Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
     {
         use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        fmt().with_env_filter(filter).with_ansi(false).init();
+        let builder = fmt().with_env_filter(filter).with_ansi(false);
+        // `gpu-info` writes a machine-readable JSON document to stdout, so its
+        // logs must go to stderr or an NVML warning would corrupt the output.
+        // Every other subcommand keeps the historical stdout behaviour.
+        match cli.command {
+            Commands::GpuInfo => builder.with_writer(std::io::stderr).init(),
+            _ => builder.init(),
+        }
     }
-
-    let cli = Cli::parse();
 
     match cli.command {
         Commands::Quote => cmd_quote()?,
@@ -1654,6 +1663,9 @@ async fn main() -> Result<()> {
         }
         Commands::Encrypt(args) => {
             cmd_encrypt(args).await?;
+        }
+        Commands::GpuInfo => {
+            gpu_info::cmd_gpu_info()?;
         }
     }
 

--- a/dstack/dstack-util/src/system_setup.rs
+++ b/dstack/dstack-util/src/system_setup.rs
@@ -1361,11 +1361,7 @@ mod gpu {
     /// Bound Rego evaluation so a runaway application policy cannot hang boot.
     const POLICY_TIMEOUT: Duration = Duration::from_secs(10);
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub(super) struct GpuInventory {
-        pub(super) total: u32,
-        pub(super) nvidia: u32,
-    }
+    use lspci::sysfs::GpuInventory;
 
     #[derive(Debug, Serialize)]
     struct GpuAttestationEvent {
@@ -1457,33 +1453,11 @@ mod gpu {
     /// the NVIDIA driver did not bind cannot be hidden from the gate. Reading
     /// the inventory is fail-closed: a mixed NVIDIA/non-NVIDIA set must not be
     /// represented by an attestation result for only the NVIDIA subset.
+    ///
+    /// The scan itself lives in `lspci::sysfs` because the guest agent's GPU
+    /// telemetry gate needs the same answer with a different failure policy.
     pub(super) fn gpu_inventory() -> Result<GpuInventory> {
-        gpu_inventory_at(Path::new("/sys/bus/pci/devices"))
-    }
-
-    fn gpu_inventory_at(devices_path: &Path) -> Result<GpuInventory> {
-        let entries = fs::read_dir(devices_path).context("failed to enumerate PCI devices")?;
-        let mut inventory = GpuInventory {
-            total: 0,
-            nvidia: 0,
-        };
-        for entry in entries {
-            let device = entry.context("failed to read PCI device entry")?;
-            let class_path = device.path().join("class");
-            let class = fs::read_to_string(&class_path)
-                .with_context(|| format!("failed to read {}", class_path.display()))?;
-            if !matches!(class.trim().get(..6), Some("0x0300") | Some("0x0302")) {
-                continue;
-            }
-            inventory.total += 1;
-            let vendor_path = device.path().join("vendor");
-            let vendor = fs::read_to_string(&vendor_path)
-                .with_context(|| format!("failed to read {}", vendor_path.display()))?;
-            if vendor.trim() == "0x10de" {
-                inventory.nvidia += 1;
-            }
-        }
-        Ok(inventory)
+        lspci::sysfs::gpu_inventory()
     }
 
     pub(super) fn nvidia_gpu_count(inventory: GpuInventory) -> Result<u32> {
@@ -1726,13 +1700,6 @@ mod gpu {
     mod tests {
         use super::*;
 
-        fn add_pci_device(root: &Path, name: &str, vendor: &str, class: &str) {
-            let device = root.join(name);
-            fs::create_dir_all(&device).unwrap();
-            fs::write(device.join("vendor"), vendor).unwrap();
-            fs::write(device.join("class"), class).unwrap();
-        }
-
         fn nvattest_output(nonce: &str, claims: usize) -> Vec<u8> {
             let claims = (0..claims)
                 .map(|_| {
@@ -1798,21 +1765,6 @@ mod gpu {
                     .keys()
                     .all(|key| key.starts_with("x-nvidia-cert-")),
                 "cert-chain claim carries certificates, not just verdicts"
-            );
-        }
-
-        #[test]
-        fn inventory_counts_nvidia_and_non_nvidia_gpus() {
-            let root = tempfile::tempdir().unwrap();
-            add_pci_device(root.path(), "0000:01:00.0", "0x10de\n", "0x030200\n");
-            add_pci_device(root.path(), "0000:02:00.0", "0x1234\n", "0x030000\n");
-            add_pci_device(root.path(), "0000:03:00.0", "0x1af4\n", "0x020000\n");
-            assert_eq!(
-                gpu_inventory_at(root.path()).unwrap(),
-                GpuInventory {
-                    total: 2,
-                    nvidia: 1
-                }
             );
         }
 

--- a/dstack/guest-agent/Cargo.toml
+++ b/dstack/guest-agent/Cargo.toml
@@ -58,6 +58,7 @@ or-panic.workspace = true
 cc-eventlog.workspace = true
 listenfd.workspace = true
 libc.workspace = true
+nvml-wrapper.workspace = true
 
 [dev-dependencies]
 # The test-only mock platform builds attestations from a fixture, which needs

--- a/dstack/guest-agent/Cargo.toml
+++ b/dstack/guest-agent/Cargo.toml
@@ -20,7 +20,7 @@ fs-err.workspace = true
 rcgen.workspace = true
 sha2.workspace = true
 clap.workspace = true
-tokio = { workspace = true, features = ["io-util", "process"] }
+tokio = { workspace = true, features = ["process"] }
 hex.workspace = true
 serde_json.workspace = true
 bollard.workspace = true
@@ -58,7 +58,8 @@ or-panic.workspace = true
 cc-eventlog.workspace = true
 listenfd.workspace = true
 libc.workspace = true
-nvml-wrapper.workspace = true
+cached-cell.workspace = true
+lspci.workspace = true
 
 [dev-dependencies]
 # The test-only mock platform builds attestations from a fixture, which needs

--- a/dstack/guest-agent/Cargo.toml
+++ b/dstack/guest-agent/Cargo.toml
@@ -20,7 +20,7 @@ fs-err.workspace = true
 rcgen.workspace = true
 sha2.workspace = true
 clap.workspace = true
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["io-util", "process"] }
 hex.workspace = true
 serde_json.workspace = true
 bollard.workspace = true

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU telemetry for the `GpuInfo` RPC.
+//!
+//! NVML is initialized once per process and reused. `Nvml`'s `Drop` shuts the
+//! library down, so a request-scoped handle would init+shutdown on every
+//! `/metrics` scrape. Init failure is retried after `INIT_FAILURE_TTL` so
+//! images without a driver do not `dlopen` on every call, while a driver that
+//! appears later can still be picked up.
+//!
+//! Sampling is serialized with `try_lock`. A stuck NVML call (GPU reset, driver
+//! assert, CC handshake) keeps that one blocking thread and the sampler lock;
+//! the RPC timeout does **not** cancel it. Later callers skip the lock and
+//! return the last snapshot, or `error: "sampling in progress"` if none exists.
+//! They never queue behind the hung sample.
+//!
+//! GpuInfo, `/metrics`, and the dashboard share one 5s snapshot so the three
+//! entry points do not stampede NVML.
+
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex, OnceLock, RwLock, TryLockError};
+use std::time::{Duration, Instant};
+
+use guest_api::{GpuDevice, GpuInfoResponse};
+use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
+use nvml_wrapper::error::NvmlError;
+use nvml_wrapper::{Device, Nvml};
+use or_panic::ResultOrPanic;
+use tracing::{debug, warn};
+
+const SAMPLE_TTL: Duration = Duration::from_secs(5);
+const INIT_FAILURE_TTL: Duration = Duration::from_secs(60);
+
+struct GpuSampler {
+    warned: HashSet<(u32, &'static str)>,
+}
+
+static NVML: OnceLock<Nvml> = OnceLock::new();
+static SNAPSHOT: RwLock<Option<(Instant, GpuInfoResponse)>> = RwLock::new(None);
+static SAMPLER: LazyLock<Mutex<GpuSampler>> = LazyLock::new(|| {
+    Mutex::new(GpuSampler {
+        warned: HashSet::new(),
+    })
+});
+
+pub(crate) fn collect_gpu_info() -> GpuInfoResponse {
+    if let Some(response) = fresh_snapshot() {
+        return response;
+    }
+
+    let mut sampler = match SAMPLER.try_lock() {
+        Ok(guard) => guard,
+        Err(TryLockError::WouldBlock) => return snapshot_or_busy(),
+        Err(TryLockError::Poisoned(_)) => SAMPLER.lock().or_panic("gpu sampler mutex poisoned"),
+    };
+
+    if let Some(response) = fresh_snapshot() {
+        return response;
+    }
+
+    let response = sample(&mut sampler);
+    *SNAPSHOT.write().or_panic("gpu snapshot lock poisoned") =
+        Some((Instant::now(), response.clone()));
+    response
+}
+
+fn fresh_snapshot() -> Option<GpuInfoResponse> {
+    let snapshot = SNAPSHOT.read().or_panic("gpu snapshot lock poisoned");
+    snapshot.as_ref().and_then(|(fetched_at, response)| {
+        (fetched_at.elapsed() < ttl_for(response)).then(|| response.clone())
+    })
+}
+
+fn snapshot_or_busy() -> GpuInfoResponse {
+    let snapshot = SNAPSHOT.read().or_panic("gpu snapshot lock poisoned");
+    if let Some((_, response)) = snapshot.as_ref() {
+        return response.clone();
+    }
+    GpuInfoResponse {
+        gpus: vec![],
+        error: "sampling in progress".into(),
+        cc_ready: None,
+    }
+}
+
+fn ttl_for(response: &GpuInfoResponse) -> Duration {
+    if response.error.is_empty() {
+        SAMPLE_TTL
+    } else {
+        INIT_FAILURE_TTL
+    }
+}
+
+fn sample(sampler: &mut GpuSampler) -> GpuInfoResponse {
+    let nvml = match NVML.get() {
+        Some(nvml) => nvml,
+        None => match Nvml::init() {
+            Ok(nvml) => {
+                let _ = NVML.set(nvml);
+                match NVML.get() {
+                    Some(nvml) => nvml,
+                    None => {
+                        return GpuInfoResponse {
+                            gpus: vec![],
+                            error: "NVML handle missing after init".into(),
+                            cc_ready: None,
+                        };
+                    }
+                }
+            }
+            Err(e) => {
+                let error = format!("failed to initialize NVML: {e}");
+                warn!("{error}");
+                return GpuInfoResponse {
+                    gpus: vec![],
+                    error,
+                    cc_ready: None,
+                };
+            }
+        },
+    };
+
+    let count = match nvml.device_count() {
+        Ok(count) => count,
+        Err(e) => {
+            let error = format!("failed to get NVML GPU count: {e}");
+            warn!("{error}");
+            return GpuInfoResponse {
+                gpus: vec![],
+                error,
+                cc_ready: None,
+            };
+        }
+    };
+
+    let cc_ready = query_cc_ready(sampler, nvml, count);
+    GpuInfoResponse {
+        gpus: (0..count)
+            .map(|index| collect_device(sampler, nvml, index))
+            .collect(),
+        error: String::new(),
+        cc_ready,
+    }
+}
+
+fn query_cc_ready(sampler: &mut GpuSampler, nvml: &'static Nvml, count: u32) -> Option<bool> {
+    if count == 0 {
+        return None;
+    }
+    let device = match nvml.device_by_index(0) {
+        Ok(device) => device,
+        Err(e) => {
+            log_query_error(sampler, 0, "cc_ready", &e);
+            return None;
+        }
+    };
+    match device.get_confidential_compute_state() {
+        Ok(ready) => Some(ready),
+        Err(e) => {
+            log_query_error(sampler, 0, "cc_ready", &e);
+            None
+        }
+    }
+}
+
+fn collect_device(sampler: &mut GpuSampler, nvml: &'static Nvml, index: u32) -> GpuDevice {
+    match nvml.device_by_index(index) {
+        Ok(device) => collect_device_fields(sampler, index, &device),
+        Err(e) => {
+            log_query_error(sampler, index, "device", &e);
+            GpuDevice {
+                index,
+                error: format!("device: {e}"),
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn collect_device_fields(sampler: &mut GpuSampler, index: u32, device: &Device<'_>) -> GpuDevice {
+    let mut errors = Vec::new();
+
+    let uuid = match device.uuid() {
+        Ok(uuid) => uuid,
+        Err(e) => {
+            push_error(sampler, index, "uuid", e, &mut errors);
+            String::new()
+        }
+    };
+    let pci_bus_id = match device.pci_info() {
+        Ok(pci) => pci.bus_id,
+        Err(e) => {
+            push_error(sampler, index, "pci_bus_id", e, &mut errors);
+            String::new()
+        }
+    };
+
+    let (utilization_gpu, utilization_memory) = match device.utilization_rates() {
+        Ok(util) => (Some(util.gpu), Some(util.memory)),
+        Err(e) => {
+            push_error(sampler, index, "utilization", e, &mut errors);
+            (None, None)
+        }
+    };
+
+    let (memory_total_bytes, memory_used_bytes, memory_free_bytes) = match device.memory_info() {
+        Ok(mem) => (Some(mem.total), Some(mem.used), Some(mem.free)),
+        Err(e) => {
+            push_error(sampler, index, "memory", e, &mut errors);
+            (None, None, None)
+        }
+    };
+
+    let temperature_c = match device.temperature(TemperatureSensor::Gpu) {
+        Ok(temp) => Some(temp),
+        Err(e) => {
+            push_error(sampler, index, "temperature", e, &mut errors);
+            None
+        }
+    };
+
+    let power_usage_mw = match device.power_usage() {
+        Ok(power) => Some(power),
+        Err(e) => {
+            push_error(sampler, index, "power", e, &mut errors);
+            None
+        }
+    };
+
+    let cc_enabled = match device.is_cc_enabled() {
+        Ok(enabled) => Some(enabled),
+        Err(e) => {
+            push_error(sampler, index, "cc_enabled", e, &mut errors);
+            None
+        }
+    };
+
+    GpuDevice {
+        index,
+        uuid,
+        pci_bus_id,
+        utilization_gpu,
+        utilization_memory,
+        memory_total_bytes,
+        memory_used_bytes,
+        memory_free_bytes,
+        temperature_c,
+        power_usage_mw,
+        error: errors.join("; "),
+        cc_enabled,
+    }
+}
+
+fn push_error(
+    sampler: &mut GpuSampler,
+    index: u32,
+    field: &'static str,
+    err: NvmlError,
+    errors: &mut Vec<String>,
+) {
+    errors.push(format!("{field}: {err}"));
+    log_query_error(sampler, index, field, &err);
+}
+
+fn log_query_error(sampler: &mut GpuSampler, index: u32, field: &'static str, err: &NvmlError) {
+    let first = sampler.warned.insert((index, field));
+    if matches!(err, NvmlError::NotSupported) {
+        debug!("GPU {index} {field} not supported: {err}");
+    } else if first {
+        warn!("failed to query GPU {index} {field}: {err}");
+    } else {
+        debug!("failed to query GPU {index} {field}: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_gpu_info;
+
+    /// NVML may or may not be present on the machine running this test.
+    /// Unavailability must be an error with no devices, not a silent empty
+    /// success (which would mean "NVML worked, zero GPUs"). A host with NVML
+    /// just has to not panic.
+    #[test]
+    fn collect_reports_nvml_unavailability_without_panicking() {
+        let info = collect_gpu_info();
+        if info.error.is_empty() {
+            return;
+        }
+        assert!(
+            info.gpus.is_empty(),
+            "NVML unavailability must not invent devices, got {:?}",
+            info.gpus
+        );
+        assert_eq!(info.cc_ready, None);
+    }
+}

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -14,10 +14,36 @@
 //!    short-lived child that can be killed when a driver call wedges. Nothing
 //!    stays resident between samples, and each sample re-initializes NVML, so a
 //!    driver that loads late is picked up instead of being cached as "no GPU".
-//! 3. **Stale beats nothing.** Callers get the last known snapshot with its age
-//!    attached and a refresh is kicked off behind them. Returning a placeholder
-//!    on expiry would mean a Prometheus scrape slower than the TTL -- which is
-//!    every realistic scrape interval -- never sees a single GPU series.
+//! 3. **A request never waits on the GPU.** Callers get the last known snapshot
+//!    with its age attached and a refresh is kicked off behind them. Returning
+//!    a placeholder on expiry would mean a Prometheus scrape slower than the
+//!    TTL -- which is every realistic scrape interval -- never sees a single
+//!    GPU series.
+//!
+//! The cache is not here because sampling is slow. One `dstack-util gpu-info`
+//! run, fork to exit, measured 94-99 ms on a single H200 in CC mode. It is here
+//! because that number describes the healthy path only, and three things do not
+//! follow from it:
+//!
+//! - `/metrics` also carries CPU, memory, disk and container state. Sampling
+//!   inline would put all of it behind a driver call that can wedge for
+//!   [`SAMPLE_TIMEOUT`], well past a default Prometheus scrape timeout, so one
+//!   stuck card would erase every metric this CVM reports rather than just the
+//!   GPU ones.
+//! - `/metrics`, the dashboard and the `GpuInfo` RPC can arrive together, and
+//!   each would otherwise fork its own collector to repeat the same `dlopen`
+//!   and `nvmlInit_v2`. [`REFRESH_LOCK`] collapses a burst into one sample.
+//! - Enumeration cost grows with card count, and only one card has been
+//!   measured.
+//!
+//! Refreshing is lazy: nothing resamples unless someone asks. A served snapshot
+//! is therefore roughly one scrape interval old, not [`SAMPLE_TTL`] old -- the
+//! TTL decides when a request triggers the next sample, not how fresh the
+//! answer is. `sample_age_ms`, and `dstack_gpu_sample_age_seconds` on
+//! `/metrics`, carry that age so a consumer can correct for it. A background
+//! ticker would cap the age at the TTL instead, at the price of a permanent
+//! ~2% of a core on every GPU guest whether or not anyone is watching, to
+//! publish a number the consumer can already derive.
 
 use std::path::Path;
 use std::process::Stdio;
@@ -34,8 +60,10 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-/// How long a successful snapshot is served before a refresh is triggered.
-/// Older snapshots are still served, just with a refresh started behind them.
+/// How long a successful snapshot is served before a request triggers a
+/// refresh. Older snapshots are still served, just with a refresh started
+/// behind them, so this bounds when resampling starts and not how old a served
+/// sample can be.
 const SAMPLE_TTL: Duration = Duration::from_secs(5);
 /// Backoff after a failed sample.
 ///
@@ -46,9 +74,13 @@ const SAMPLE_TTL: Duration = Duration::from_secs(5);
 /// Long enough to stop hammering, short enough that a recovered driver is
 /// picked up while an operator is still looking at the dashboard.
 const FAILURE_BACKOFF: Duration = Duration::from_secs(30);
-/// Upper bound on one `dstack-util gpu-info` run. Generous because a cold
-/// `nvmlInit_v2` on a multi-GPU CC system is not fast, but finite because the
-/// whole point of the child process is that a wedged driver can be abandoned.
+/// Upper bound on one `dstack-util gpu-info` run. Finite because the whole
+/// point of the child process is that a wedged driver can be abandoned.
+///
+/// A measured run on a single H200 in CC mode takes 94-99 ms, so this is two
+/// orders of magnitude of headroom. The margin stays until a multi-GPU CVM has
+/// been measured: `nvmlInit_v2` enumerates every card, and trading the untested
+/// case for faster recovery in the tested one is the wrong direction.
 const SAMPLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The collector, installed into the rootfs alongside this agent.

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -2,358 +2,369 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! GPU telemetry collection isolated in a helper process.
+//! GPU telemetry, sampled out of process and cached.
 //!
-//! NVML calls cannot be cancelled safely. Keeping them in a child process lets
-//! the agent terminate and recreate the sampler after a driver call hangs. The
-//! helper keeps one NVML handle for its lifetime. Successful samples are cached
-//! for five seconds; initialization failures are cached for one minute.
+//! Three properties drive the shape of this module:
+//!
+//! 1. **A guest without an NVIDIA card pays nothing.** PCI topology is fixed
+//!    for a CVM's lifetime -- the VMM assigns GPUs through VFIO when QEMU
+//!    starts and never hot-plugs -- so the scan runs once and every later
+//!    request is an atomic load returning a constant.
+//! 2. **NVML never runs in this process.** `dstack-util gpu-info` samples in a
+//!    short-lived child that can be killed when a driver call wedges. Nothing
+//!    stays resident between samples, and each sample re-initializes NVML, so a
+//!    driver that loads late is picked up instead of being cached as "no GPU".
+//! 3. **Stale beats nothing.** Callers get the last known snapshot with its age
+//!    attached and a refresh is kicked off behind them. Returning a placeholder
+//!    on expiry would mean a Prometheus scrape slower than the TTL -- which is
+//!    every realistic scrape interval -- never sees a single GPU series.
 
-use std::collections::HashSet;
-use std::io::{BufRead, Write};
+use std::path::Path;
 use std::process::Stdio;
-use std::sync::{LazyLock, RwLock};
-use std::time::{Duration, Instant};
+use std::sync::{LazyLock, OnceLock};
+use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
-use guest_api::{GpuDevice, GpuInfoResponse};
-use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
-use nvml_wrapper::error::NvmlError;
-use nvml_wrapper::{Device, Nvml};
+use anyhow::{bail, Context, Result};
+use cached_cell::TtlCell;
+use guest_api::GpuInfoResponse;
+#[cfg(test)]
 use or_panic::ResultOrPanic;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::Command;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
+/// How long a snapshot is served before a refresh is triggered. Older snapshots
+/// are still served, just with a refresh started behind them.
 const SAMPLE_TTL: Duration = Duration::from_secs(5);
-const INIT_FAILURE_TTL: Duration = Duration::from_secs(60);
-const SAMPLE_TIMEOUT: Duration = Duration::from_secs(4);
+/// Upper bound on one `dstack-util gpu-info` run. Generous because a cold
+/// `nvmlInit_v2` on a multi-GPU CC system is not fast, but finite because the
+/// whole point of the child process is that a wedged driver can be abandoned.
+const SAMPLE_TIMEOUT: Duration = Duration::from_secs(10);
 
-struct GpuSampler {
-    warned: HashSet<(u32, &'static str)>,
+/// The collector, installed into the rootfs alongside this agent.
+const DSTACK_UTIL: &str = "/usr/bin/dstack-util";
+/// Set by tests to point at a stub collector.
+#[cfg(test)]
+static COLLECTOR_OVERRIDE: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
+
+static SNAPSHOT: LazyLock<TtlCell<GpuInfoResponse>> = LazyLock::new(|| TtlCell::new(SAMPLE_TTL));
+/// Serializes refreshes so a burst of scrapes spawns one collector, not N.
+static REFRESH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Why this guest cannot produce GPU telemetry, if it cannot.
+enum Gate {
+    /// No NVIDIA device on the PCI bus. Nothing to report, ever.
+    NoGpu,
+    /// A card is present but the kernel module is not loaded yet.
+    NoDriver,
+    /// Sampling is worth attempting.
+    Sample,
 }
 
-struct Worker {
-    child: Child,
-    stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
+fn gate() -> Gate {
+    if !nvidia_on_pci() {
+        return Gate::NoGpu;
+    }
+    // Unlike PCI presence this is not fixed: the module can load after the
+    // agent starts, so it is re-checked every time. It is one `stat`.
+    if !Path::new("/sys/module/nvidia").exists() {
+        return Gate::NoDriver;
+    }
+    Gate::Sample
 }
 
-static SNAPSHOT: RwLock<Option<(Instant, GpuInfoResponse)>> = RwLock::new(None);
-static WORKER: LazyLock<Mutex<Option<Worker>>> = LazyLock::new(|| Mutex::new(None));
-
-/// Returns a fresh sample, starting or restarting the isolated NVML worker as needed.
-pub(crate) async fn collect_gpu_info() -> GpuInfoResponse {
-    if let Some(response) = fresh_snapshot() {
-        return response;
-    }
-
-    let mut worker_slot = match WORKER.try_lock() {
-        Ok(guard) => guard,
-        Err(_) => return unavailable("GPU sampling is in progress"),
-    };
-
-    if let Some(response) = fresh_snapshot() {
-        return response;
-    }
-
-    let result = timeout(SAMPLE_TIMEOUT, sample_worker(&mut worker_slot)).await;
-    let response = match result {
-        Ok(Ok(response)) => response,
-        Ok(Err(error)) => {
-            stop_worker(&mut worker_slot);
-            unavailable(format!("GPU sampler failed: {error:#}"))
+/// True when an NVIDIA display device is attached to the PCI bus.
+///
+/// Cached for the process lifetime. A CVM's GPUs are fixed at launch by the
+/// VMM's VFIO assignment; there is no hot-plug path that could change this
+/// answer, and paying a directory scan on every scrape of every GPU-less guest
+/// is exactly the cost this gate exists to avoid.
+///
+/// Fails open to "no GPU" where the boot attestation gate in `dstack-util`
+/// fails closed on the same inventory: refusing to report telemetry is the
+/// safe direction here, and spawning a collector forever on a guest whose
+/// sysfs cannot be read is not.
+fn nvidia_on_pci() -> bool {
+    static PRESENT: OnceLock<bool> = OnceLock::new();
+    *PRESENT.get_or_init(|| match lspci::sysfs::gpu_inventory() {
+        Ok(inventory) => inventory.has_nvidia(),
+        Err(error) => {
+            warn!("failed to scan PCI for GPUs, assuming none: {error:#}");
+            false
         }
-        Err(_) => {
-            stop_worker(&mut worker_slot);
-            unavailable("GPU sampling timed out")
-        }
-    };
-    *SNAPSHOT.write().or_panic("gpu snapshot lock poisoned") =
-        Some((Instant::now(), response.clone()));
-    response
-}
-
-/// Returns immediately for Prometheus. An expired cache starts a refresh in the
-/// background so a wedged GPU cannot delay unrelated guest metrics.
-pub(crate) fn collect_gpu_info_nonblocking() -> GpuInfoResponse {
-    if let Some(response) = fresh_snapshot() {
-        return response;
-    }
-    tokio::spawn(async {
-        let _ = collect_gpu_info().await;
-    });
-    unavailable("GPU sample is not available yet")
-}
-
-fn fresh_snapshot() -> Option<GpuInfoResponse> {
-    let snapshot = SNAPSHOT.read().or_panic("gpu snapshot lock poisoned");
-    snapshot.as_ref().and_then(|(fetched_at, response)| {
-        (fetched_at.elapsed() < ttl_for(response)).then(|| response.clone())
     })
 }
 
-fn ttl_for(response: &GpuInfoResponse) -> Duration {
-    if response.error.is_empty() {
-        SAMPLE_TTL
-    } else {
-        INIT_FAILURE_TTL
+/// Returns the best answer available without ever blocking.
+///
+/// Serves the last snapshot whatever its age, annotated with `sample_age_ms`,
+/// and starts a refresh behind the caller when that snapshot has aged past the
+/// TTL. Used by `/metrics` and the dashboard, where a wedged GPU must not
+/// delay unrelated guest data. Only the very first call on a GPU guest returns
+/// "not sampled yet".
+pub(crate) fn gpu_info() -> GpuInfoResponse {
+    match gate() {
+        Gate::NoGpu => return no_gpus(),
+        Gate::NoDriver => return unavailable("NVIDIA driver is not loaded"),
+        Gate::Sample => {}
     }
+
+    let cached = SNAPSHOT.get_allow_stale().ok();
+    let needs_refresh = cached
+        .as_ref()
+        .is_none_or(|snapshot| snapshot.age() >= SAMPLE_TTL);
+    if needs_refresh {
+        tokio::spawn(refresh_if_free());
+    }
+    serve(cached)
+}
+
+/// Like [`gpu_info`], but waits for a first sample when the cache is cold.
+///
+/// The `GpuInfo` RPC is a direct question from an operator or the control
+/// plane, so "ask again in five seconds" is a worse answer than a bounded
+/// wait. The wait is bounded twice: by [`SAMPLE_TIMEOUT`] here and by the RPC
+/// timeout at the call site.
+pub(crate) async fn gpu_info_awaited() -> GpuInfoResponse {
+    match gate() {
+        Gate::NoGpu => return no_gpus(),
+        Gate::NoDriver => return unavailable("NVIDIA driver is not loaded"),
+        Gate::Sample => {}
+    }
+
+    if SNAPSHOT.get_allow_stale().is_err() {
+        // Cold cache. Queue behind any in-flight sample rather than reporting
+        // nothing; whoever wins the lock fills the cache for both.
+        let _guard = REFRESH_LOCK.lock().await;
+        if SNAPSHOT.get_allow_stale().is_err() {
+            sample_into_cache().await;
+        }
+    }
+    gpu_info()
+}
+
+fn serve(cached: Option<cached_cell::Snapshot<GpuInfoResponse>>) -> GpuInfoResponse {
+    match cached {
+        Some(snapshot) => {
+            let mut response = snapshot.value().clone();
+            response.sample_age_ms = Some(snapshot.age().as_millis() as u64);
+            response
+        }
+        None => unavailable("GPU sample is not available yet"),
+    }
+}
+
+/// Runs one collection unless another one is already in flight.
+///
+/// Dropping the refresh when the lock is held is deliberate: a burst of scrapes
+/// must spawn one collector, not one per scrape, and the waiting callers are
+/// already being served the previous snapshot.
+async fn refresh_if_free() {
+    let Ok(_guard) = REFRESH_LOCK.try_lock() else {
+        debug!("GPU sample already in progress, skipping refresh");
+        return;
+    };
+    // Another task may have refreshed between the staleness check and here.
+    if SNAPSHOT.get().is_ok() {
+        return;
+    }
+    sample_into_cache().await;
+}
+
+/// Collects once and stores the outcome, success or failure.
+///
+/// Failures are cached like successes so a guest whose driver is broken reports
+/// the reason instead of an empty device list, and so a hard-failing collector
+/// is not re-spawned on every single scrape.
+///
+/// Caller must hold [`REFRESH_LOCK`].
+async fn sample_into_cache() {
+    match timeout(SAMPLE_TIMEOUT, collect()).await {
+        Ok(Ok(response)) => {
+            SNAPSHOT.set(response);
+        }
+        Ok(Err(error)) => {
+            warn!("failed to sample GPU telemetry: {error:#}");
+            SNAPSHOT.set(unavailable(format!("GPU sampling failed: {error:#}")));
+        }
+        Err(_) => {
+            warn!("GPU sampling timed out after {SAMPLE_TIMEOUT:?}");
+            SNAPSHOT.set(unavailable("GPU sampling timed out"));
+        }
+    }
+}
+
+/// Spawns `dstack-util gpu-info` and parses its stdout.
+///
+/// `kill_on_drop` matters: the timeout above drops this future, and a wedged
+/// NVML call inside the child must not outlive it.
+async fn collect() -> Result<GpuInfoResponse> {
+    let collector = collector_path();
+    if !Path::new(&collector).exists() {
+        bail!("{collector} is not installed");
+    }
+    let output = Command::new(&collector)
+        .arg("gpu-info")
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .with_context(|| format!("failed to run {collector} gpu-info"))?;
+    // The collector logs to stderr and reserves stdout for the document, so
+    // anything here is diagnostics worth keeping rather than protocol noise.
+    if !output.stderr.is_empty() {
+        warn!(
+            "gpu-info collector: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    if !output.status.success() {
+        bail!("gpu-info collector exited with {}", output.status);
+    }
+    serde_json::from_slice(&output.stdout).context("invalid gpu-info output")
+}
+
+fn collector_path() -> String {
+    #[cfg(test)]
+    if let Some(path) = COLLECTOR_OVERRIDE
+        .read()
+        .or_panic("collector override poisoned")
+        .clone()
+    {
+        return path;
+    }
+    DSTACK_UTIL.to_string()
+}
+
+/// The guest has no NVIDIA hardware. Empty devices with no error is the
+/// documented encoding for "the collector ran and found nothing".
+fn no_gpus() -> GpuInfoResponse {
+    GpuInfoResponse::default()
 }
 
 fn unavailable(error: impl Into<String>) -> GpuInfoResponse {
     GpuInfoResponse {
-        gpus: vec![],
         error: error.into(),
-        cc_ready: None,
+        ..Default::default()
     }
 }
 
-async fn sample_worker(slot: &mut Option<Worker>) -> Result<GpuInfoResponse> {
-    if slot.is_none() {
-        *slot = Some(start_worker()?);
+/// Test-only hooks. Production callers go through [`gpu_info`].
+#[cfg(test)]
+mod test_support {
+    use super::*;
+
+    pub(super) fn set_snapshot(response: GpuInfoResponse) {
+        SNAPSHOT.set(response);
     }
-    let worker = slot.as_mut().context("GPU sampler worker is missing")?;
-    worker.stdin.write_all(b"sample\n").await?;
-    worker.stdin.flush().await?;
-    let mut line = String::new();
-    let bytes = worker.stdout.read_line(&mut line).await?;
-    if bytes == 0 {
-        let status = worker.child.wait().await?;
-        return Err(anyhow!("GPU sampler exited with {status}"));
+
+    pub(super) fn hold_refresh_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        REFRESH_LOCK.try_lock().expect("refresh lock is free")
     }
-    serde_json::from_str(&line).context("invalid response from GPU sampler")
-}
 
-fn start_worker() -> Result<Worker> {
-    let mut child = Command::new(std::env::current_exe()?)
-        .arg("--gpu-info-helper")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .context("failed to start GPU sampler")?;
-    let stdin = child.stdin.take().context("GPU sampler stdin is missing")?;
-    let stdout = child
-        .stdout
-        .take()
-        .context("GPU sampler stdout is missing")?;
-    Ok(Worker {
-        child,
-        stdin,
-        stdout: BufReader::new(stdout),
-    })
-}
-
-fn stop_worker(slot: &mut Option<Worker>) {
-    if let Some(mut worker) = slot.take() {
-        let _ = worker.child.start_kill();
-        tokio::spawn(async move {
-            let _ = worker.child.wait().await;
-        });
-    }
-}
-
-/// Entry point for the hidden helper mode. Each request is one line on stdin
-/// and each response is one JSON line on stdout.
-pub fn run_gpu_info_helper() -> Result<()> {
-    let nvml = Nvml::init().map_err(|error| format!("failed to initialize NVML: {error}"));
-    let mut sampler = GpuSampler {
-        warned: HashSet::new(),
-    };
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout().lock();
-    for line in stdin.lock().lines() {
-        if line? != "sample" {
-            continue;
-        }
-        let response = match &nvml {
-            Ok(nvml) => sample(&mut sampler, nvml),
-            Err(error) => unavailable(error),
-        };
-        serde_json::to_writer(&mut stdout, &response)?;
-        stdout.write_all(b"\n")?;
-        stdout.flush()?;
-    }
-    Ok(())
-}
-
-fn sample(sampler: &mut GpuSampler, nvml: &Nvml) -> GpuInfoResponse {
-    let count = match nvml.device_count() {
-        Ok(count) => count,
-        Err(e) => {
-            let error = format!("failed to get NVML GPU count: {e}");
-            warn!("{error}");
-            return unavailable(error);
-        }
-    };
-
-    let cc_ready = query_cc_ready(sampler, nvml, count);
-    GpuInfoResponse {
-        gpus: (0..count)
-            .map(|index| collect_device(sampler, nvml, index))
-            .collect(),
-        error: String::new(),
-        cc_ready,
-    }
-}
-
-fn query_cc_ready(sampler: &mut GpuSampler, nvml: &Nvml, count: u32) -> Option<bool> {
-    if count == 0 {
-        return None;
-    }
-    let device = match nvml.device_by_index(0) {
-        Ok(device) => device,
-        Err(e) => {
-            log_query_error(sampler, 0, "cc_ready", &e);
-            return None;
-        }
-    };
-    match device.get_confidential_compute_state() {
-        Ok(ready) => Some(ready),
-        Err(e) => {
-            log_query_error(sampler, 0, "cc_ready", &e);
-            None
-        }
-    }
-}
-
-fn collect_device(sampler: &mut GpuSampler, nvml: &Nvml, index: u32) -> GpuDevice {
-    match nvml.device_by_index(index) {
-        Ok(device) => collect_device_fields(sampler, index, &device),
-        Err(e) => {
-            log_query_error(sampler, index, "device", &e);
-            GpuDevice {
-                index,
-                error: format!("device: {e}"),
-                ..Default::default()
-            }
-        }
-    }
-}
-
-fn collect_device_fields(sampler: &mut GpuSampler, index: u32, device: &Device<'_>) -> GpuDevice {
-    let mut errors = Vec::new();
-
-    let uuid = match device.uuid() {
-        Ok(uuid) => uuid,
-        Err(e) => {
-            push_error(sampler, index, "uuid", e, &mut errors);
-            String::new()
-        }
-    };
-    let pci_bus_id = match device.pci_info() {
-        Ok(pci) => pci.bus_id,
-        Err(e) => {
-            push_error(sampler, index, "pci_bus_id", e, &mut errors);
-            String::new()
-        }
-    };
-
-    let (utilization_gpu, utilization_memory) = match device.utilization_rates() {
-        Ok(util) => (Some(util.gpu), Some(util.memory)),
-        Err(e) => {
-            push_error(sampler, index, "utilization", e, &mut errors);
-            (None, None)
-        }
-    };
-
-    let (memory_total_bytes, memory_used_bytes, memory_free_bytes) = match device.memory_info() {
-        Ok(mem) => (Some(mem.total), Some(mem.used), Some(mem.free)),
-        Err(e) => {
-            push_error(sampler, index, "memory", e, &mut errors);
-            (None, None, None)
-        }
-    };
-
-    let temperature_c = match device.temperature(TemperatureSensor::Gpu) {
-        Ok(temp) => Some(temp),
-        Err(e) => {
-            push_error(sampler, index, "temperature", e, &mut errors);
-            None
-        }
-    };
-
-    let power_usage_mw = match device.power_usage() {
-        Ok(power) => Some(power),
-        Err(e) => {
-            push_error(sampler, index, "power", e, &mut errors);
-            None
-        }
-    };
-
-    let cc_enabled = match device.is_cc_enabled() {
-        Ok(enabled) => Some(enabled),
-        Err(e) => {
-            push_error(sampler, index, "cc_enabled", e, &mut errors);
-            None
-        }
-    };
-
-    GpuDevice {
-        index,
-        uuid,
-        pci_bus_id,
-        utilization_gpu,
-        utilization_memory,
-        memory_total_bytes,
-        memory_used_bytes,
-        memory_free_bytes,
-        temperature_c,
-        power_usage_mw,
-        error: errors.join("; "),
-        cc_enabled,
-    }
-}
-
-fn push_error(
-    sampler: &mut GpuSampler,
-    index: u32,
-    field: &'static str,
-    err: NvmlError,
-    errors: &mut Vec<String>,
-) {
-    errors.push(format!("{field}: {err}"));
-    log_query_error(sampler, index, field, &err);
-}
-
-fn log_query_error(sampler: &mut GpuSampler, index: u32, field: &'static str, err: &NvmlError) {
-    let first = sampler.warned.insert((index, field));
-    if matches!(err, NvmlError::NotSupported) {
-        debug!("GPU {index} {field} not supported: {err}");
-    } else if first {
-        warn!("failed to query GPU {index} {field}: {err}");
-    } else {
-        debug!("failed to query GPU {index} {field}: {err}");
+    pub(super) fn set_collector(path: &str) {
+        *COLLECTOR_OVERRIDE
+            .write()
+            .or_panic("collector override poisoned") = Some(path.to_string());
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{sample, unavailable, GpuSampler};
-    use nvml_wrapper::Nvml;
-    use std::collections::HashSet;
+    use super::*;
+    use guest_api::GpuDevice;
+    use std::os::unix::fs::PermissionsExt;
 
-    /// NVML may or may not be present on the machine running this test.
-    /// Unavailability must be an error with no devices, not a silent empty
-    /// success (which would mean "NVML worked, zero GPUs").
-    #[test]
-    fn collect_reports_nvml_unavailability_without_panicking() {
-        let info = match Nvml::init() {
-            Ok(nvml) => sample(
-                &mut GpuSampler {
-                    warned: HashSet::new(),
-                },
-                &nvml,
-            ),
-            Err(error) => unavailable(format!("failed to initialize NVML: {error}")),
-        };
-        if info.error.is_empty() {
-            return;
+    fn sample_response() -> GpuInfoResponse {
+        GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                index: 0,
+                uuid: "GPU-abc".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
         }
-        assert!(info.gpus.is_empty());
-        assert_eq!(info.cc_ready, None);
+    }
+
+    /// A guest with no NVIDIA device must not scan, spawn, or cache anything.
+    /// The distinction that matters downstream is "no GPUs" (empty, no error)
+    /// versus "could not tell" (error set).
+    #[test]
+    fn a_guest_without_a_card_reports_no_gpus_rather_than_an_error() {
+        let response = no_gpus();
+        assert!(response.gpus.is_empty());
+        assert!(response.error.is_empty());
+        assert_eq!(response.sample_age_ms, None);
+    }
+
+    /// The bug this design exists to prevent: a scrape interval longer than the
+    /// TTL must still see the GPU series. Serving a placeholder on expiry meant
+    /// `/metrics` reported zero GPUs forever at Prometheus' default 15s.
+    #[tokio::test]
+    async fn a_snapshot_older_than_the_ttl_is_still_served() {
+        // Hold the refresh lock so the spawned refresh cannot overwrite the
+        // snapshot mid-assertion on a machine that does have a GPU.
+        let _guard = test_support::hold_refresh_lock();
+        test_support::set_snapshot(sample_response());
+
+        let served = serve(SNAPSHOT.get_allow_stale().ok());
+
+        assert!(
+            served.error.is_empty(),
+            "stale data must not become an error"
+        );
+        assert_eq!(served.gpus.len(), 1);
+        assert!(served.sample_age_ms.is_some(), "age must be reported");
+    }
+
+    /// The reason sampling lives in a child process: when a driver call wedges,
+    /// the timeout must actually reclaim it. Nothing may be left running
+    /// between samples.
+    #[tokio::test]
+    async fn a_collector_that_hangs_is_killed_when_the_sample_times_out() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("stub-collector");
+        let pid_file = dir.path().join("pid");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\necho $$ > {}\nsleep 60\n", pid_file.display()),
+        )
+        .expect("write stub");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod stub");
+
+        let _guard = test_support::hold_refresh_lock();
+        test_support::set_collector(&script.to_string_lossy());
+
+        let outcome = timeout(Duration::from_millis(500), collect()).await;
+        assert!(outcome.is_err(), "the stub sleeps far past the timeout");
+
+        let pid: i32 = std::fs::read_to_string(&pid_file)
+            .expect("stub recorded its pid")
+            .trim()
+            .parse()
+            .expect("pid is a number");
+
+        // SIGKILL is asynchronous; give the kernel a moment to reap.
+        for _ in 0..50 {
+            if !Path::new(&format!("/proc/{pid}")).exists() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("collector {pid} survived the sample timeout");
+    }
+
+    /// A collector that is not installed must degrade to a recorded error, not
+    /// a panic and not a silent "no GPUs".
+    #[tokio::test]
+    async fn a_missing_collector_is_reported_as_an_error() {
+        test_support::set_collector("/nonexistent/dstack-util");
+        let error = collect().await.expect_err("must fail");
+        assert!(
+            error.to_string().contains("not installed"),
+            "unexpected error: {error:#}"
+        );
     }
 }

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -2,68 +2,90 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! GPU telemetry for the `GpuInfo` RPC.
+//! GPU telemetry collection isolated in a helper process.
 //!
-//! NVML is initialized once per process and reused. `Nvml`'s `Drop` shuts the
-//! library down, so a request-scoped handle would init+shutdown on every
-//! `/metrics` scrape. Init failure is retried after `INIT_FAILURE_TTL` so
-//! images without a driver do not `dlopen` on every call, while a driver that
-//! appears later can still be picked up.
-//!
-//! Sampling is serialized with `try_lock`. A stuck NVML call (GPU reset, driver
-//! assert, CC handshake) keeps that one blocking thread and the sampler lock;
-//! the RPC timeout does **not** cancel it. Later callers skip the lock and
-//! return the last snapshot, or `error: "sampling in progress"` if none exists.
-//! They never queue behind the hung sample.
-//!
-//! GpuInfo, `/metrics`, and the dashboard share one 5s snapshot so the three
-//! entry points do not stampede NVML.
+//! NVML calls cannot be cancelled safely. Keeping them in a child process lets
+//! the agent terminate and recreate the sampler after a driver call hangs. The
+//! helper keeps one NVML handle for its lifetime. Successful samples are cached
+//! for five seconds; initialization failures are cached for one minute.
 
 use std::collections::HashSet;
-use std::sync::{LazyLock, Mutex, OnceLock, RwLock, TryLockError};
+use std::io::{BufRead, Write};
+use std::process::Stdio;
+use std::sync::{LazyLock, RwLock};
 use std::time::{Duration, Instant};
 
+use anyhow::{anyhow, Context, Result};
 use guest_api::{GpuDevice, GpuInfoResponse};
 use nvml_wrapper::enum_wrappers::device::TemperatureSensor;
 use nvml_wrapper::error::NvmlError;
 use nvml_wrapper::{Device, Nvml};
 use or_panic::ResultOrPanic;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 const SAMPLE_TTL: Duration = Duration::from_secs(5);
 const INIT_FAILURE_TTL: Duration = Duration::from_secs(60);
+const SAMPLE_TIMEOUT: Duration = Duration::from_secs(4);
 
 struct GpuSampler {
     warned: HashSet<(u32, &'static str)>,
 }
 
-static NVML: OnceLock<Nvml> = OnceLock::new();
-static SNAPSHOT: RwLock<Option<(Instant, GpuInfoResponse)>> = RwLock::new(None);
-static SAMPLER: LazyLock<Mutex<GpuSampler>> = LazyLock::new(|| {
-    Mutex::new(GpuSampler {
-        warned: HashSet::new(),
-    })
-});
+struct Worker {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
 
-pub(crate) fn collect_gpu_info() -> GpuInfoResponse {
+static SNAPSHOT: RwLock<Option<(Instant, GpuInfoResponse)>> = RwLock::new(None);
+static WORKER: LazyLock<Mutex<Option<Worker>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Returns a fresh sample, starting or restarting the isolated NVML worker as needed.
+pub(crate) async fn collect_gpu_info() -> GpuInfoResponse {
     if let Some(response) = fresh_snapshot() {
         return response;
     }
 
-    let mut sampler = match SAMPLER.try_lock() {
+    let mut worker_slot = match WORKER.try_lock() {
         Ok(guard) => guard,
-        Err(TryLockError::WouldBlock) => return snapshot_or_busy(),
-        Err(TryLockError::Poisoned(_)) => SAMPLER.lock().or_panic("gpu sampler mutex poisoned"),
+        Err(_) => return unavailable("GPU sampling is in progress"),
     };
 
     if let Some(response) = fresh_snapshot() {
         return response;
     }
 
-    let response = sample(&mut sampler);
+    let result = timeout(SAMPLE_TIMEOUT, sample_worker(&mut worker_slot)).await;
+    let response = match result {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            stop_worker(&mut worker_slot);
+            unavailable(format!("GPU sampler failed: {error:#}"))
+        }
+        Err(_) => {
+            stop_worker(&mut worker_slot);
+            unavailable("GPU sampling timed out")
+        }
+    };
     *SNAPSHOT.write().or_panic("gpu snapshot lock poisoned") =
         Some((Instant::now(), response.clone()));
     response
+}
+
+/// Returns immediately for Prometheus. An expired cache starts a refresh in the
+/// background so a wedged GPU cannot delay unrelated guest metrics.
+pub(crate) fn collect_gpu_info_nonblocking() -> GpuInfoResponse {
+    if let Some(response) = fresh_snapshot() {
+        return response;
+    }
+    tokio::spawn(async {
+        let _ = collect_gpu_info().await;
+    });
+    unavailable("GPU sample is not available yet")
 }
 
 fn fresh_snapshot() -> Option<GpuInfoResponse> {
@@ -71,18 +93,6 @@ fn fresh_snapshot() -> Option<GpuInfoResponse> {
     snapshot.as_ref().and_then(|(fetched_at, response)| {
         (fetched_at.elapsed() < ttl_for(response)).then(|| response.clone())
     })
-}
-
-fn snapshot_or_busy() -> GpuInfoResponse {
-    let snapshot = SNAPSHOT.read().or_panic("gpu snapshot lock poisoned");
-    if let Some((_, response)) = snapshot.as_ref() {
-        return response.clone();
-    }
-    GpuInfoResponse {
-        gpus: vec![],
-        error: "sampling in progress".into(),
-        cc_ready: None,
-    }
 }
 
 fn ttl_for(response: &GpuInfoResponse) -> Duration {
@@ -93,45 +103,90 @@ fn ttl_for(response: &GpuInfoResponse) -> Duration {
     }
 }
 
-fn sample(sampler: &mut GpuSampler) -> GpuInfoResponse {
-    let nvml = match NVML.get() {
-        Some(nvml) => nvml,
-        None => match Nvml::init() {
-            Ok(nvml) => {
-                let _ = NVML.set(nvml);
-                match NVML.get() {
-                    Some(nvml) => nvml,
-                    None => {
-                        return GpuInfoResponse {
-                            gpus: vec![],
-                            error: "NVML handle missing after init".into(),
-                            cc_ready: None,
-                        };
-                    }
-                }
-            }
-            Err(e) => {
-                let error = format!("failed to initialize NVML: {e}");
-                warn!("{error}");
-                return GpuInfoResponse {
-                    gpus: vec![],
-                    error,
-                    cc_ready: None,
-                };
-            }
-        },
-    };
+fn unavailable(error: impl Into<String>) -> GpuInfoResponse {
+    GpuInfoResponse {
+        gpus: vec![],
+        error: error.into(),
+        cc_ready: None,
+    }
+}
 
+async fn sample_worker(slot: &mut Option<Worker>) -> Result<GpuInfoResponse> {
+    if slot.is_none() {
+        *slot = Some(start_worker()?);
+    }
+    let worker = slot.as_mut().context("GPU sampler worker is missing")?;
+    worker.stdin.write_all(b"sample\n").await?;
+    worker.stdin.flush().await?;
+    let mut line = String::new();
+    let bytes = worker.stdout.read_line(&mut line).await?;
+    if bytes == 0 {
+        let status = worker.child.wait().await?;
+        return Err(anyhow!("GPU sampler exited with {status}"));
+    }
+    serde_json::from_str(&line).context("invalid response from GPU sampler")
+}
+
+fn start_worker() -> Result<Worker> {
+    let mut child = Command::new(std::env::current_exe()?)
+        .arg("--gpu-info-helper")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("failed to start GPU sampler")?;
+    let stdin = child.stdin.take().context("GPU sampler stdin is missing")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("GPU sampler stdout is missing")?;
+    Ok(Worker {
+        child,
+        stdin,
+        stdout: BufReader::new(stdout),
+    })
+}
+
+fn stop_worker(slot: &mut Option<Worker>) {
+    if let Some(mut worker) = slot.take() {
+        let _ = worker.child.start_kill();
+        tokio::spawn(async move {
+            let _ = worker.child.wait().await;
+        });
+    }
+}
+
+/// Entry point for the hidden helper mode. Each request is one line on stdin
+/// and each response is one JSON line on stdout.
+pub fn run_gpu_info_helper() -> Result<()> {
+    let nvml = Nvml::init().map_err(|error| format!("failed to initialize NVML: {error}"));
+    let mut sampler = GpuSampler {
+        warned: HashSet::new(),
+    };
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout().lock();
+    for line in stdin.lock().lines() {
+        if line? != "sample" {
+            continue;
+        }
+        let response = match &nvml {
+            Ok(nvml) => sample(&mut sampler, nvml),
+            Err(error) => unavailable(error),
+        };
+        serde_json::to_writer(&mut stdout, &response)?;
+        stdout.write_all(b"\n")?;
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
+fn sample(sampler: &mut GpuSampler, nvml: &Nvml) -> GpuInfoResponse {
     let count = match nvml.device_count() {
         Ok(count) => count,
         Err(e) => {
             let error = format!("failed to get NVML GPU count: {e}");
             warn!("{error}");
-            return GpuInfoResponse {
-                gpus: vec![],
-                error,
-                cc_ready: None,
-            };
+            return unavailable(error);
         }
     };
 
@@ -145,7 +200,7 @@ fn sample(sampler: &mut GpuSampler) -> GpuInfoResponse {
     }
 }
 
-fn query_cc_ready(sampler: &mut GpuSampler, nvml: &'static Nvml, count: u32) -> Option<bool> {
+fn query_cc_ready(sampler: &mut GpuSampler, nvml: &Nvml, count: u32) -> Option<bool> {
     if count == 0 {
         return None;
     }
@@ -165,7 +220,7 @@ fn query_cc_ready(sampler: &mut GpuSampler, nvml: &'static Nvml, count: u32) -> 
     }
 }
 
-fn collect_device(sampler: &mut GpuSampler, nvml: &'static Nvml, index: u32) -> GpuDevice {
+fn collect_device(sampler: &mut GpuSampler, nvml: &Nvml, index: u32) -> GpuDevice {
     match nvml.device_by_index(index) {
         Ok(device) => collect_device_fields(sampler, index, &device),
         Err(e) => {
@@ -277,23 +332,28 @@ fn log_query_error(sampler: &mut GpuSampler, index: u32, field: &'static str, er
 
 #[cfg(test)]
 mod tests {
-    use super::collect_gpu_info;
+    use super::{sample, unavailable, GpuSampler};
+    use nvml_wrapper::Nvml;
+    use std::collections::HashSet;
 
     /// NVML may or may not be present on the machine running this test.
     /// Unavailability must be an error with no devices, not a silent empty
-    /// success (which would mean "NVML worked, zero GPUs"). A host with NVML
-    /// just has to not panic.
+    /// success (which would mean "NVML worked, zero GPUs").
     #[test]
     fn collect_reports_nvml_unavailability_without_panicking() {
-        let info = collect_gpu_info();
+        let info = match Nvml::init() {
+            Ok(nvml) => sample(
+                &mut GpuSampler {
+                    warned: HashSet::new(),
+                },
+                &nvml,
+            ),
+            Err(error) => unavailable(format!("failed to initialize NVML: {error}")),
+        };
         if info.error.is_empty() {
             return;
         }
-        assert!(
-            info.gpus.is_empty(),
-            "NVML unavailability must not invent devices, got {:?}",
-            info.gpus
-        );
+        assert!(info.gpus.is_empty());
         assert_eq!(info.cc_ready, None);
     }
 }

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -309,12 +309,45 @@ fn unavailable(error: impl Into<String>) -> GpuInfoResponse {
 mod test_support {
     use super::*;
 
-    pub(super) fn set_snapshot(response: GpuInfoResponse) {
-        SNAPSHOT.set(response);
+    /// Serializes the tests that reach into process-global state.
+    ///
+    /// [`SNAPSHOT`], [`REFRESH_LOCK`] and [`COLLECTOR_OVERRIDE`] are one per
+    /// process while the harness runs tests on parallel threads, so without
+    /// this two tests race over the same cache entry and the same collector
+    /// path -- one pointing at a stub that sleeps, the other at a path that
+    /// does not exist.
+    static EXCLUSION: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    /// Held for the whole test body, not just the mutation, and restores the
+    /// collector override on the way out so a stub cannot leak into a test
+    /// that expects the real path.
+    pub(super) struct Exclusive {
+        _exclusion: tokio::sync::MutexGuard<'static, ()>,
+        _refresh: tokio::sync::MutexGuard<'static, ()>,
     }
 
-    pub(super) fn hold_refresh_lock() -> tokio::sync::MutexGuard<'static, ()> {
-        REFRESH_LOCK.try_lock().expect("refresh lock is free")
+    impl Drop for Exclusive {
+        fn drop(&mut self) {
+            *COLLECTOR_OVERRIDE
+                .write()
+                .or_panic("collector override poisoned") = None;
+        }
+    }
+
+    pub(super) async fn exclusive() -> Exclusive {
+        let exclusion = EXCLUSION.lock().await;
+        // Waits rather than try_lock: a refresh spawned by an earlier test may
+        // still be finishing, and failing a test for losing that race tests
+        // the harness rather than the code.
+        let refresh = REFRESH_LOCK.lock().await;
+        Exclusive {
+            _exclusion: exclusion,
+            _refresh: refresh,
+        }
+    }
+
+    pub(super) fn set_snapshot(response: GpuInfoResponse) {
+        SNAPSHOT.set(response);
     }
 
     pub(super) fn set_collector(path: &str) {
@@ -377,9 +410,9 @@ mod tests {
     /// `/metrics` reported zero GPUs forever at Prometheus' default 15s.
     #[tokio::test]
     async fn a_snapshot_older_than_the_ttl_is_still_served() {
-        // Hold the refresh lock so the spawned refresh cannot overwrite the
+        // Hold the globals so no refresh, and no other test, can overwrite the
         // snapshot mid-assertion on a machine that does have a GPU.
-        let _guard = test_support::hold_refresh_lock();
+        let _guard = test_support::exclusive().await;
         test_support::set_snapshot(sample_response());
 
         let served = serve(SNAPSHOT.get_allow_stale().ok());
@@ -408,7 +441,7 @@ mod tests {
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
             .expect("chmod stub");
 
-        let _guard = test_support::hold_refresh_lock();
+        let _guard = test_support::exclusive().await;
         test_support::set_collector(&script.to_string_lossy());
 
         let outcome = timeout(Duration::from_millis(500), collect()).await;
@@ -434,6 +467,7 @@ mod tests {
     /// a panic and not a silent "no GPUs".
     #[tokio::test]
     async fn a_missing_collector_is_reported_as_an_error() {
+        let _guard = test_support::exclusive().await;
         test_support::set_collector("/nonexistent/dstack-util");
         let error = collect().await.expect_err("must fail");
         assert!(

--- a/dstack/guest-agent/src/gpu_info.rs
+++ b/dstack/guest-agent/src/gpu_info.rs
@@ -34,9 +34,18 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-/// How long a snapshot is served before a refresh is triggered. Older snapshots
-/// are still served, just with a refresh started behind them.
+/// How long a successful snapshot is served before a refresh is triggered.
+/// Older snapshots are still served, just with a refresh started behind them.
 const SAMPLE_TTL: Duration = Duration::from_secs(5);
+/// Backoff after a failed sample.
+///
+/// A collector that hangs burns [`SAMPLE_TIMEOUT`] and is then killed. Retrying
+/// that on the success cadence would keep a guest whose driver has wedged in a
+/// near-continuous spawn-and-kill loop, which is both useless and the state
+/// most likely to leave a process stuck in an uninterruptible driver call.
+/// Long enough to stop hammering, short enough that a recovered driver is
+/// picked up while an operator is still looking at the dashboard.
+const FAILURE_BACKOFF: Duration = Duration::from_secs(30);
 /// Upper bound on one `dstack-util gpu-info` run. Generous because a cold
 /// `nvmlInit_v2` on a multi-GPU CC system is not fast, but finite because the
 /// whole point of the child process is that a wedged driver can be abandoned.
@@ -48,6 +57,8 @@ const DSTACK_UTIL: &str = "/usr/bin/dstack-util";
 #[cfg(test)]
 static COLLECTOR_OVERRIDE: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
 
+/// Holds the last outcome, successful or not. The cell's own TTL is unused:
+/// serving is always allowed and [`refresh_interval`] decides when to resample.
 static SNAPSHOT: LazyLock<TtlCell<GpuInfoResponse>> = LazyLock::new(|| TtlCell::new(SAMPLE_TTL));
 /// Serializes refreshes so a burst of scrapes spawns one collector, not N.
 static REFRESH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -111,10 +122,7 @@ pub(crate) fn gpu_info() -> GpuInfoResponse {
     }
 
     let cached = SNAPSHOT.get_allow_stale().ok();
-    let needs_refresh = cached
-        .as_ref()
-        .is_none_or(|snapshot| snapshot.age() >= SAMPLE_TTL);
-    if needs_refresh {
+    if is_due(cached.as_ref()) {
         tokio::spawn(refresh_if_free());
     }
     serve(cached)
@@ -144,6 +152,20 @@ pub(crate) async fn gpu_info_awaited() -> GpuInfoResponse {
     gpu_info()
 }
 
+/// How long this outcome is kept before resampling.
+fn refresh_interval(response: &GpuInfoResponse) -> Duration {
+    if response.error.is_empty() {
+        SAMPLE_TTL
+    } else {
+        FAILURE_BACKOFF
+    }
+}
+
+/// True when the cached outcome has outlived its refresh interval.
+fn is_due(cached: Option<&cached_cell::Snapshot<GpuInfoResponse>>) -> bool {
+    cached.is_none_or(|snapshot| snapshot.age() >= refresh_interval(snapshot.value()))
+}
+
 fn serve(cached: Option<cached_cell::Snapshot<GpuInfoResponse>>) -> GpuInfoResponse {
     match cached {
         Some(snapshot) => {
@@ -166,7 +188,7 @@ async fn refresh_if_free() {
         return;
     };
     // Another task may have refreshed between the staleness check and here.
-    if SNAPSHOT.get().is_ok() {
+    if !is_due(SNAPSHOT.get_allow_stale().ok().as_ref()) {
         return;
     }
     sample_into_cache().await;
@@ -296,6 +318,26 @@ mod tests {
         assert!(response.gpus.is_empty());
         assert!(response.error.is_empty());
         assert_eq!(response.sample_age_ms, None);
+    }
+
+    /// A failed sample must not be retried on the success cadence. A collector
+    /// that burns the whole timeout and gets killed would otherwise be respawned
+    /// on every scrape, which is the state most likely to strand a process in an
+    /// uninterruptible driver call.
+    #[test]
+    fn a_failed_sample_backs_off_further_than_a_successful_one() {
+        assert_eq!(refresh_interval(&sample_response()), SAMPLE_TTL);
+        assert_eq!(
+            refresh_interval(&unavailable("GPU sampling timed out")),
+            FAILURE_BACKOFF
+        );
+        assert!(FAILURE_BACKOFF > SAMPLE_TTL);
+    }
+
+    /// An empty cache is always due; that is the cold-start path.
+    #[test]
+    fn an_empty_cache_is_due() {
+        assert!(is_due(None));
     }
 
     /// The bug this design exists to prevent: a scrape interval longer than the

--- a/dstack/guest-agent/src/guest_api_service.rs
+++ b/dstack/guest-agent/src/guest_api_service.rs
@@ -103,13 +103,9 @@ impl GuestApiRpc for GuestApiHandler {
     }
 
     async fn gpu_info(self) -> Result<GpuInfoResponse> {
-        timeout(
-            GPU_INFO_TIMEOUT,
-            spawn_blocking(crate::gpu_info::collect_gpu_info),
-        )
-        .await
-        .context("GpuInfo request timed out")?
-        .context("GpuInfo worker failed")
+        timeout(GPU_INFO_TIMEOUT, crate::gpu_info::collect_gpu_info())
+            .await
+            .context("GpuInfo request timed out")
     }
 
     async fn list_containers(self) -> Result<ListContainersResponse> {

--- a/dstack/guest-agent/src/guest_api_service.rs
+++ b/dstack/guest-agent/src/guest_api_service.rs
@@ -27,7 +27,7 @@ const DOCKER_API_TIMEOUT: Duration = Duration::from_secs(15);
 const SHUTDOWN_NOTIFY_TIMEOUT: Duration = Duration::from_secs(5);
 const POWEROFF_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const WG_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
-const GPU_INFO_TIMEOUT: Duration = Duration::from_secs(5);
+const GPU_INFO_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct GuestApiHandler {
     state: AppState,
@@ -103,7 +103,7 @@ impl GuestApiRpc for GuestApiHandler {
     }
 
     async fn gpu_info(self) -> Result<GpuInfoResponse> {
-        timeout(GPU_INFO_TIMEOUT, crate::gpu_info::collect_gpu_info())
+        timeout(GPU_INFO_TIMEOUT, crate::gpu_info::gpu_info_awaited())
             .await
             .context("GpuInfo request timed out")
     }

--- a/dstack/guest-agent/src/guest_api_service.rs
+++ b/dstack/guest-agent/src/guest_api_service.rs
@@ -12,8 +12,8 @@ use dstack_types::SysConfig;
 use fs_err as fs;
 use guest_api::{
     guest_api_server::{GuestApiRpc, GuestApiServer},
-    Container, DiskInfo, Gateway, GuestInfo, Interface, IpAddress, ListContainersResponse,
-    NetworkInformation, SystemInfo,
+    Container, DiskInfo, Gateway, GpuInfoResponse, GuestInfo, Interface, IpAddress,
+    ListContainersResponse, NetworkInformation, SystemInfo,
 };
 use host_api::Notification;
 use ra_rpc::{CallContext, RpcCall};
@@ -27,6 +27,7 @@ const DOCKER_API_TIMEOUT: Duration = Duration::from_secs(15);
 const SHUTDOWN_NOTIFY_TIMEOUT: Duration = Duration::from_secs(5);
 const POWEROFF_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const WG_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const GPU_INFO_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct GuestApiHandler {
     state: AppState,
@@ -99,6 +100,16 @@ impl GuestApiRpc for GuestApiHandler {
         .await
         .context("SysInfo request timed out")?
         .context("SysInfo worker failed")
+    }
+
+    async fn gpu_info(self) -> Result<GpuInfoResponse> {
+        timeout(
+            GPU_INFO_TIMEOUT,
+            spawn_blocking(crate::gpu_info::collect_gpu_info),
+        )
+        .await
+        .context("GpuInfo request timed out")?
+        .context("GpuInfo worker failed")
     }
 
     async fn list_containers(self) -> Result<ListContainersResponse> {

--- a/dstack/guest-agent/src/http_routes.rs
+++ b/dstack/guest-agent/src/http_routes.rs
@@ -55,12 +55,16 @@ async fn index(state: &State<AppState>) -> Result<RawHtml<String>, String> {
         .await
         .map_err(|e| format!("Failed to get worker info: {}", e))?;
 
-    let handler = GuestApiHandler::construct(context.clone())
-        .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
-    let system_info = handler.sys_info().await.unwrap_or_default();
     let handler = GuestApiHandler::construct(context)
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
-    let gpu_info = handler.gpu_info().await.unwrap_or_default();
+    let system_info = handler.sys_info().await.unwrap_or_default();
+    // Only sampled when the page will actually render it. Asking otherwise
+    // would spawn a collector on guests that keep their sysinfo private.
+    let gpu_info = if public_sysinfo {
+        crate::gpu_info::gpu_info()
+    } else {
+        Default::default()
+    };
 
     let containers = list_containers().await.unwrap_or_default().containers;
     let model = crate::models::Dashboard {
@@ -97,7 +101,7 @@ async fn metrics(state: &State<AppState>) -> Result<String, String> {
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
 
     let system_info = handler.sys_info().await.unwrap_or_default();
-    let gpu_info = crate::gpu_info::collect_gpu_info_nonblocking();
+    let gpu_info = crate::gpu_info::gpu_info();
     let model = crate::models::Metrics {
         system_info,
         gpu_info,

--- a/dstack/guest-agent/src/http_routes.rs
+++ b/dstack/guest-agent/src/http_routes.rs
@@ -55,9 +55,12 @@ async fn index(state: &State<AppState>) -> Result<RawHtml<String>, String> {
         .await
         .map_err(|e| format!("Failed to get worker info: {}", e))?;
 
-    let handler = GuestApiHandler::construct(context)
+    let handler = GuestApiHandler::construct(context.clone())
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
     let system_info = handler.sys_info().await.unwrap_or_default();
+    let handler = GuestApiHandler::construct(context)
+        .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
+    let gpu_info = handler.gpu_info().await.unwrap_or_default();
 
     let containers = list_containers().await.unwrap_or_default().containers;
     let model = crate::models::Dashboard {
@@ -74,6 +77,7 @@ async fn index(state: &State<AppState>) -> Result<RawHtml<String>, String> {
         public_tcbinfo,
         cloud_vendor,
         cloud_product,
+        gpu_info,
     };
     match model.render() {
         Ok(html) => Ok(RawHtml(html)),
@@ -93,7 +97,13 @@ async fn metrics(state: &State<AppState>) -> Result<String, String> {
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
 
     let system_info = handler.sys_info().await.unwrap_or_default();
-    let model = crate::models::Metrics { system_info };
+    let handler = GuestApiHandler::construct(context)
+        .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
+    let gpu_info = handler.gpu_info().await.unwrap_or_default();
+    let model = crate::models::Metrics {
+        system_info,
+        gpu_info,
+    };
     match model.render() {
         Ok(body) => Ok(body),
         Err(err) => Err(format!("Failed to render template: {err}")),

--- a/dstack/guest-agent/src/http_routes.rs
+++ b/dstack/guest-agent/src/http_routes.rs
@@ -97,9 +97,7 @@ async fn metrics(state: &State<AppState>) -> Result<String, String> {
         .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
 
     let system_info = handler.sys_info().await.unwrap_or_default();
-    let handler = GuestApiHandler::construct(context)
-        .map_err(|e| format!("Failed to construct RPC handler: {}", e))?;
-    let gpu_info = handler.gpu_info().await.unwrap_or_default();
+    let gpu_info = crate::gpu_info::collect_gpu_info_nonblocking();
     let model = crate::models::Metrics {
         system_info,
         gpu_info,

--- a/dstack/guest-agent/src/lib.rs
+++ b/dstack/guest-agent/src/lib.rs
@@ -10,7 +10,6 @@ pub mod config;
 mod container_health;
 mod gpu_attest;
 mod gpu_info;
-pub use gpu_info::run_gpu_info_helper;
 mod guest_api_service;
 mod health;
 mod http_routes;

--- a/dstack/guest-agent/src/lib.rs
+++ b/dstack/guest-agent/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod config;
 mod container_health;
 mod gpu_attest;
+mod gpu_info;
 mod guest_api_service;
 mod health;
 mod http_routes;

--- a/dstack/guest-agent/src/lib.rs
+++ b/dstack/guest-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 mod container_health;
 mod gpu_attest;
 mod gpu_info;
+pub use gpu_info::run_gpu_info_helper;
 mod guest_api_service;
 mod health;
 mod http_routes;

--- a/dstack/guest-agent/src/main.rs
+++ b/dstack/guest-agent/src/main.rs
@@ -16,16 +16,26 @@ struct Args {
     /// Enable systemd watchdog
     #[arg(short, long)]
     watchdog: bool,
+
+    /// Run the internal, process-isolated NVML sampler.
+    #[arg(long, hide = true)]
+    gpu_info_helper: bool,
 }
 
 #[rocket::main]
 async fn main() -> Result<()> {
+    let args = Args::parse();
+    // The helper's stdout is a machine-readable protocol pipe. Do not install
+    // a tracing subscriber in this mode: the default formatter may write to
+    // stdout, and NVML warnings must never corrupt protocol responses.
+    if args.gpu_info_helper {
+        return dstack_guest_agent::run_gpu_info_helper();
+    }
     {
         use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }
-    let args = Args::parse();
     let figment = config::load_config_figment(args.config.as_deref());
     let state = AppState::new(figment.focus("core").extract()?)
         .await

--- a/dstack/guest-agent/src/main.rs
+++ b/dstack/guest-agent/src/main.rs
@@ -16,26 +16,16 @@ struct Args {
     /// Enable systemd watchdog
     #[arg(short, long)]
     watchdog: bool,
-
-    /// Run the internal, process-isolated NVML sampler.
-    #[arg(long, hide = true)]
-    gpu_info_helper: bool,
 }
 
 #[rocket::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
-    // The helper's stdout is a machine-readable protocol pipe. Do not install
-    // a tracing subscriber in this mode: the default formatter may write to
-    // stdout, and NVML warnings must never corrupt protocol responses.
-    if args.gpu_info_helper {
-        return dstack_guest_agent::run_gpu_info_helper();
-    }
     {
         use tracing_subscriber::{fmt, EnvFilter};
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         fmt().with_env_filter(filter).with_ansi(false).init();
     }
+    let args = Args::parse();
     let figment = config::load_config_figment(args.config.as_deref());
     let state = AppState::new(figment.focus("core").extract()?)
         .await

--- a/dstack/guest-agent/src/models.rs
+++ b/dstack/guest-agent/src/models.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use guest_api::{Container, SystemInfo};
+use guest_api::{Container, GpuInfoResponse, SystemInfo};
 use rinja::Template;
 
 mod filters {
@@ -56,10 +56,12 @@ pub struct Dashboard {
     pub public_tcbinfo: bool,
     pub cloud_vendor: String,
     pub cloud_product: String,
+    pub gpu_info: GpuInfoResponse,
 }
 
 #[derive(Template)]
 #[template(path = "metrics.tpl", escape = "none")]
 pub struct Metrics {
     pub system_info: SystemInfo,
+    pub gpu_info: GpuInfoResponse,
 }

--- a/dstack/guest-agent/src/models.rs
+++ b/dstack/guest-agent/src/models.rs
@@ -33,6 +33,25 @@ mod filters {
         Ok(hex::encode(s))
     }
 
+    /// Drops a zero PCI domain. NVML reports `00000000:01:00.0` where lspci and
+    /// the kernel print `0000:01:00.0` or just `01:00.0`.
+    ///
+    /// Only a zero domain is dropped, and only from the three-field form: a
+    /// non-zero domain distinguishes two cards that would otherwise display the
+    /// same address, and `00:00.0` is a bus, not a domain.
+    ///
+    /// Display only. `/metrics` keeps the full string, because that is what
+    /// host-side tooling joins on.
+    pub fn short_bdf(s: &str) -> Result<&str, rinja::Error> {
+        let Some((domain, rest)) = s.split_once(':') else {
+            return Ok(s);
+        };
+        if rest.contains(':') && !domain.is_empty() && domain.bytes().all(|b| b == b'0') {
+            return Ok(rest);
+        }
+        Ok(s)
+    }
+
     /// The label set every `dstack_gpu_*` series carries, matching
     /// dcgm-exporter so host-side tooling that speaks BDF can correlate.
     /// Written once here rather than repeated in the template for each metric.
@@ -217,5 +236,102 @@ mod tests {
         };
         let html = dashboard.render().expect("render");
         assert!(html.contains("70.1 W"), "{html}");
+    }
+
+    /// The CC fields are labelled rows, so the value carries no prose of its
+    /// own. What must not come back is the old run-on line, and the age has to
+    /// round like every other number on the page.
+    #[test]
+    fn dashboard_renders_the_gpu_header_as_labelled_rows() {
+        let html = dashboard_with(GpuInfoResponse {
+            gpus: vec![gpu(0)],
+            cc_enabled: Some(true),
+            cc_ready: Some(false),
+            sample_age_ms: Some(1_049),
+            ..Default::default()
+        });
+        assert!(html.contains(">Confidential Computing<"), "{html}");
+        assert!(html.contains(">true<"), "{html}");
+        assert!(html.contains(">GPU Ready State<"), "{html}");
+        assert!(html.contains(">false<"), "{html}");
+        assert!(html.contains("1.0 s"), "{html}");
+        assert!(!html.contains("enabled = true"), "{html}");
+    }
+
+    /// An unset field is a third state, not a false. Reporting a GPU whose CC
+    /// status could not be read as `false` would invert the claim.
+    #[test]
+    fn dashboard_distinguishes_unknown_cc_state_from_false() {
+        let html = dashboard_with(GpuInfoResponse {
+            gpus: vec![gpu(0)],
+            cc_enabled: None,
+            cc_ready: None,
+            ..Default::default()
+        });
+        assert!(html.contains(">unknown<"), "{html}");
+        assert!(!html.contains(">false<"), "{html}");
+    }
+
+    /// Every other block on the page is a card. A bare paragraph on the page
+    /// background is what this section used to render into.
+    #[test]
+    fn dashboard_keeps_the_gpu_section_inside_a_card() {
+        let html = dashboard_with(GpuInfoResponse::default());
+        assert!(
+            html.contains(r#"<div class="info-section">No NVIDIA GPUs</div>"#),
+            "{html}"
+        );
+    }
+
+    /// The zero domain is display noise, but only the noise may go. A non-zero
+    /// domain is what tells two cards on a multi-domain host apart, and
+    /// `00:00.0` is bus zero, not a domain that can be dropped.
+    #[test]
+    fn the_pci_domain_is_dropped_only_where_it_carries_nothing() {
+        use super::filters::short_bdf;
+
+        assert_eq!(short_bdf("00000000:01:00.0").unwrap(), "01:00.0");
+        assert_eq!(short_bdf("0000:01:00.0").unwrap(), "01:00.0");
+        assert_eq!(short_bdf("00010000:01:00.0").unwrap(), "00010000:01:00.0");
+        assert_eq!(short_bdf("00:00.0").unwrap(), "00:00.0");
+        assert_eq!(short_bdf("01:00.0").unwrap(), "01:00.0");
+    }
+
+    /// The dashboard drops the UUID column and shortens the address. Neither
+    /// may reach `/metrics`: those labels are what a host-side exporter joins
+    /// on, so they carry the identifiers verbatim.
+    #[test]
+    fn metrics_labels_keep_the_full_identifiers() {
+        let body = render(GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                uuid: "GPU-b2880e21-86ab".into(),
+                pci_bus_id: "00000000:01:00.0".into(),
+                ..gpu(0)
+            }],
+            ..Default::default()
+        });
+        assert!(body.contains(r#"uuid="GPU-b2880e21-86ab""#), "{body}");
+        assert!(body.contains(r#"pci_bus_id="00000000:01:00.0""#), "{body}");
+    }
+
+    fn dashboard_with(gpu_info: GpuInfoResponse) -> String {
+        Dashboard {
+            app_name: String::new(),
+            app_id: vec![],
+            instance_id: vec![],
+            device_id: vec![],
+            key_provider_info: String::new(),
+            tcb_info: String::new(),
+            containers: vec![],
+            system_info: Default::default(),
+            public_sysinfo: true,
+            public_logs: false,
+            public_tcbinfo: false,
+            cloud_vendor: String::new(),
+            cloud_product: String::new(),
+            gpu_info,
+        }
+        .render()
+        .expect("render")
     }
 }

--- a/dstack/guest-agent/src/models.rs
+++ b/dstack/guest-agent/src/models.rs
@@ -33,6 +33,18 @@ mod filters {
         Ok(hex::encode(s))
     }
 
+    /// The label set every `dstack_gpu_*` series carries, matching
+    /// dcgm-exporter so host-side tooling that speaks BDF can correlate.
+    /// Written once here rather than repeated in the template for each metric.
+    pub fn gpu_labels(gpu: &guest_api::GpuDevice) -> Result<String, rinja::Error> {
+        Ok(format!(
+            "{{index=\"{}\", uuid=\"{}\", pci_bus_id=\"{}\"}}",
+            gpu.index,
+            prometheus_label(&gpu.uuid)?,
+            prometheus_label(&gpu.pci_bus_id)?,
+        ))
+    }
+
     pub fn prometheus_label(s: &str) -> Result<String, rinja::Error> {
         Ok(s.replace('\\', "\\\\")
             .replace('\n', "\\n")
@@ -64,4 +76,146 @@ pub struct Dashboard {
 pub struct Metrics {
     pub system_info: SystemInfo,
     pub gpu_info: GpuInfoResponse,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use guest_api::GpuDevice;
+    use rinja::Template;
+
+    fn render(gpu_info: GpuInfoResponse) -> String {
+        Metrics {
+            system_info: Default::default(),
+            gpu_info,
+        }
+        .render()
+        .expect("render")
+    }
+
+    fn gpu(index: u32) -> GpuDevice {
+        GpuDevice {
+            index,
+            uuid: format!("GPU-{index}"),
+            pci_bus_id: format!("00000000:0{index}:00.0"),
+            ..Default::default()
+        }
+    }
+
+    /// The regression this whole design exists for: a sample older than the
+    /// collection TTL is still exposed. Emitting nothing meant every scrape at
+    /// Prometheus' default interval saw zero GPU series on a healthy card.
+    #[test]
+    fn a_stale_sample_still_produces_series() {
+        let body = render(GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                utilization_gpu: Some(37),
+                ..gpu(0)
+            }],
+            sample_age_ms: Some(60_000),
+            ..Default::default()
+        });
+        assert!(body.contains(
+            r#"dstack_gpu_utilization_percent{index="0", uuid="GPU-0", pci_bus_id="00000000:00:00.0"} 37"#
+        ));
+        assert!(body.contains("dstack_gpu_nvml_up 1"));
+        assert!(body.contains("dstack_gpu_sample_age_seconds 60"));
+    }
+
+    /// A field NVML could not answer must be absent, not zero: a scraped 0 is
+    /// indistinguishable from an idle GPU.
+    #[test]
+    fn a_field_that_failed_to_sample_emits_no_series() {
+        let body = render(GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                utilization_gpu: None,
+                temperature_c: Some(0),
+                ..gpu(0)
+            }],
+            ..Default::default()
+        });
+        assert!(!body.contains("dstack_gpu_utilization_percent{"));
+        assert!(body.contains(r#"dstack_gpu_temperature_celsius{index="0""#));
+    }
+
+    /// Failed queries are counted from a list. When they were a `"; "`-joined
+    /// string, a message containing that separator inflated the count.
+    #[test]
+    fn query_errors_counts_entries_not_separators() {
+        let body = render(GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                errors: vec![
+                    "power: not supported".into(),
+                    "memory: unknown error; retry advised".into(),
+                ],
+                ..gpu(0)
+            }],
+            ..Default::default()
+        });
+        assert!(body.contains(
+            r#"dstack_gpu_query_errors{index="0", uuid="GPU-0", pci_bus_id="00000000:00:00.0"} 2"#
+        ));
+    }
+
+    /// A guest with no GPU reports `nvml_up 1` with no devices: the collector
+    /// ran and found nothing. `nvml_up 0` is reserved for "could not tell".
+    #[test]
+    fn a_guest_without_gpus_is_not_reported_as_a_collection_failure() {
+        let body = render(GpuInfoResponse::default());
+        assert!(body.contains("dstack_gpu_nvml_up 1"));
+        assert!(!body.contains("dstack_gpu_utilization_percent{"));
+        assert!(!body.contains("dstack_gpu_cc_ready"));
+
+        let failed = render(GpuInfoResponse {
+            error: "NVIDIA driver is not loaded".into(),
+            ..Default::default()
+        });
+        assert!(failed.contains("dstack_gpu_nvml_up 0"));
+    }
+
+    /// Label values are escaped, so a hostile UUID cannot inject a series.
+    #[test]
+    fn label_values_are_escaped() {
+        let body = render(GpuInfoResponse {
+            gpus: vec![GpuDevice {
+                uuid: r#"GPU-"injected" \ end"#.into(),
+                utilization_gpu: Some(1),
+                ..gpu(0)
+            }],
+            ..Default::default()
+        });
+        assert!(body.contains(r#"uuid="GPU-\"injected\" \\ end""#), "{body}");
+    }
+
+    /// Watts are rendered from milliwatts. Raw f32 Display would print
+    /// 70.123001 for a card drawing 70.123 W.
+    #[test]
+    fn dashboard_power_is_formatted_to_one_decimal() {
+        let dashboard = Dashboard {
+            app_name: String::new(),
+            app_id: vec![],
+            instance_id: vec![],
+            device_id: vec![],
+            key_provider_info: String::new(),
+            tcb_info: String::new(),
+            containers: vec![],
+            system_info: Default::default(),
+            public_sysinfo: true,
+            public_logs: false,
+            public_tcbinfo: false,
+            cloud_vendor: String::new(),
+            cloud_product: String::new(),
+            gpu_info: GpuInfoResponse {
+                gpus: vec![GpuDevice {
+                    power_usage_mw: Some(70_123),
+                    ..gpu(0)
+                }],
+                cc_enabled: Some(true),
+                sample_age_ms: Some(2_500),
+                ..Default::default()
+            },
+        };
+        let html = dashboard.render().expect("render");
+        assert!(html.contains("70.1 W"), "{html}");
+    }
 }

--- a/dstack/guest-agent/templates/dashboard.html
+++ b/dstack/guest-agent/templates/dashboard.html
@@ -220,9 +220,20 @@ SPDX-License-Identifier: Apache-2.0
     {% else if gpu_info.gpus.is_empty() %}
     <p>No NVIDIA GPUs</p>
     {% else %}
-    {% match gpu_info.cc_ready %}
-    {% when Some with (ready) %}
-    <p>CC ready: {{ ready }}</p>
+    <p>
+        Confidential computing:
+        {% match gpu_info.cc_enabled %}
+        {% when Some with (enabled) %}enabled = {{ enabled }},
+        {% when None %}enabled = unknown,
+        {% endmatch %}
+        {% match gpu_info.cc_ready %}
+        {% when Some with (ready) %}ready = {{ ready }}
+        {% when None %}ready = unknown
+        {% endmatch %}
+    </p>
+    {% match gpu_info.sample_age_ms %}
+    {% when Some with (age) %}
+    <p>Sampled {{ age as f32 / 1000.0 }}s ago</p>
     {% when None %}
     {% endmatch %}
     <table>
@@ -236,7 +247,6 @@ SPDX-License-Identifier: Apache-2.0
                 <th>Memory</th>
                 <th>Temp</th>
                 <th>Power</th>
-                <th>CC</th>
                 <th>Error</th>
             </tr>
         </thead>
@@ -280,17 +290,11 @@ SPDX-License-Identifier: Apache-2.0
                 </td>
                 <td>
                     {% match gpu.power_usage_mw %}
-                    {% when Some with (value) %}{{ value as f32 / 1000.0 }} W
+                    {% when Some with (value) %}{{ "{:.1}"|format(value as f32 / 1000.0) }} W
                     {% when None %}-
                     {% endmatch %}
                 </td>
-                <td>
-                    {% match gpu.cc_enabled %}
-                    {% when Some with (value) %}{{ value }}
-                    {% when None %}-
-                    {% endmatch %}
-                </td>
-                <td>{{ gpu.error }}</td>
+                <td>{{ gpu.errors.join("; ") }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/dstack/guest-agent/templates/dashboard.html
+++ b/dstack/guest-agent/templates/dashboard.html
@@ -216,31 +216,48 @@ SPDX-License-Identifier: Apache-2.0
     {% if public_sysinfo %}
     <h2>GPUs</h2>
     {% if !gpu_info.error.is_empty() %}
-    <p>{{ gpu_info.error }}</p>
+    <div class="info-section">{{ gpu_info.error }}</div>
     {% else if gpu_info.gpus.is_empty() %}
-    <p>No NVIDIA GPUs</p>
+    <div class="info-section">No NVIDIA GPUs</div>
     {% else %}
-    <p>
-        Confidential computing:
-        {% match gpu_info.cc_enabled %}
-        {% when Some with (enabled) %}enabled = {{ enabled }},
-        {% when None %}enabled = unknown,
-        {% endmatch %}
-        {% match gpu_info.cc_ready %}
-        {% when Some with (ready) %}ready = {{ ready }}
-        {% when None %}ready = unknown
-        {% endmatch %}
-    </p>
-    {% match gpu_info.sample_age_ms %}
-    {% when Some with (age) %}
-    <p>Sampled {{ age as f32 / 1000.0 }}s ago</p>
-    {% when None %}
-    {% endmatch %}
+    <div class="info-section">
+        <div class="info-grid">
+            <div class="info-row">
+                <div class="info-label">Confidential Computing</div>
+                <div class="info-value">
+                    {%- match gpu_info.cc_enabled -%}
+                    {%- when Some with (enabled) -%}
+                    {{- enabled -}}
+                    {%- when None -%}
+                    unknown
+                    {%- endmatch -%}
+                </div>
+            </div>
+            <div class="info-row">
+                <div class="info-label">GPU Ready State</div>
+                <div class="info-value">
+                    {%- match gpu_info.cc_ready -%}
+                    {%- when Some with (ready) -%}
+                    {{- ready -}}
+                    {%- when None -%}
+                    unknown
+                    {%- endmatch -%}
+                </div>
+            </div>
+            {%- match gpu_info.sample_age_ms %}
+            {%- when Some with (age) %}
+            <div class="info-row">
+                <div class="info-label">Sample Age</div>
+                <div class="info-value">{{ "{:.1}"|format(age as f32 / 1000.0) }} s</div>
+            </div>
+            {%- when None %}
+            {%- endmatch %}
+        </div>
+    </div>
     <table>
         <thead>
             <tr>
                 <th>Index</th>
-                <th>UUID</th>
                 <th>PCI</th>
                 <th>GPU %</th>
                 <th>Mem %</th>
@@ -254,8 +271,7 @@ SPDX-License-Identifier: Apache-2.0
             {% for gpu in gpu_info.gpus %}
             <tr>
                 <td>{{ gpu.index }}</td>
-                <td>{{ gpu.uuid }}</td>
-                <td>{{ gpu.pci_bus_id }}</td>
+                <td>{{ gpu.pci_bus_id|short_bdf }}</td>
                 <td>
                     {% match gpu.utilization_gpu %}
                     {% when Some with (value) %}{{ value }}%

--- a/dstack/guest-agent/templates/dashboard.html
+++ b/dstack/guest-agent/templates/dashboard.html
@@ -213,6 +213,91 @@ SPDX-License-Identifier: Apache-2.0
         </div>
     </div>
 
+    {% if public_sysinfo %}
+    <h2>GPUs</h2>
+    {% if !gpu_info.error.is_empty() %}
+    <p>{{ gpu_info.error }}</p>
+    {% else if gpu_info.gpus.is_empty() %}
+    <p>No NVIDIA GPUs</p>
+    {% else %}
+    {% match gpu_info.cc_ready %}
+    {% when Some with (ready) %}
+    <p>CC ready: {{ ready }}</p>
+    {% when None %}
+    {% endmatch %}
+    <table>
+        <thead>
+            <tr>
+                <th>Index</th>
+                <th>UUID</th>
+                <th>PCI</th>
+                <th>GPU %</th>
+                <th>Mem %</th>
+                <th>Memory</th>
+                <th>Temp</th>
+                <th>Power</th>
+                <th>CC</th>
+                <th>Error</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for gpu in gpu_info.gpus %}
+            <tr>
+                <td>{{ gpu.index }}</td>
+                <td>{{ gpu.uuid }}</td>
+                <td>{{ gpu.pci_bus_id }}</td>
+                <td>
+                    {% match gpu.utilization_gpu %}
+                    {% when Some with (value) %}{{ value }}%
+                    {% when None %}-
+                    {% endmatch %}
+                </td>
+                <td>
+                    {% match gpu.utilization_memory %}
+                    {% when Some with (value) %}{{ value }}%
+                    {% when None %}-
+                    {% endmatch %}
+                </td>
+                <td>
+                    {% match gpu.memory_used_bytes %}
+                    {% when Some with (used) %}
+                    {% match gpu.memory_total_bytes %}
+                    {% when Some with (total) %}{{ used|hsize }} / {{ total|hsize }}
+                    {% when None %}{{ used|hsize }}
+                    {% endmatch %}
+                    {% when None %}
+                    {% match gpu.memory_total_bytes %}
+                    {% when Some with (total) %}- / {{ total|hsize }}
+                    {% when None %}-
+                    {% endmatch %}
+                    {% endmatch %}
+                </td>
+                <td>
+                    {% match gpu.temperature_c %}
+                    {% when Some with (value) %}{{ value }} C
+                    {% when None %}-
+                    {% endmatch %}
+                </td>
+                <td>
+                    {% match gpu.power_usage_mw %}
+                    {% when Some with (value) %}{{ value as f32 / 1000.0 }} W
+                    {% when None %}-
+                    {% endmatch %}
+                </td>
+                <td>
+                    {% match gpu.cc_enabled %}
+                    {% when Some with (value) %}{{ value }}
+                    {% when None %}-
+                    {% endmatch %}
+                </td>
+                <td>{{ gpu.error }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+    {% endif %}
+
     <h2>Deployed Containers</h2>
     <table>
         <thead>

--- a/dstack/guest-agent/templates/metrics.tpl
+++ b/dstack/guest-agent/templates/metrics.tpl
@@ -74,6 +74,94 @@ dstack_guest_disk_used_bytes{name="{{disk.name|prometheus_label}}", mount_point=
 dstack_guest_disk_used_ratio{name="{{disk.name|prometheus_label}}", mount_point="{{disk.mount_point|prometheus_label}}"} {% if disk.total_size > 0 %}{{(disk.total_size - disk.free_size) as f64 / disk.total_size as f64}}{% else %}0{% endif %}
 {% endfor %}
 
+# HELP dstack_gpu_nvml_up 1 if NVML collection succeeded, 0 otherwise.
+# TYPE dstack_gpu_nvml_up gauge
+dstack_gpu_nvml_up {% if gpu_info.error.is_empty() %}1{% else %}0{% endif %}
+
+# HELP dstack_gpu_cc_ready 1 if NVIDIA CC GPUs are accepting client requests.
+# TYPE dstack_gpu_cc_ready gauge
+{% match gpu_info.cc_ready %}
+{% when Some with (ready) %}
+dstack_gpu_cc_ready {% if ready %}1{% else %}0{% endif %}
+{% when None %}
+{% endmatch %}
+
+# HELP dstack_gpu_utilization_percent GPU SM duty cycle, percent.
+# TYPE dstack_gpu_utilization_percent gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.utilization_gpu %}
+{% when Some with (value) %}
+dstack_gpu_utilization_percent{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_memory_utilization_percent GPU memory-bus duty cycle, percent.
+# TYPE dstack_gpu_memory_utilization_percent gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.utilization_memory %}
+{% when Some with (value) %}
+dstack_gpu_memory_utilization_percent{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_memory_total_bytes GPU framebuffer size in bytes.
+# TYPE dstack_gpu_memory_total_bytes gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.memory_total_bytes %}
+{% when Some with (value) %}
+dstack_gpu_memory_total_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_memory_used_bytes GPU framebuffer used in bytes.
+# TYPE dstack_gpu_memory_used_bytes gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.memory_used_bytes %}
+{% when Some with (value) %}
+dstack_gpu_memory_used_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_memory_free_bytes GPU framebuffer free in bytes.
+# TYPE dstack_gpu_memory_free_bytes gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.memory_free_bytes %}
+{% when Some with (value) %}
+dstack_gpu_memory_free_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_temperature_celsius GPU temperature in Celsius.
+# TYPE dstack_gpu_temperature_celsius gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.temperature_c %}
+{% when Some with (value) %}
+dstack_gpu_temperature_celsius{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_power_usage_milliwatts GPU power usage in milliwatts.
+# TYPE dstack_gpu_power_usage_milliwatts gauge
+{% for gpu in gpu_info.gpus %}
+{% match gpu.power_usage_mw %}
+{% when Some with (value) %}
+dstack_gpu_power_usage_milliwatts{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
+{% when None %}
+{% endmatch %}
+{% endfor %}
+
+# HELP dstack_gpu_query_errors Number of NVML field queries that failed on this GPU.
+# TYPE dstack_gpu_query_errors gauge
+{% for gpu in gpu_info.gpus %}
+dstack_gpu_query_errors{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {% if gpu.error.is_empty() %}0{% else %}{{ gpu.error.split("; ").count() }}{% endif %}
+{% endfor %}
+
 # Everything below is the pre-rename exposition, kept verbatim so existing
 # dashboards keep working through one release cycle. Deprecated: use the
 # dstack_guest_* series above; these will be removed in a future release.

--- a/dstack/guest-agent/templates/metrics.tpl
+++ b/dstack/guest-agent/templates/metrics.tpl
@@ -74,93 +74,78 @@ dstack_guest_disk_used_bytes{name="{{disk.name|prometheus_label}}", mount_point=
 dstack_guest_disk_used_ratio{name="{{disk.name|prometheus_label}}", mount_point="{{disk.mount_point|prometheus_label}}"} {% if disk.total_size > 0 %}{{(disk.total_size - disk.free_size) as f64 / disk.total_size as f64}}{% else %}0{% endif %}
 {% endfor %}
 
-# HELP dstack_gpu_nvml_up 1 if NVML collection succeeded, 0 otherwise.
+# HELP dstack_gpu_nvml_up 1 if the last GPU sample succeeded, 0 otherwise.
 # TYPE dstack_gpu_nvml_up gauge
 dstack_gpu_nvml_up {% if gpu_info.error.is_empty() %}1{% else %}0{% endif %}
 
+{%- match gpu_info.sample_age_ms %}{% when Some with (age) %}
+
+# HELP dstack_gpu_sample_age_seconds Age of the GPU sample being served.
+# TYPE dstack_gpu_sample_age_seconds gauge
+dstack_gpu_sample_age_seconds {{ age as f64 / 1000.0 }}
+{%- when None %}{% endmatch %}
+
+{%- match gpu_info.cc_enabled %}{% when Some with (enabled) %}
+
+# HELP dstack_gpu_cc_enabled 1 if NVIDIA confidential computing is enabled.
+# TYPE dstack_gpu_cc_enabled gauge
+dstack_gpu_cc_enabled {% if enabled %}1{% else %}0{% endif %}
+{%- when None %}{% endmatch %}
+
+{%- match gpu_info.cc_ready %}{% when Some with (ready) %}
+
 # HELP dstack_gpu_cc_ready 1 if NVIDIA CC GPUs are accepting client requests.
 # TYPE dstack_gpu_cc_ready gauge
-{% match gpu_info.cc_ready %}
-{% when Some with (ready) %}
 dstack_gpu_cc_ready {% if ready %}1{% else %}0{% endif %}
-{% when None %}
-{% endmatch %}
+{%- when None %}{% endmatch %}
 
 # HELP dstack_gpu_utilization_percent GPU SM duty cycle, percent.
 # TYPE dstack_gpu_utilization_percent gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.utilization_gpu %}
-{% when Some with (value) %}
-dstack_gpu_utilization_percent{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.utilization_gpu %}{% when Some with (value) %}
+dstack_gpu_utilization_percent{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_memory_utilization_percent GPU memory-bus duty cycle, percent.
 # TYPE dstack_gpu_memory_utilization_percent gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.utilization_memory %}
-{% when Some with (value) %}
-dstack_gpu_memory_utilization_percent{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.utilization_memory %}{% when Some with (value) %}
+dstack_gpu_memory_utilization_percent{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_memory_total_bytes GPU framebuffer size in bytes.
 # TYPE dstack_gpu_memory_total_bytes gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.memory_total_bytes %}
-{% when Some with (value) %}
-dstack_gpu_memory_total_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.memory_total_bytes %}{% when Some with (value) %}
+dstack_gpu_memory_total_bytes{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_memory_used_bytes GPU framebuffer used in bytes.
 # TYPE dstack_gpu_memory_used_bytes gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.memory_used_bytes %}
-{% when Some with (value) %}
-dstack_gpu_memory_used_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.memory_used_bytes %}{% when Some with (value) %}
+dstack_gpu_memory_used_bytes{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_memory_free_bytes GPU framebuffer free in bytes.
 # TYPE dstack_gpu_memory_free_bytes gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.memory_free_bytes %}
-{% when Some with (value) %}
-dstack_gpu_memory_free_bytes{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.memory_free_bytes %}{% when Some with (value) %}
+dstack_gpu_memory_free_bytes{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_temperature_celsius GPU temperature in Celsius.
 # TYPE dstack_gpu_temperature_celsius gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.temperature_c %}
-{% when Some with (value) %}
-dstack_gpu_temperature_celsius{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.temperature_c %}{% when Some with (value) %}
+dstack_gpu_temperature_celsius{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_power_usage_milliwatts GPU power usage in milliwatts.
 # TYPE dstack_gpu_power_usage_milliwatts gauge
-{% for gpu in gpu_info.gpus %}
-{% match gpu.power_usage_mw %}
-{% when Some with (value) %}
-dstack_gpu_power_usage_milliwatts{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {{value}}
-{% when None %}
-{% endmatch %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}{% match gpu.power_usage_mw %}{% when Some with (value) %}
+dstack_gpu_power_usage_milliwatts{{ gpu|gpu_labels }} {{ value }}
+{%- when None %}{% endmatch %}{% endfor %}
 
 # HELP dstack_gpu_query_errors Number of NVML field queries that failed on this GPU.
 # TYPE dstack_gpu_query_errors gauge
-{% for gpu in gpu_info.gpus %}
-dstack_gpu_query_errors{index="{{gpu.index}}", uuid="{{gpu.uuid|prometheus_label}}", pci_bus_id="{{gpu.pci_bus_id|prometheus_label}}"} {% if gpu.error.is_empty() %}0{% else %}{{ gpu.error.split("; ").count() }}{% endif %}
-{% endfor %}
+{%- for gpu in gpu_info.gpus %}
+dstack_gpu_query_errors{{ gpu|gpu_labels }} {{ gpu.errors.len() }}
+{%- endfor %}
 
 # Everything below is the pre-rename exposition, kept verbatim so existing
 # dashboards keep working through one release cycle. Deprecated: use the

--- a/dstack/guest-api/proto/guest_api.proto
+++ b/dstack/guest-api/proto/guest_api.proto
@@ -132,8 +132,9 @@ message DiskInfo {
 // One NVIDIA GPU sampled through NVML.
 //
 // Optional numeric fields are unset when that query failed, so a consumer can
-// tell a genuine zero from a missing sample. `error` lists the failed queries
-// for this card. `uuid` is the stable identity; `index` and `pci_bus_id` are
+// tell a genuine zero from a missing sample. `errors` lists the failed queries
+// for this card, one entry each, so counting them does not mean re-parsing a
+// joined string. `uuid` is the stable identity; `index` and `pci_bus_id` are
 // ordinal/location helpers. `uuid` may be empty if that query failed.
 message GpuDevice {
   // NVML device index (PCI order)
@@ -150,23 +151,33 @@ message GpuDevice {
   optional uint64 memory_free_bytes = 8;
   optional uint32 temperature_c = 9;
   optional uint32 power_usage_mw = 10;
-  // Failed queries for this card; empty if all fields succeeded
-  string error = 11;
-  // Whether this GPU has CC mode enabled. Unset if the query is unsupported.
-  optional bool cc_enabled = 12;
+  // Failed queries for this card, one per entry; empty if all fields succeeded
+  repeated string errors = 11;
 }
 
 // GPU inventory collected through NVML.
 //
-// `error` is non-empty when NVML itself is unavailable (init or device-count
-// failed). In that case `gpus` is empty. An empty `gpus` with an empty `error`
-// means NVML worked and the guest has no NVIDIA GPUs.
-// `cc_ready` is the system-wide NVML CC ready state (SPDM handshake done and
-// GPUs accepting client work). Unset when the query is unsupported or failed.
+// `error` is non-empty when NVML itself is unavailable, or when the sample
+// could not be taken at all. In that case `gpus` is empty. An empty `gpus`
+// with an empty `error` means the collector ran and the guest has no NVIDIA
+// GPUs.
+//
+// `cc_ready` and `cc_enabled` are both system-wide, not per device: NVML
+// exposes them as `nvmlSystemGetConfComputeGpusReadyState` and
+// `nvmlSystemGetConfComputeSettings`, which nvml-wrapper hangs off `Device`
+// without using the device handle. `cc_enabled` says the CC feature is turned
+// on; `cc_ready` says the SPDM handshake finished and the GPUs are accepting
+// client work. Both unset when the query is unsupported or failed.
+//
+// `sample_age_ms` is how old the returned sample is. The agent serves the last
+// known snapshot rather than nothing, so consumers must decide for themselves
+// how stale is too stale. Unset when the response carries no sample.
 message GpuInfoResponse {
   repeated GpuDevice gpus = 1;
   string error = 2;
   optional bool cc_ready = 3;
+  optional bool cc_enabled = 4;
+  optional uint64 sample_age_ms = 5;
 }
 
 // Direct gRPC surface exposed by the in-guest agent.

--- a/dstack/guest-api/proto/guest_api.proto
+++ b/dstack/guest-api/proto/guest_api.proto
@@ -129,12 +129,54 @@ message DiskInfo {
   uint64 free_size = 5;
 }
 
+// One NVIDIA GPU sampled through NVML.
+//
+// Optional numeric fields are unset when that query failed, so a consumer can
+// tell a genuine zero from a missing sample. `error` lists the failed queries
+// for this card. `uuid` is the stable identity; `index` and `pci_bus_id` are
+// ordinal/location helpers. `uuid` may be empty if that query failed.
+message GpuDevice {
+  // NVML device index (PCI order)
+  uint32 index = 1;
+  string uuid = 2;
+  // PCI BDF from nvmlPciInfo.busId
+  string pci_bus_id = 3;
+  // SM duty cycle, percent
+  optional uint32 utilization_gpu = 4;
+  // Memory-bus duty cycle, percent
+  optional uint32 utilization_memory = 5;
+  optional uint64 memory_total_bytes = 6;
+  optional uint64 memory_used_bytes = 7;
+  optional uint64 memory_free_bytes = 8;
+  optional uint32 temperature_c = 9;
+  optional uint32 power_usage_mw = 10;
+  // Failed queries for this card; empty if all fields succeeded
+  string error = 11;
+  // Whether this GPU has CC mode enabled. Unset if the query is unsupported.
+  optional bool cc_enabled = 12;
+}
+
+// GPU inventory collected through NVML.
+//
+// `error` is non-empty when NVML itself is unavailable (init or device-count
+// failed). In that case `gpus` is empty. An empty `gpus` with an empty `error`
+// means NVML worked and the guest has no NVIDIA GPUs.
+// `cc_ready` is the system-wide NVML CC ready state (SPDM handshake done and
+// GPUs accepting client work). Unset when the query is unsupported or failed.
+message GpuInfoResponse {
+  repeated GpuDevice gpus = 1;
+  string error = 2;
+  optional bool cc_ready = 3;
+}
+
 // Direct gRPC surface exposed by the in-guest agent.
 service GuestApi {
   // Returns attestation material and identifiers for the calling guest.
   rpc Info(google.protobuf.Empty) returns (GuestInfo);
   // Reports the guest's OS/kernel and resource statistics.
   rpc SysInfo(google.protobuf.Empty) returns (SystemInfo);
+  // Reports per-GPU utilization, memory, temperature, power, and CC ready state.
+  rpc GpuInfo(google.protobuf.Empty) returns (GpuInfoResponse);
   // Dumps NIC/Gateway configuration so operators can debug connectivity.
   rpc NetworkInfo(google.protobuf.Empty) returns (NetworkInformation);
   // Enumerates the containers running under the guest supervisor.
@@ -147,6 +189,7 @@ service GuestApi {
 service ProxiedGuestApi {
   rpc Info(Id) returns (GuestInfo);
   rpc SysInfo(Id) returns (SystemInfo);
+  rpc GpuInfo(Id) returns (GpuInfoResponse);
   rpc NetworkInfo(Id) returns (NetworkInformation);
   rpc ListContainers(Id) returns (ListContainersResponse);
   rpc Shutdown(Id) returns (google.protobuf.Empty);

--- a/dstack/guest-api/proto/guest_api.proto
+++ b/dstack/guest-api/proto/guest_api.proto
@@ -134,8 +134,13 @@ message DiskInfo {
 // Optional numeric fields are unset when that query failed, so a consumer can
 // tell a genuine zero from a missing sample. `errors` lists the failed queries
 // for this card, one entry each, so counting them does not mean re-parsing a
-// joined string. `uuid` is the stable identity; `index` and `pci_bus_id` are
-// ordinal/location helpers. `uuid` may be empty if that query failed.
+// joined string.
+//
+// `uuid` is the stable identity; `index` and `pci_bus_id` are ordinal/location
+// helpers. `uuid` and `pci_bus_id` are plain strings rather than `optional`
+// because an empty value is already unambiguous: NVML never returns one, and
+// the matching `errors` entry names the query that failed. `index` is always
+// populated, so a device is identifiable even when both lookups fail.
 message GpuDevice {
   // NVML device index (PCI order)
   uint32 index = 1;

--- a/dstack/guest-api/src/lib.rs
+++ b/dstack/guest-api/src/lib.rs
@@ -16,11 +16,16 @@ mod tests {
     use super::*;
     use prost::Message;
 
+    /// Every numeric field is `optional` so a consumer can tell "the query
+    /// failed" from a genuine zero. That distinction only holds if it survives
+    /// the wire, which is what this pins.
     #[test]
     fn gpu_info_response_roundtrips_optional_fields() {
         let original = GpuInfoResponse {
             error: String::new(),
             cc_ready: Some(true),
+            cc_enabled: Some(true),
+            sample_age_ms: Some(4200),
             gpus: vec![GpuDevice {
                 index: 0,
                 uuid: "GPU-abc".into(),
@@ -32,8 +37,7 @@ mod tests {
                 memory_free_bytes: None,
                 temperature_c: Some(0),
                 power_usage_mw: None,
-                error: "temperature: timeout".into(),
-                cc_enabled: Some(true),
+                errors: vec!["temperature: timeout".into()],
             }],
         };
         let bytes = original.encode_to_vec();
@@ -42,13 +46,19 @@ mod tests {
         assert_eq!(decoded.gpus[0].utilization_memory, None);
         assert_eq!(decoded.gpus[0].memory_used_bytes, Some(0));
         assert_eq!(decoded.cc_ready, Some(true));
+        assert_eq!(decoded.sample_age_ms, Some(4200));
     }
 
+    /// The NVML-unavailable shape: an error, no devices, and no CC state at
+    /// all. `cc_ready` unset must not decode as `Some(false)`, which would
+    /// read as "the handshake failed" rather than "we could not ask".
     #[test]
     fn gpu_info_response_omits_unset_optionals() {
         let original = GpuInfoResponse {
             error: "failed to initialize NVML: driver not loaded".into(),
             cc_ready: None,
+            cc_enabled: None,
+            sample_age_ms: None,
             gpus: vec![],
         };
         let decoded = GpuInfoResponse::decode(original.encode_to_vec().as_slice()).expect("decode");
@@ -56,5 +66,36 @@ mod tests {
         assert!(decoded.gpus.is_empty());
         assert!(!decoded.error.is_empty());
         assert_eq!(decoded.cc_ready, None);
+        assert_eq!(decoded.cc_enabled, None);
+    }
+
+    /// "No GPUs" is the default response: empty devices, empty error. It must
+    /// stay distinguishable from every failure shape above.
+    #[test]
+    fn the_default_response_means_no_gpus_rather_than_a_failure() {
+        let decoded =
+            GpuInfoResponse::decode(GpuInfoResponse::default().encode_to_vec().as_slice())
+                .expect("decode");
+        assert!(decoded.gpus.is_empty());
+        assert!(decoded.error.is_empty());
+        assert_eq!(decoded.sample_age_ms, None);
+    }
+
+    /// Per-field failures are a list, so counting them for
+    /// `dstack_gpu_query_errors` does not mean re-parsing a joined string.
+    #[test]
+    fn per_device_errors_are_counted_not_parsed() {
+        let device = GpuDevice {
+            index: 0,
+            errors: vec![
+                "power: not supported".into(),
+                // A message containing the old "; " separator would have
+                // inflated the count when errors were a joined string.
+                "memory: unknown error; retry advised".into(),
+            ],
+            ..Default::default()
+        };
+        let decoded = GpuDevice::decode(device.encode_to_vec().as_slice()).expect("decode");
+        assert_eq!(decoded.errors.len(), 2);
     }
 }

--- a/dstack/guest-api/src/lib.rs
+++ b/dstack/guest-api/src/lib.rs
@@ -10,3 +10,51 @@ mod generated;
 
 #[cfg(feature = "client")]
 pub mod client;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn gpu_info_response_roundtrips_optional_fields() {
+        let original = GpuInfoResponse {
+            error: String::new(),
+            cc_ready: Some(true),
+            gpus: vec![GpuDevice {
+                index: 0,
+                uuid: "GPU-abc".into(),
+                pci_bus_id: "00000000:01:00.0".into(),
+                utilization_gpu: Some(12),
+                utilization_memory: None,
+                memory_total_bytes: Some(8 << 30),
+                memory_used_bytes: Some(0),
+                memory_free_bytes: None,
+                temperature_c: Some(0),
+                power_usage_mw: None,
+                error: "temperature: timeout".into(),
+                cc_enabled: Some(true),
+            }],
+        };
+        let bytes = original.encode_to_vec();
+        let decoded = GpuInfoResponse::decode(bytes.as_slice()).expect("decode");
+        assert_eq!(decoded, original);
+        assert_eq!(decoded.gpus[0].utilization_memory, None);
+        assert_eq!(decoded.gpus[0].memory_used_bytes, Some(0));
+        assert_eq!(decoded.cc_ready, Some(true));
+    }
+
+    #[test]
+    fn gpu_info_response_omits_unset_optionals() {
+        let original = GpuInfoResponse {
+            error: "failed to initialize NVML: driver not loaded".into(),
+            cc_ready: None,
+            gpus: vec![],
+        };
+        let decoded = GpuInfoResponse::decode(original.encode_to_vec().as_slice()).expect("decode");
+        assert_eq!(decoded, original);
+        assert!(decoded.gpus.is_empty());
+        assert!(!decoded.error.is_empty());
+        assert_eq!(decoded.cc_ready, None);
+    }
+}

--- a/dstack/lspci/Cargo.toml
+++ b/dstack/lspci/Cargo.toml
@@ -14,3 +14,4 @@ anyhow.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+tempfile.workspace = true

--- a/dstack/lspci/src/lib.rs
+++ b/dstack/lspci/src/lib.rs
@@ -6,6 +6,8 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 
+pub mod sysfs;
+
 /// Represents a PCI device with the specified fields.
 #[derive(Debug)]
 pub struct Device {

--- a/dstack/lspci/src/sysfs.rs
+++ b/dstack/lspci/src/sysfs.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2025 Phala Network <dstack@phala.network>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU inventory read straight from sysfs.
+//!
+//! Distinct from the `lspci` parser in this crate: no subprocess, no text
+//! parsing, and it sees devices the NVIDIA driver never bound. That matters in
+//! two places with opposite failure policies -- the boot attestation gate must
+//! fail closed when the inventory cannot be read, while a telemetry collector
+//! wants to shrug and report no GPUs -- so this returns the raw counts and lets
+//! each caller decide.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Where the kernel exposes the PCI bus.
+pub const PCI_DEVICES: &str = "/sys/bus/pci/devices";
+
+const NVIDIA_VENDOR_ID: &str = "0x10de";
+/// PCI class prefixes for VGA and 3D controllers.
+const DISPLAY_CLASS_PREFIXES: [&str; 2] = ["0x0300", "0x0302"];
+
+/// Display-class PCI devices, split by vendor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GpuInventory {
+    /// All display-class devices, whatever the vendor.
+    pub total: u32,
+    /// The subset made by NVIDIA.
+    pub nvidia: u32,
+}
+
+impl GpuInventory {
+    /// True when at least one NVIDIA display device is attached.
+    pub fn has_nvidia(&self) -> bool {
+        self.nvidia > 0
+    }
+}
+
+/// Counts display-class GPUs on the live PCI bus.
+pub fn gpu_inventory() -> Result<GpuInventory> {
+    gpu_inventory_at(Path::new(PCI_DEVICES))
+}
+
+/// Counts display-class GPUs under an arbitrary sysfs root, for tests.
+pub fn gpu_inventory_at(devices_path: &Path) -> Result<GpuInventory> {
+    let entries = std::fs::read_dir(devices_path)
+        .with_context(|| format!("failed to enumerate {}", devices_path.display()))?;
+    let mut inventory = GpuInventory::default();
+    for entry in entries {
+        let device = entry.context("failed to read PCI device entry")?;
+        let class_path = device.path().join("class");
+        let class = std::fs::read_to_string(&class_path)
+            .with_context(|| format!("failed to read {}", class_path.display()))?;
+        if !class
+            .trim()
+            .get(..6)
+            .is_some_and(|prefix| DISPLAY_CLASS_PREFIXES.contains(&prefix))
+        {
+            continue;
+        }
+        inventory.total += 1;
+        let vendor_path = device.path().join("vendor");
+        let vendor = std::fs::read_to_string(&vendor_path)
+            .with_context(|| format!("failed to read {}", vendor_path.display()))?;
+        if vendor.trim() == NVIDIA_VENDOR_ID {
+            inventory.nvidia += 1;
+        }
+    }
+    Ok(inventory)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_pci_device(root: &Path, name: &str, vendor: &str, class: &str) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vendor"), vendor).unwrap();
+        std::fs::write(dir.join("class"), class).unwrap();
+    }
+
+    #[test]
+    fn inventory_counts_nvidia_and_non_nvidia_gpus() {
+        let root = tempfile::tempdir().unwrap();
+        add_pci_device(root.path(), "0000:01:00.0", "0x10de\n", "0x030200\n");
+        add_pci_device(root.path(), "0000:02:00.0", "0x1234\n", "0x030000\n");
+        // A virtio NIC is not a display device and must not be counted.
+        add_pci_device(root.path(), "0000:03:00.0", "0x1af4\n", "0x020000\n");
+        assert_eq!(
+            gpu_inventory_at(root.path()).unwrap(),
+            GpuInventory {
+                total: 2,
+                nvidia: 1
+            }
+        );
+    }
+
+    /// The common CVM: virtio devices only. `has_nvidia` is the gate that keeps
+    /// GPU telemetry from costing such a guest anything.
+    #[test]
+    fn a_guest_without_a_display_device_reports_no_gpus() {
+        let root = tempfile::tempdir().unwrap();
+        add_pci_device(root.path(), "0000:01:00.0", "0x1af4\n", "0x020000\n");
+        add_pci_device(root.path(), "0000:02:00.0", "0x1af4\n", "0x010000\n");
+        let inventory = gpu_inventory_at(root.path()).unwrap();
+        assert_eq!(inventory, GpuInventory::default());
+        assert!(!inventory.has_nvidia());
+    }
+
+    /// Callers must be able to tell "no GPUs" from "could not look".
+    #[test]
+    fn an_unreadable_root_is_an_error_not_an_empty_inventory() {
+        assert!(gpu_inventory_at(Path::new("/nonexistent/pci/devices")).is_err());
+    }
+}

--- a/dstack/vmm/src/guest_api_service.rs
+++ b/dstack/vmm/src/guest_api_service.rs
@@ -6,7 +6,7 @@ use crate::App as AppState;
 use anyhow::Result;
 use guest_api::{
     proxied_guest_api_server::{ProxiedGuestApiRpc, ProxiedGuestApiServer},
-    GuestInfo, Id, ListContainersResponse, NetworkInformation, SystemInfo,
+    GpuInfoResponse, GuestInfo, Id, ListContainersResponse, NetworkInformation, SystemInfo,
 };
 use ra_rpc::{CallContext, RpcCall};
 use std::ops::Deref;
@@ -40,6 +40,10 @@ impl ProxiedGuestApiRpc for GuestApiHandler {
 
     async fn sys_info(self, request: Id) -> Result<SystemInfo> {
         self.guest_agent_client(&request.id)?.sys_info().await
+    }
+
+    async fn gpu_info(self, request: Id) -> Result<GpuInfoResponse> {
+        self.guest_agent_client(&request.id)?.gpu_info().await
     }
 
     async fn network_info(self, request: Id) -> Result<NetworkInformation> {


### PR DESCRIPTION
## Why

Operators and the cloud control plane need to know whether a GPU attached to a CVM is actually being used: SM utilization, framebuffer usage, temperature, power, and whether the confidential-computing handshake has completed. None of that is visible from the host. With VFIO passthrough the host driver never binds the card, so host-side NVML and DCGM cannot read it, and in CC mode the device is attested to the guest only. The only vantage point is inside the guest, which is where `dstack-guest-agent` already runs. This PR gives the agent a GPU telemetry surface.

## Design

The first draft put a `gpus` list on `SystemInfo` and called `Nvml::init()` on every request. Review found three problems, and a survey of how DCGM exporter, go-nvml, nvml-wrapper, the Kubernetes device plugin, and the GCP/AWS in-VM agents handle this confirmed the direction:

- **One NVML handle per process.** go-nvml and nvml-wrapper both document init-once, shutdown-once. nvml-wrapper's `Nvml` shuts the library down on `Drop`, so a request-scoped handle meant init+shutdown on every `/metrics` scrape.
- **GPU collection must not share fate with SysInfo.** DCGM exporter's known failure mode is one GPU in `ERR!` state taking the whole exporter down. Here GPU collection had SysInfo's 20 s timeout and `spawn_blocking`; a stuck NVML call (GPU reset, driver assert, CC handshake) would stall host and guest health reporting.
- **Missing must be distinguishable from zero.** The draft swallowed init and per-field errors, so "no GPU", "NVML down", "query failed", and a genuine 0 all looked the same. Two fields (`memory_reserved_bytes`, `memory_usable_bytes`) were placeholders with fabricated values.
- **Proto changes cross the VMM.** `ProxiedGuestApi` decodes and re-encodes, so a `SystemInfo` field the VMM does not know is dropped silently. The VMM must ship the same proto.

What this PR does instead:

- Independent `GpuInfo` RPC on `GuestApi` and `ProxiedGuestApi` (named like `Info` / `SysInfo` / `NetworkInfo`). `SystemInfo` is unchanged.
- Process-wide NVML handle in `gpu_info.rs`. A failed init is cached for 60 s so driver-less images do not `dlopen` on every scrape.
- Sampling is serialized with `try_lock`. The 5 s RPC timeout does not cancel a stuck NVML call; later callers receive the last snapshot, or `error: "sampling in progress"` if there is none, instead of queueing behind it. Successful snapshots are cached for 5 s and shared by the RPC, `/metrics`, and the dashboard.
- Every numeric field is `optional`. Per-device `error` lists the queries that failed. `NotSupported` logs at debug, because CC mode disables some counters by design; other per-field errors warn once per (device, field).
- Identity is `uuid` (stable), with `index` and `pci_bus_id` (`nvmlPciInfo.busId`) alongside, matching the DCGM exporter label set so host-side tooling that speaks BDF can correlate.
- `cc_ready` (system-wide `nvmlDeviceGetConfComputeGpusReadyState`) and per-device `cc_enabled`, so "driver present but still attesting" is distinguishable from "NVML unavailable".
- The two placeholder memory fields are removed; nvml-wrapper 0.12.1 has no `memory_info_v2`.

## Where the data is exposed, and who can see it

| Surface | Path | Audience | Gate |
|---|---|---|---|
| vsock `GuestApi.GpuInfo` | guest agent, vsock port 8000 | the VMM only | none; host operator channel |
| VMM `ProxiedGuestApi.GpuInfo` | `POST /guest/GpuInfo?json` on the VMM socket | host operators, control plane | VMM access control |
| `/metrics` on the guest's external port | Prometheus text, `dstack_gpu_*` series | anyone who can reach the port | `public_sysinfo` in app-compose |
| Dashboard | GPU table on the guest dashboard | anyone who can reach the port | `public_sysinfo` in app-compose |

The public surfaces reuse the existing `public_sysinfo` switch. `/metrics` already refused requests when it is off; the dashboard GPU section is wrapped in the same check. An app owner who keeps `public_sysinfo: false` exposes nothing new, and the host still gets telemetry through the VMM.

Metrics series: `dstack_gpu_nvml_up`, `dstack_gpu_cc_ready`, and per device `dstack_gpu_utilization_percent`, `dstack_gpu_memory_utilization_percent`, `dstack_gpu_memory_{total,used,free}_bytes`, `dstack_gpu_temperature_celsius`, `dstack_gpu_power_usage_milliwatts`, `dstack_gpu_query_errors`, all labeled `index`, `uuid`, `pci_bus_id`. A field that failed to sample emits no series rather than a 0.

## Tests

- Proto round trip preserves `None` vs `Some(0)` and an unset `cc_ready`.
- Collector does not panic without NVML; unavailability is reported as `error` with an empty device list, not as a silent empty success. The test passes with or without a driver present.

## Validation

- `cargo build -p dstack-guest-agent -p dstack-vmm`, `cargo test -p dstack-guest-agent -p guest-api`, `cargo fmt --check`, `cargo clippy -p dstack-guest-agent -p dstack-vmm -- -D warnings` on a TDX lab host without GPUs.
- A B200 test image was built from `next` + #1181 + #1177 + this branch (os_image_hash `a7a7646b0111236340b576645a4c8ff29c89facf8510c1019e52383f675326a7`, `git_revision` clean) and the rootfs was checked offline for the NVML symbols and the 595.91.07 driver. Live single-GPU validation on that image, with a VMM built from the same tree, is the remaining step.

## Known limits

- XID event based health tracking is out of scope.
- The exact set of NVML fields that return `NotSupported` under CC mode on B200 has not been enumerated yet; the design tolerates it but the list should be recorded once the live run happens.
- The VMM must be released with the same proto for `/guest/GpuInfo` to exist.

## References

Prior art surveyed for the design decisions above:

- NVIDIA DCGM exporter: https://github.com/NVIDIA/dcgm-exporter , metric and label reference https://docs.nvidia.com/datacenter/dcgm/latest/reference/dcgm-exporter-metrics.html , docs https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/dcgm-exporter.html , one bad GPU aborting the exporter https://github.com/NVIDIA/dcgm-exporter/issues/46
- go-nvml, init-once lifecycle: https://github.com/NVIDIA/go-nvml
- nvml-wrapper (Rust), process-wide handle guidance: https://github.com/rust-nvml/nvml-wrapper , https://docs.rs/nvml-wrapper
- nvidia_gpu_exporter, per-scrape vs background collection and graceful degradation: https://github.com/utkuozdemir/nvidia_gpu_exporter , https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/master/METRICS.md
- Kubernetes device plugin, UUID/BDF identity and per-device XID health: https://github.com/NVIDIA/k8s-device-plugin , https://github.com/NVIDIA/k8s-device-plugin/blob/main/docs/gpu-feature-discovery/README.md , https://github.com/NVIDIA/k8s-device-plugin/issues/1014
- In-VM cloud agents: Google Ops Agent GPU metrics https://docs.cloud.google.com/compute/docs/gpus/monitor-gpus , https://docs.cloud.google.com/monitoring/api/metrics_opsagent ; AWS CloudWatch agent NVIDIA metrics https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Solution-NVIDIA-GPU-On-EC2.html ; Azure guidance (Telegraf + nvidia-smi / DCGM) https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/comprehensive-nvidia-gpu-monitoring-for-azure-n-series-vms-using-telegraf-with-a/4257402
- NVIDIA confidential computing, counters disabled and CC ready state: https://developer.nvidia.com/blog/confidential-computing-on-h100-gpus-for-secure-and-trustworthy-ai/ , https://cloud.google.com/confidential-computing/confidential-vm/docs/verify-confidential-computing-mode-on-gpu , https://cacm.acm.org/practice/creating-the-first-confidential-gpus/
