### PR TITLE
fix(os/mkosi): ship libnvidia-container-go.so with the container stack

### DIFF
--- a/os/mkosi/components/container-stack/container-stack-build.sh
+++ b/os/mkosi/components/container-stack/container-stack-build.sh
@@ -43,6 +43,14 @@ objcopy --remove-section=.gnu_debuglink "$lnc/libnvidia-container.so.1.18.1"
 install -m0755 "$lnc/nvidia-container-cli" "$STAGE/usr/bin/"
 install -Dm0755 "$lnc/libnvidia-container.so.1.18.1" "$STAGE/usr/lib/x86_64-linux-gnu/libnvidia-container.so.1.18.1"
 ln -sfn libnvidia-container.so.1.18.1 "$STAGE/usr/lib/x86_64-linux-gnu/libnvidia-container.so.1"
+# nvcgo (WITH_NVCGO=yes) builds the Go-side lib and installs it under
+# $lnc/deps/usr/local/lib (Makefile prefix=/usr/local). libnvidia-container.so.1
+# dlopen()s it at runtime -- it is not a DT_NEEDED, so ldd and
+# "nvidia-container-cli --version" never surface it; the OCI hook only fails at
+# GPU-container init when the dlopen misses. Ship it alongside the C lib.
+objcopy --remove-section=.gnu_debuglink "$lnc/deps/usr/local/lib/libnvidia-container-go.so.1.18.1"
+install -Dm0755 "$lnc/deps/usr/local/lib/libnvidia-container-go.so.1.18.1" "$STAGE/usr/lib/x86_64-linux-gnu/libnvidia-container-go.so.1.18.1"
+ln -sfn libnvidia-container-go.so.1.18.1 "$STAGE/usr/lib/x86_64-linux-gnu/libnvidia-container-go.so.1"
 
 nct="$BUILD_DIR/nvidia-container-toolkit"
 checkout https://github.com/NVIDIA/nvidia-container-toolkit.git "$NVIDIA_CONTAINER_TOOLKIT_REVISION" "$nct"

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -50,6 +50,8 @@
       "usr/bin/nvidia-container-cli",
       "usr/bin/nvidia-container-runtime",
       "usr/bin/nvidia-ctk",
+      "usr/lib/x86_64-linux-gnu/libnvidia-container.so.1",
+      "usr/lib/x86_64-linux-gnu/libnvidia-container-go.so.1",
       "etc/nvidia-container-runtime/config.toml"
     ],
     "nvattest-2026.06.09": [


### PR DESCRIPTION
## Symptom

On the mkosi-built guest image, the first GPU container never reaches its entrypoint. The OCI NVIDIA hook fails with exit code 127:

```
nvidia-container-cli: initialization error: load library failed:
libnvidia-container-go.so.1: cannot open shared object file: no such file or directory
```

`nvidia-container-cli --version` and `ldd nvidia-container-cli` both look fine on the same image, and the parity check passed at build time.

## Root cause

`os/mkosi/components/container-stack/container-stack-build.sh` builds libnvidia-container with `WITH_NVCGO=yes`, which produces two libraries: the C library `libnvidia-container.so.1.18.1` and the Go-side library `libnvidia-container-go.so.1.18.1`. nvcgo installs the Go library under `$lnc/deps/usr/local/lib` (the upstream Makefile prefix is `/usr/local`). The install step only copied the C library and its SONAME symlink into the rootfs, so the Go library was built and then dropped.

`libnvidia-container.so.1` loads `libnvidia-container-go.so.1` with `dlopen()` at runtime. It is not a `DT_NEEDED` entry, so:

- `ldd` and the `runtime_link_paths` parity check (lddtree) never see it.
- `nvidia-container-cli --version` never triggers the dlopen.
- The `nvidia-container` parity component only listed the cli/runtime/ctk binaries and `config.toml`, never the libraries.

The miss only surfaces when the hook initialises a real GPU container.

## Fix

- Install `libnvidia-container-go.so.1.18.1` and its `.so.1` symlink next to the C library, with the same `objcopy --remove-section=.gnu_debuglink` treatment for reproducibility.
- Add `libnvidia-container.so.1` and `libnvidia-container-go.so.1` to the `nvidia-container` `required_rootfs_paths` in `parity.json`. `check-parity.py` follows symlinks to a real file, so a dangling SONAME now fails at build finalize instead of at GPU-container start.

## Verification

Built an image from `next` plus this commit on a B200 host (driver 595.91.07, CC on) and booted a single-GPU CVM through the KMS path:

- Offline: the rootfs squashfs contains `libnvidia-container-go.so.1.18.1` and the `.so.1` symlink.
- In guest: `nvidia-container-cli --version` reports cli 1.18.1 / lib 1.18.1; `nvidia-container-cli info` lists the B200.
- A `nvidia/cuda:12.6.2-base` container with `runtime: nvidia` starts and prints `GPU 0: NVIDIA B200 (UUID: GPU-...)` from `nvidia-smi -L`. Before this change the same compose failed at the hook with exit 127.
- GPU TEE attestation succeeded; no driver asserts in the serial log.

Not covered by this PR: the same build script's hand-written NVIDIA driver library whitelist also omits `libnvidia-sandboxutils`, `libcudadebugger`, and the CUDA MPS binaries. None of them block container start, so they are left for a separate change.
