### PR TITLE
feat(os): give both guest kernels the tc and checkpoint/restore capabilities Incus needs

### DIFF
--- a/LICENSES/LGPL-2.1-or-later.txt
+++ b/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,176 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts as the successor of the GNU Library Public License, version 2, hence the version number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+
+GNU LESSER GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+
+     c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+That's all there is to it!

--- a/docs/guest-netfilter-capabilities.md
+++ b/docs/guest-netfilter-capabilities.md
@@ -47,16 +47,16 @@ mkosi.
 | --- | --- | --- | --- | --- |
 | nftables core | `NF_TABLES` | yes | yes | 0.5.x |
 | xtables-over-nftables | `NFT_COMPAT` | yes | yes | 0.5.x |
-| nftables bridge family | `NF_TABLES_BRIDGE` | yes | yes | 0.6.1 (mkosi) |
-| bridge meta / reject | `NFT_BRIDGE_META`, `NFT_BRIDGE_REJECT` | yes | yes | 0.6.1 |
+| nftables bridge family | `NF_TABLES_BRIDGE` | yes | yes | 0.6.0 (mkosi) |
+| bridge meta / reject | `NFT_BRIDGE_META`, `NFT_BRIDGE_REJECT` | yes | yes | 0.6.0 |
 | ebtables framework | `BRIDGE_NF_EBTABLES` | yes | yes | 0.5.x |
-| ebtables matches | `BRIDGE_EBT_ARP`, `_IP`, `_IP6`, `_AMONG`, `_LIMIT`, `_VLAN` | yes | yes | 0.6.1 |
+| ebtables matches | `BRIDGE_EBT_ARP`, `_IP`, `_IP6`, `_AMONG`, `_LIMIT`, `_VLAN` | yes | yes | 0.6.0 |
 | ebtables legacy tables | `BRIDGE_NF_EBTABLES_LEGACY`, `BRIDGE_EBT_T_*` | **no** | **no** | — |
-| CHECKSUM target | `NETFILTER_XT_TARGET_CHECKSUM` | yes | yes | 0.6.1 (mkosi) |
+| CHECKSUM target | `NETFILTER_XT_TARGET_CHECKSUM` | yes | yes | 0.6.0 (mkosi) |
 | IPv4 tables | `IP_NF_IPTABLES` | yes | built in | 0.5.x |
 | IPv4 legacy tables | `IP_NF_IPTABLES_LEGACY` | yes | **no** | — |
-| IPv6 tables | `IP6_NF_IPTABLES` | yes | built in | 0.6.1 (Yocto) |
-| IPv6 NAT / filter / mangle | `IP6_NF_NAT`, `IP6_NF_FILTER`, `IP6_NF_MANGLE` | yes | n/a | 0.6.1 (Yocto) |
+| IPv6 tables | `IP6_NF_IPTABLES` | yes | built in | 0.6.0 (Yocto) |
+| IPv6 NAT / filter / mangle | `IP6_NF_NAT`, `IP6_NF_FILTER`, `IP6_NF_MANGLE` | yes | n/a | 0.6.0 (Yocto) |
 | ipset | `IP_SET` and the hash/bitmap set types | yes | yes | 0.5.x |
 
 Userspace: both images ship `iptables` and `nftables`. `ebtables` is the
@@ -134,7 +134,7 @@ libvirt/LXD/Incus-style bridge managers, and it is what every distribution that
 defaults to the nftables frontend already behaves like.
 
 It is, however, a behaviour change for the Yocto image, which programmed the
-legacy tables before dstack 0.6.1. On that path Incus selected its xtables
+legacy tables before dstack 0.6.0. On that path Incus selected its xtables
 driver and installed its accept rules with
 `iptables -I filter FORWARD -i <bridge> -j ACCEPT` — into Docker's *own* chain,
 ahead of the policy — so forwarding worked without any extra rule. Under the

--- a/docs/guest-netfilter-capabilities.md
+++ b/docs/guest-netfilter-capabilities.md
@@ -96,7 +96,10 @@ module to package or autoload.
 | ingress qdisc | `NET_SCH_INGRESS` | built in | built in | 0.6.0 |
 | u32 classifier | `NET_CLS_U32` | built in | built in | 0.6.0 |
 | police action | `NET_ACT_POLICE` | built in | built in | 0.6.0 |
-| checkpoint/restore | `CHECKPOINT_RESTORE` | built in | built in | 0.6.0 |
+| checkpoint/restore | `CHECKPOINT_RESTORE` | built in | built in | 0.6.0 (mkosi) |
+| macvlan | `MACVLAN` | built in | built in | 0.6.0 (mkosi) |
+| comment match | `NETFILTER_XT_MATCH_COMMENT` | yes | yes | 0.6.0 (mkosi) |
+| socket diag | `UNIX_DIAG`, `INET_DIAG`, `PACKET_DIAG`, `NETLINK_DIAG` | built in | built in | 0.6.0 (mkosi) |
 
 **Per-instance bandwidth limits need all four `tc` pieces.** Incus implements
 `limits.max` (and `limits.ingress` / `limits.egress`) on a bridged NIC as an
@@ -116,6 +119,21 @@ for monitor <pid>`, and every intercepted syscall
 (`security.syscalls.intercept.*`) is resumed unhandled instead of getting the
 container-aware answer (#1180). Everything the symbol gates needs
 `CAP_CHECKPOINT_RESTORE` or `CAP_SYS_ADMIN`, and none of it faces the host.
+The Yocto 6.18 kernel already had it through meta-virtualization's
+`cfg/lxc.scc` and `cfg/criu.scc`; the mkosi kernel did not, and the 6.9
+kernel of 0.5.9 did not either.
+
+**LXC's own audit runs against both kernels.** `lxc-checkconfig` is the
+script LXC ships to check a kernel for what containers need, and it is the
+closest thing Incus has to Docker's `check-config.sh` — Incus itself has no
+equivalent, and its documentation defers to "any kernel feature required by
+the LXC version in use". It is vendored at `os/common/scripts/lxc-checkconfig`
+and `check-lxc-kernel-config.sh` runs it after the fragment gate in both
+builds, failing on anything it reports missing. The last three rows above are
+what it flagged on the mkosi kernel the first time it ran: `MACVLAN` (Incus
+`nictype=macvlan`), `xt_comment` (`-m comment` on the xtables frontends) and
+the socket-diag interfaces `ss` and CRIU use. It does not know about traffic
+control, so the `tc` rows are asserted by the fragments alone.
 
 ## Running a nested bridge manager alongside Docker
 
@@ -176,6 +194,11 @@ becomes `=m`, and the build still succeeds. Check the produced `.config` rather
 than assuming, with `os/common/scripts/check-kernel-config.sh <.config>
 <fragment...>`; both backends run it, mkosi during the kernel build and Yocto
 in `os/yocto/scripts/export-artifacts.sh` before anything is published.
+`os/common/scripts/check-lxc-kernel-config.sh <.config>` runs at the same two
+points and is the second gate to satisfy: it fails on anything LXC's
+`lxc-checkconfig` reports missing, with the two `IP*_NF_TARGET_MASQUERADE`
+compat aliases (pure `select`s of `NETFILTER_XT_TARGET_MASQUERADE`, which both
+kernels build) as the only exemptions.
 
 On the Yocto backend a module also has to be *packaged* into the rootfs.
 `RDEPENDS:${KERNEL_PACKAGE_NAME}-base` is cleared in

--- a/docs/guest-netfilter-capabilities.md
+++ b/docs/guest-netfilter-capabilities.md
@@ -84,6 +84,39 @@ a table.
 checksum-offloading virtio NICs. On an nft frontend that is programmed through
 `nft_compat`, which still needs the `xt_CHECKSUM` module.
 
+## Beyond netfilter: traffic control and checkpoint/restore
+
+Two more guest-kernel capabilities a nested container manager depends on live
+in the same two fragments. Both are built in (`=y`), so neither backend has a
+module to package or autoload.
+
+| Capability | Kconfig symbol | Yocto | mkosi | Since |
+| --- | --- | --- | --- | --- |
+| HTB qdisc | `NET_SCH_HTB` | built in | built in | 0.6.0 |
+| ingress qdisc | `NET_SCH_INGRESS` | built in | built in | 0.6.0 |
+| u32 classifier | `NET_CLS_U32` | built in | built in | 0.6.0 |
+| police action | `NET_ACT_POLICE` | built in | built in | 0.6.0 |
+| checkpoint/restore | `CHECKPOINT_RESTORE` | built in | built in | 0.6.0 |
+
+**Per-instance bandwidth limits need all four `tc` pieces.** Incus implements
+`limits.max` (and `limits.ingress` / `limits.egress`) on a bridged NIC as an
+HTB root qdisc and class on the host-side veth for egress, and an ingress
+qdisc with a u32 filter and a police action for ingress. `NET_SCHED` and
+`NET_CLS_ACT` alone do not provide any of them: on 0.5.x the manager accepts
+the setting and then fails to start the instance with `Specified qdisc kind is
+unknown` (#1176).
+
+**`CHECKPOINT_RESTORE` is what lets the LXC monitor be found.** LXC retitles
+its monitor process to `[lxc monitor] <path> <name>` with
+`prctl(PR_SET_MM, PR_SET_MM_MAP, ...)`, and Incus's seccomp notification
+handler resolves a monitor PID to its instance by that title. The prctl is
+only implemented under `CHECKPOINT_RESTORE`; without it the monitor keeps its
+`incusd forkstart` command line, the daemon logs `Failed to find container
+for monitor <pid>`, and every intercepted syscall
+(`security.syscalls.intercept.*`) is resumed unhandled instead of getting the
+container-aware answer (#1180). Everything the symbol gates needs
+`CAP_CHECKPOINT_RESTORE` or `CAP_SYS_ADMIN`, and none of it faces the host.
+
 ## Running a nested bridge manager alongside Docker
 
 Having the capabilities is not the whole story. Docker sets the `FORWARD` chain

--- a/os/common/scripts/check-lxc-kernel-config.sh
+++ b/os/common/scripts/check-lxc-kernel-config.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run LXC's own kernel audit, lxc-checkconfig, against a built .config and
+# fail on anything it reports missing. check-kernel-config.sh asserts what
+# dstack's fragments ask for; this asserts what the container stack asks for,
+# from the list its maintainers keep, so a symbol dstack never thought to
+# request (CONFIG_CHECKPOINT_RESTORE was one, #1180) fails the build instead
+# of reaching a tenant. lxc-checkconfig knows nothing about traffic control or
+# anything else Incus needs beyond LXC, so the fragments still carry those.
+#
+# Usage: check-lxc-kernel-config.sh <built .config>
+set -euo pipefail
+config=${1:?kernel .config required}
+[[ -r $config ]] || { printf 'unreadable kernel config: %s\n' "$config" >&2; exit 1; }
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Backwards-compat aliases that only `select NETFILTER_XT_TARGET_MASQUERADE`,
+# the module every frontend has used since 5.2 and which both kernels build.
+# The IPv6 one is also unreachable on the mkosi kernel: it depends on
+# IP6_NF_NAT, which needs the legacy ip6tables that image does not have (see
+# docs/guest-netfilter-capabilities.md).
+ignored_symbols=(
+    CONFIG_IP_NF_TARGET_MASQUERADE
+    CONFIG_IP6_NF_TARGET_MASQUERADE
+)
+# lxc-checkconfig also probes the machine it runs on -- cgroup mounts,
+# /proc/self/ns/cgroup, newuidmap -- which says nothing about the kernel being
+# built. Only its "<label>: enabled|missing|required" lines are read, and the
+# host-state labels among them are skipped.
+ignored_labels=("Cgroup namespace" "Cgroup v1 *")
+
+# Stdout is not a terminal inside $(...), so the output carries no colour codes.
+if ! output=$(CONFIG="$config" sh "$here/lxc-checkconfig" </dev/null 2>&1); then
+    printf 'lxc-checkconfig failed to run:\n%s\n' "$output" >&2
+    exit 1
+fi
+
+failed=0
+enabled=0
+while IFS= read -r line; do
+    [[ $line == *": "* ]] || continue
+    label=${line%%: *}
+    status=${line#*: }
+    status=${status%%,*}
+    case $status in
+        enabled) enabled=$((enabled + 1)); continue ;;
+        missing | required) ;;
+        *) continue ;;
+    esac
+    for ignored in "${ignored_labels[@]}"; do
+        # shellcheck disable=SC2053
+        [[ $label == $ignored ]] && continue 2
+    done
+    for ignored in "${ignored_symbols[@]}"; do
+        [[ $label == "$ignored" ]] && continue 2
+    done
+    printf 'lxc-checkconfig: %s\n' "$line" >&2
+    failed=1
+done <<< "$output"
+
+# lxc-checkconfig reports about thirty symbols on a 6.x kernel. A run that
+# checked nothing -- a config it could not parse, a copy of the script that
+# lost its checks -- would otherwise pass vacuously.
+MIN_ENABLED=20
+if (( enabled < MIN_ENABLED )); then
+    printf 'lxc-checkconfig reported only %d enabled symbols; refusing to proceed\n' \
+      "$enabled" >&2
+    failed=1
+fi
+exit "$failed"

--- a/os/common/scripts/lxc-checkconfig
+++ b/os/common/scripts/lxc-checkconfig
@@ -1,0 +1,301 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: The LXC contributors
+#
+# Vendored from lxc/lxc src/lxc/cmd/lxc-checkconfig.in at commit
+# 969a3c5992251b6ca180854e7e7844b2daff2677 (2025-12-04). Only this header
+# differs from upstream; keep it that way and re-vendor to update. Driven by
+# check-lxc-kernel-config.sh next to it, which is what the builds call.
+
+export LC_ALL=C.UTF-8
+export LANGUAGE=en
+
+# Allow environment variables to override config
+: "${CONFIG:=/proc/config.gz}"
+: "${MODNAME:=configs}"
+
+GREP="grep"
+
+if [ -t 1 ]; then
+    SETCOLOR_SUCCESS="printf \\033[1;32m"
+    SETCOLOR_FAILURE="printf \\033[1;31m"
+    SETCOLOR_WARNING="printf \\033[1;33m"
+    SETCOLOR_NORMAL="printf \\033[0;39m"
+else
+    SETCOLOR_SUCCESS=":"
+    SETCOLOR_FAILURE=":"
+    SETCOLOR_WARNING=":"
+    SETCOLOR_NORMAL=":"
+fi
+
+is_set() {
+    $GREP -wm1 "^${1}=[y|m]" "${CONFIG}" > /dev/null
+    return $?
+}
+
+show_enabled() {
+    RES=$1
+    RET=1
+    if [ "$RES" -eq 0 ]; then
+        $SETCOLOR_SUCCESS && printf "enabled" && $SETCOLOR_NORMAL
+        RET=0
+    else
+        if [ -n "$mandatory" ] && [ "$mandatory" = yes ]; then
+            $SETCOLOR_FAILURE && printf "required" && $SETCOLOR_NORMAL
+        else
+            $SETCOLOR_WARNING && printf "missing" && $SETCOLOR_NORMAL
+        fi
+    fi
+    return $RET
+}
+
+is_enabled() {
+    mandatory=$2
+
+    is_set "$1"
+    show_enabled $?
+}
+
+has_cgroup_ns() {
+    mandatory=no
+
+    if [ -f "/proc/self/ns/cgroup" ]; then
+        show_enabled 0
+    else
+        show_enabled 1
+    fi
+}
+
+is_probed() {
+    if [ ! -f /proc/modules ]; then
+        return
+    fi
+    if lsmod | grep -wm1 "^${1}" > /dev/null; then
+        printf ", loaded"
+    else
+        printf ", not loaded"
+    fi
+}
+
+if command -v lxc-start >/dev/null; then
+    echo "LXC version $(lxc-start --version)"
+fi
+
+if [ ! -f "${CONFIG}" ]; then
+    echo "Kernel configuration not found at $CONFIG; searching..."
+    KVER="$(uname -r)"
+    HEADERS_CONFIG="/lib/modules/$KVER/build/.config"
+    BOOT_CONFIG="/boot/config-$KVER"
+    [ -f "${HEADERS_CONFIG}" ] && CONFIG=${HEADERS_CONFIG}
+    [ -f "${BOOT_CONFIG}" ] && CONFIG=${BOOT_CONFIG}
+    if [ ! -f "$CONFIG" ]; then
+        MODULEFILE="$(modinfo -k "$KVER" -n "$MODNAME" 2> /dev/null)"
+        # don't want to modprobe, so give user a hint
+        # although scripts/extract-ikconfig could be used to extract contents without loading kernel module
+        # http://svn.pld-linux.org/trac/svn/browser/geninitrd/trunk/geninitrd?rev=12696#L327
+    fi
+    if [ ! -f "$CONFIG" ]; then
+        echo "$(basename "$0"): unable to retrieve kernel configuration" >&2
+        echo >&2
+        if [ -f "$MODULEFILE" ]; then
+            echo "Try modprobe $MODNAME module, or" >&2
+        fi
+        echo "Try recompiling with IKCONFIG_PROC, installing the kernel headers," >&2
+        echo "or specifying the kernel configuration path with:" >&2
+        echo "  CONFIG=<path> $(basename "$0")" >&2
+        exit 1
+    else
+        echo "Kernel configuration found at $CONFIG"
+    fi
+fi
+
+if gunzip -t < "$CONFIG" >/dev/null 2>&1; then
+    GREP="zgrep"
+fi
+
+KVER_MAJOR="$($GREP -m1 '^# Linux.*Kernel Configuration' "${CONFIG}" | \
+    sed -r 's/.* ([0-9])\.[0-9]{1,2}\.[0-9]{1,3}.*/\1/')"
+if [ "$KVER_MAJOR" = "2" ]; then
+  KVER_MINOR="$($GREP -m1 '^# Linux.*Kernel Configuration' "${CONFIG}" | \
+    sed -r 's/.* 2.6.([0-9]{2}).*/\1/')"
+else
+  KVER_MINOR="$($GREP -m1 '^# Linux.*Kernel Configuration' "${CONFIG}" | \
+    sed -r 's/.* [0-9]\.([0-9]{1,3})\.[0-9]{1,3}.*/\1/')"
+fi
+
+if [ -z "${KVER_MAJOR}" ]; then
+    echo "WARNING: Unable to detect version from configuration, assuming latest"
+    echo
+    KVER_MAJOR="100"
+    KVER_MINOR="0"
+fi
+
+echo "
+--- Namespaces ---"
+printf "Namespaces: " && is_enabled CONFIG_NAMESPACES yes
+echo
+printf "Utsname namespace: " && is_enabled CONFIG_UTS_NS
+echo
+printf "Ipc namespace: " && is_enabled CONFIG_IPC_NS yes
+echo
+printf "Pid namespace: " && is_enabled CONFIG_PID_NS yes
+echo
+printf "User namespace: " && is_enabled CONFIG_USER_NS
+echo
+if is_set CONFIG_USER_NS; then
+    if command -v newuidmap >/dev/null 2>&1; then
+        f=$(command -v newuidmap)
+        if [ ! -u "${f}" ]; then
+            echo "Warning: newuidmap is not setuid-root"
+        fi
+    else
+        echo "newuidmap is not installed"
+    fi
+    if command -v newgidmap >/dev/null 2>&1; then
+        f=$(command -v newgidmap)
+        if [ ! -u "${f}" ]; then
+            echo "Warning: newgidmap is not setuid-root"
+        fi
+    else
+        echo "newgidmap is not installed"
+    fi
+fi
+printf "Network namespace: " && is_enabled CONFIG_NET_NS
+echo
+if [ "${KVER_MAJOR}" -lt 4 ] || { [ "${KVER_MAJOR}" -eq 4 ] && [ "${KVER_MINOR}" -lt 7 ]; }; then
+    printf "Multiple /dev/pts instances: " && is_enabled DEVPTS_MULTIPLE_INSTANCES
+    echo
+fi
+echo "Namespace limits:"
+for file in /proc/sys/user/max_*_namespaces; do
+    [ -r "${file}" ] || continue
+
+    ns_name="$(basename "${file}" | sed -e "s/^max_//g" -e "s/_namespaces$//g")"
+    printf "  %s: %s" "${ns_name}" "$(cat "${file}")"
+    echo
+done
+
+echo "
+--- Control groups ---"
+printf "Cgroups: " && is_enabled CONFIG_CGROUPS
+echo
+printf "Cgroup namespace: " && has_cgroup_ns
+echo
+
+print_cgroups() {
+  # print all mountpoints for cgroup filesystems
+  awk '$1 !~ /#/ && $3 == mp { print $2; } ; END { exit(0); } '  "mp=$1" "$2" ;
+}
+CGROUP_V1_MNTS=$(print_cgroups cgroup /proc/self/mounts)
+CGROUP_V2_MNTS=$(print_cgroups cgroup2 /proc/self/mounts)
+
+echo "Cgroup v1 mount points: "
+for mnt in ${CGROUP_V1_MNTS}; do
+    echo " - ${mnt}"
+done
+
+echo "Cgroup v2 mount points: "
+for mnt in ${CGROUP_V2_MNTS}; do
+    echo " - ${mnt}"
+done
+
+if [ "${CGROUP_V2_MNTS}" != "/sys/fs/cgroup" ]; then
+    CGROUP_SYSTEMD_MNTPT=$(echo "$CGROUP_V1_MNTS" | grep -F "/systemd")
+    if [ -z "$CGROUP_SYSTEMD_MNTPT" ]; then
+        printf "Cgroup v1 systemd controller: "
+        $SETCOLOR_FAILURE && echo "missing" && $SETCOLOR_NORMAL
+    fi
+
+    CGROUP_FREEZER_MNTPT=$(echo "$CGROUP_V1_MNTS" | grep -F "/freezer")
+    if [ -z "$CGROUP_FREEZER_MNTPT" ]; then
+        printf "Cgroup v1 freezer controller: "
+        $SETCOLOR_FAILURE && echo "missing" && $SETCOLOR_NORMAL
+    fi
+
+    CGROUP_MNT_PATH=$(echo "$CGROUP_V1_MNTS" | head -n 1)
+    if [ -f "$CGROUP_MNT_PATH/cgroup.clone_children" ]; then
+        printf "Cgroup v1 clone_children flag: " &&
+        $SETCOLOR_SUCCESS && echo "enabled" && $SETCOLOR_NORMAL
+    fi
+fi
+
+printf "Cgroup device: " && is_enabled CONFIG_CGROUP_DEVICE
+echo
+
+printf "Cgroup sched: " && is_enabled CONFIG_CGROUP_SCHED
+echo
+
+printf "Cgroup cpu account: " && is_enabled CONFIG_CGROUP_CPUACCT
+echo
+
+printf "Cgroup memory controller: "
+if { [ "${KVER_MAJOR}" -ge 3 ] && [ "${KVER_MINOR}" -ge 6 ]; } || [ "${KVER_MAJOR}" -gt 3 ]; then
+    is_enabled CONFIG_MEMCG
+else
+    is_enabled CONFIG_CGROUP_MEM_RES_CTLR
+fi
+echo
+
+is_set CONFIG_SMP && printf "Cgroup cpuset: " && is_enabled CONFIG_CPUSETS && echo
+
+echo "
+--- Misc ---"
+printf "Veth pair device: " && is_enabled CONFIG_VETH && is_probed veth
+echo
+printf "Macvlan: " && is_enabled CONFIG_MACVLAN && is_probed macvlan
+echo
+printf "Vlan: " && is_enabled CONFIG_VLAN_8021Q && is_probed 8021q
+echo
+printf "Bridges: " && is_enabled CONFIG_BRIDGE && is_probed bridge
+echo
+printf "Advanced netfilter: " && is_enabled CONFIG_NETFILTER_ADVANCED && is_probed nf_tables
+if { [ "${KVER_MAJOR}" -gt 3 ] && [ "${KVER_MINOR}" -gt 6 ]; } && [ "${KVER_MAJOR}" -lt 5 ]; then
+    echo
+    printf "CONFIG_NF_NAT_IPV4: " && is_enabled CONFIG_NF_NAT_IPV4 && is_probed nf_nat_ipv4
+    echo
+    printf "CONFIG_NF_NAT_IPV6: " && is_enabled CONFIG_NF_NAT_IPV6 && is_probed nf_nat_ipv6
+fi
+echo
+printf "CONFIG_IP_NF_TARGET_MASQUERADE: " && is_enabled CONFIG_IP_NF_TARGET_MASQUERADE && is_probed nf_nat_masquerade_ipv4
+echo
+printf "CONFIG_IP6_NF_TARGET_MASQUERADE: " && is_enabled CONFIG_IP6_NF_TARGET_MASQUERADE && is_probed nf_nat_masquerade_ipv6
+echo
+printf "CONFIG_NETFILTER_XT_TARGET_CHECKSUM: " && is_enabled CONFIG_NETFILTER_XT_TARGET_CHECKSUM && is_probed xt_CHECKSUM
+echo
+printf "CONFIG_NETFILTER_XT_MATCH_COMMENT: " && is_enabled CONFIG_NETFILTER_XT_MATCH_COMMENT && is_probed xt_comment
+echo
+printf "FUSE (for use with lxcfs): " && is_enabled CONFIG_FUSE_FS && is_probed fuse
+echo
+
+echo "
+--- Checkpoint/Restore ---"
+printf "checkpoint restore: " && is_enabled CONFIG_CHECKPOINT_RESTORE
+echo
+printf "CONFIG_FHANDLE: " && is_enabled CONFIG_FHANDLE
+echo
+printf "CONFIG_EVENTFD: " && is_enabled CONFIG_EVENTFD
+echo
+printf "CONFIG_EPOLL: " && is_enabled CONFIG_EPOLL
+echo
+printf "CONFIG_UNIX_DIAG: " && is_enabled CONFIG_UNIX_DIAG
+echo
+printf "CONFIG_INET_DIAG: " && is_enabled CONFIG_INET_DIAG
+echo
+printf "CONFIG_PACKET_DIAG: " && is_enabled CONFIG_PACKET_DIAG
+echo
+printf "CONFIG_NETLINK_DIAG: " && is_enabled CONFIG_NETLINK_DIAG
+echo
+printf "File capabilities: "
+if [ "${KVER_MAJOR}" = 2 ] && [ "${KVER_MINOR}" -lt 33 ]; then
+    is_enabled CONFIG_SECURITY_FILE_CAPABILITIES
+    echo
+else
+    $SETCOLOR_SUCCESS && echo "enabled" && $SETCOLOR_NORMAL
+fi
+
+echo "
+Note: Before booting a new kernel, you can check its configuration with:
+
+  CONFIG=/path/to/config $0
+
+"

--- a/os/mkosi/components/kernel/kernel-build.sh
+++ b/os/mkosi/components/kernel/kernel-build.sh
@@ -62,6 +62,7 @@ make -C "$src" O="$BUILD_DIR/kernel-build" PAHOLE="$pahole_wrapper" x86_64_defco
 make -C "$src" O="$BUILD_DIR/kernel-build" PAHOLE="$pahole_wrapper" olddefconfig
 "$ROOT/os/common/scripts/check-kernel-config.sh" "$BUILD_DIR/kernel-build/.config" \
     "$MKOSI_DIR/components/kernel/kernel.config"
+"$ROOT/os/common/scripts/check-lxc-kernel-config.sh" "$BUILD_DIR/kernel-build/.config"
 make -C "$src" O="$BUILD_DIR/kernel-build" PAHOLE="$pahole_wrapper" -j"$JOBS" bzImage modules
 make -C "$src" O="$BUILD_DIR/kernel-build" \
     PAHOLE="$pahole_wrapper" INSTALL_MOD_PATH="$STAGING" modules_install

--- a/os/mkosi/components/kernel/kernel.config
+++ b/os/mkosi/components/kernel/kernel.config
@@ -337,3 +337,20 @@ CONFIG_EARLY_PRINTK_DBGP=n
 # egress channel for whatever the log happens to contain, configurable at
 # runtime by root, and nothing in the image uses it.
 CONFIG_NETCONSOLE=n
+
+# Traffic control for the per-instance bandwidth limits of nested container
+# managers (Incus `limits.max`, #1176). Incus caps a bridged NIC with an HTB
+# root qdisc and class on egress and, on ingress, an ingress qdisc carrying a
+# u32 filter with a police action. NET_SCHED and NET_CLS_ACT provide none of
+# the four: each is its own tristate, and a missing one surfaces only at
+# runtime, as "Specified qdisc kind is unknown" for a limit the manager had
+# already accepted. Built in rather than modules for the same reason as
+# CONFIG_TLS: no kernel-module-* package to forget on the Yocto side, and no
+# reliance on module autoload from inside the manager's own namespaces. This
+# block and its counterpart in the other backend are deliberately identical.
+CONFIG_NET_SCHED=y
+CONFIG_NET_CLS_ACT=y
+CONFIG_NET_SCH_HTB=y
+CONFIG_NET_SCH_INGRESS=y
+CONFIG_NET_CLS_U32=y
+CONFIG_NET_ACT_POLICE=y

--- a/os/mkosi/components/kernel/kernel.config
+++ b/os/mkosi/components/kernel/kernel.config
@@ -371,3 +371,18 @@ CONFIG_NET_ACT_POLICE=y
 # of 0.5.9 and x86_64_defconfig do not. Asserted here so neither backend can
 # lose it.
 CONFIG_CHECKPOINT_RESTORE=y
+
+# The rest of what lxc-checkconfig asks for. That is LXC's own list, vendored
+# at os/common/scripts/lxc-checkconfig and run against both kernel builds
+# after the fragment check; these are the symbols the two images lacked or
+# disagreed on the first time it ran. MACVLAN backs Incus `nictype=macvlan`;
+# xt_comment is what the xtables frontends attach `-m comment` to (the Yocto
+# rootfs already ships it as kernel-module-xt-comment, and the mkosi image
+# installs every module it builds); the *_DIAG interfaces are how `ss` and
+# CRIU read socket state. Built in where the Yocto tree already had them so.
+CONFIG_MACVLAN=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=m
+CONFIG_UNIX_DIAG=y
+CONFIG_INET_DIAG=y
+CONFIG_PACKET_DIAG=y
+CONFIG_NETLINK_DIAG=y

--- a/os/mkosi/components/kernel/kernel.config
+++ b/os/mkosi/components/kernel/kernel.config
@@ -354,3 +354,20 @@ CONFIG_NET_SCH_HTB=y
 CONFIG_NET_SCH_INGRESS=y
 CONFIG_NET_CLS_U32=y
 CONFIG_NET_ACT_POLICE=y
+
+# Checkpoint/restore support (#1180). What LXC needs from it is PR_SET_MM_MAP:
+# that is how the container monitor rewrites its own title to
+# "[lxc monitor] <path> <name>", and Incus's seccomp notification handler
+# resolves a monitor PID to its instance by that title. Without the symbol the
+# prctl returns EINVAL, the monitor keeps its "incusd forkstart" command line,
+# the lookup fails ("Failed to find container for monitor <pid>") and every
+# intercepted syscall (security.syscalls.intercept.*) is resumed unhandled
+# instead of getting the container-aware answer. Everything the symbol gates
+# needs CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN (PR_SET_MM, ns_last_pid, the
+# IPC *_next_id sysctls, PTRACE_O_SUSPEND_SECCOMP, seccomp filter dumps of a
+# ptraced task), and it is what every general-purpose distro kernel ships;
+# none of it faces the host. The Yocto 6.18 build already had it, from the
+# cfg/lxc.scc and cfg/criu.scc that meta-virtualization adds; the 6.9 kernel
+# of 0.5.9 and x86_64_defconfig do not. Asserted here so neither backend can
+# lose it.
+CONFIG_CHECKPOINT_RESTORE=y

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -142,7 +142,11 @@
     "CONFIG_NF_TABLES_BRIDGE=m",
     "CONFIG_NFT_BRIDGE_META=m",
     "CONFIG_NFT_BRIDGE_REJECT=m",
-    "CONFIG_NETFILTER_XT_TARGET_CHECKSUM=m"
+    "CONFIG_NETFILTER_XT_TARGET_CHECKSUM=m",
+    "CONFIG_NET_SCH_HTB=y",
+    "CONFIG_NET_SCH_INGRESS=y",
+    "CONFIG_NET_CLS_U32=y",
+    "CONFIG_NET_ACT_POLICE=y"
   ],
   "prod_forbidden_paths": [
     "usr/bin/dstack-tee-simulator",

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -147,7 +147,9 @@
     "CONFIG_NET_SCH_INGRESS=y",
     "CONFIG_NET_CLS_U32=y",
     "CONFIG_NET_ACT_POLICE=y",
-    "CONFIG_CHECKPOINT_RESTORE=y"
+    "CONFIG_CHECKPOINT_RESTORE=y",
+    "CONFIG_MACVLAN=y",
+    "CONFIG_NETFILTER_XT_MATCH_COMMENT=m"
   ],
   "prod_forbidden_paths": [
     "usr/bin/dstack-tee-simulator",

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -146,7 +146,8 @@
     "CONFIG_NET_SCH_HTB=y",
     "CONFIG_NET_SCH_INGRESS=y",
     "CONFIG_NET_CLS_U32=y",
-    "CONFIG_NET_ACT_POLICE=y"
+    "CONFIG_NET_ACT_POLICE=y",
+    "CONFIG_CHECKPOINT_RESTORE=y"
   ],
   "prod_forbidden_paths": [
     "usr/bin/dstack-tee-simulator",

--- a/os/mkosi/tests/acceptance.sh
+++ b/os/mkosi/tests/acceptance.sh
@@ -89,6 +89,8 @@ while read -r key want; do
 done < <(sed -n 's/^require_config \(CONFIG_[A-Z0-9_]*\) \([ynm]\)$/\1 \2/p' "$audit")
 [[ $required -ge 10 ]]
 grep -q '0002-acpi-sandbox' "$D/components/kernel/kernel-build.sh"
+# LXC's own kernel audit runs after the fragment gate; see check-lxc-kernel-config.sh.
+grep -q 'check-lxc-kernel-config.sh' "$D/components/kernel/kernel-build.sh"
 grep -q -- '--fuzz=0' "$D/components/kernel/kernel-build.sh"
 for service in dstack-guest-agent dstack-prepare app-compose dstack-gateway-checker; do
   grep -q "$service" "$D/mkosi.skeleton/usr/lib/systemd/system-preset/80-dstack.preset"

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
@@ -141,3 +141,20 @@ CONFIG_BLK_CGROUP=y
 CONFIG_BLK_DEV_THROTTLING=y
 # CONFIG_BLK_DEV_THROTTLING_LOW was removed upstream and no longer exists, so
 # the line it replaced could never be satisfied.
+
+# Traffic control for the per-instance bandwidth limits of nested container
+# managers (Incus `limits.max`, #1176). Incus caps a bridged NIC with an HTB
+# root qdisc and class on egress and, on ingress, an ingress qdisc carrying a
+# u32 filter with a police action. NET_SCHED and NET_CLS_ACT provide none of
+# the four: each is its own tristate, and a missing one surfaces only at
+# runtime, as "Specified qdisc kind is unknown" for a limit the manager had
+# already accepted. Built in rather than modules for the same reason as
+# CONFIG_TLS: no kernel-module-* package to forget on the Yocto side, and no
+# reliance on module autoload from inside the manager's own namespaces. This
+# block and its counterpart in the other backend are deliberately identical.
+CONFIG_NET_SCHED=y
+CONFIG_NET_CLS_ACT=y
+CONFIG_NET_SCH_HTB=y
+CONFIG_NET_SCH_INGRESS=y
+CONFIG_NET_CLS_U32=y
+CONFIG_NET_ACT_POLICE=y

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
@@ -175,3 +175,18 @@ CONFIG_NET_ACT_POLICE=y
 # of 0.5.9 and x86_64_defconfig do not. Asserted here so neither backend can
 # lose it.
 CONFIG_CHECKPOINT_RESTORE=y
+
+# The rest of what lxc-checkconfig asks for. That is LXC's own list, vendored
+# at os/common/scripts/lxc-checkconfig and run against both kernel builds
+# after the fragment check; these are the symbols the two images lacked or
+# disagreed on the first time it ran. MACVLAN backs Incus `nictype=macvlan`;
+# xt_comment is what the xtables frontends attach `-m comment` to (the Yocto
+# rootfs already ships it as kernel-module-xt-comment, and the mkosi image
+# installs every module it builds); the *_DIAG interfaces are how `ss` and
+# CRIU read socket state. Built in where the Yocto tree already had them so.
+CONFIG_MACVLAN=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=m
+CONFIG_UNIX_DIAG=y
+CONFIG_INET_DIAG=y
+CONFIG_PACKET_DIAG=y
+CONFIG_NETLINK_DIAG=y

--- a/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
+++ b/os/yocto/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
@@ -158,3 +158,20 @@ CONFIG_NET_SCH_HTB=y
 CONFIG_NET_SCH_INGRESS=y
 CONFIG_NET_CLS_U32=y
 CONFIG_NET_ACT_POLICE=y
+
+# Checkpoint/restore support (#1180). What LXC needs from it is PR_SET_MM_MAP:
+# that is how the container monitor rewrites its own title to
+# "[lxc monitor] <path> <name>", and Incus's seccomp notification handler
+# resolves a monitor PID to its instance by that title. Without the symbol the
+# prctl returns EINVAL, the monitor keeps its "incusd forkstart" command line,
+# the lookup fails ("Failed to find container for monitor <pid>") and every
+# intercepted syscall (security.syscalls.intercept.*) is resumed unhandled
+# instead of getting the container-aware answer. Everything the symbol gates
+# needs CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN (PR_SET_MM, ns_last_pid, the
+# IPC *_next_id sysctls, PTRACE_O_SUSPEND_SECCOMP, seccomp filter dumps of a
+# ptraced task), and it is what every general-purpose distro kernel ships;
+# none of it faces the host. The Yocto 6.18 build already had it, from the
+# cfg/lxc.scc and cfg/criu.scc that meta-virtualization adds; the 6.9 kernel
+# of 0.5.9 and x86_64_defconfig do not. Asserted here so neither backend can
+# lose it.
+CONFIG_CHECKPOINT_RESTORE=y

--- a/os/yocto/scripts/export-artifacts.sh
+++ b/os/yocto/scripts/export-artifacts.sh
@@ -124,6 +124,7 @@ if [ -f "$KERNEL_CONFIG_FILE" ]; then
         "$KERNEL_CONFIG_FILE" \
         "$YOCTO_DIR/layers/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg" \
         "$YOCTO_DIR/layers/meta-dstack/recipes-kernel/linux/files/dstack.cfg"
+    "$REPO_ROOT/os/common/scripts/check-lxc-kernel-config.sh" "$KERNEL_CONFIG_FILE"
 else
     echo "Error: kernel config not found: $KERNEL_CONFIG_FILE" >&2
     exit 1


### PR DESCRIPTION
## Problem

Two guest-kernel capability gaps that Incus system containers inside a CVM run into, reported against the 0.5.9 guest (`6.9.0-dstack`):

**Per-instance bandwidth limits (#1176).** Incus implements `limits.max` / `limits.ingress` / `limits.egress` on a bridged NIC as an HTB root qdisc and class on the host-side veth for egress, and an ingress qdisc with a u32 filter and a police action for ingress. That needs `NET_SCH_HTB`, `NET_SCH_INGRESS`, `NET_CLS_U32` and `NET_ACT_POLICE`. `NET_SCHED` alone provides none of them — each is its own tristate — so the manager accepts the setting and then fails to start the instance:

```
Failed to create root tc qdisc ... qdisc htb ... Specified qdisc kind is unknown
```

Both current backends lack all four: the locally built Yocto 6.18 `kernel-config` has them (and `NET_CLS_ACT`) as `not set`, and `x86_64_defconfig` plus `os/mkosi/components/kernel/kernel.config` produces the same.

**Seccomp notification handling (#1180).** LXC retitles its monitor process to `[lxc monitor] <path> <name>` with `prctl(PR_SET_MM, PR_SET_MM_MAP, ...)`, and Incus's seccomp handler resolves a monitor PID to its instance by that title. The kernel only implements `PR_SET_MM_MAP` under `CONFIG_CHECKPOINT_RESTORE`; without it the prctl returns `EINVAL`, the monitor keeps its `incusd forkstart` command line, `incusd` logs `Failed to find container for monitor <pid>`, and with `seccomp_listener_continue` every intercepted syscall (`security.syscalls.intercept.*`) is resumed unhandled instead of getting the container-aware answer. Here the two backends differ: the Yocto 6.18 build already has the symbol, through the `cfg/lxc.scc` and `cfg/criu.scc` that meta-virtualization adds to `KERNEL_FEATURES` (the 0.5.9 kernel did not), while `x86_64_defconfig` leaves it at its Kconfig default of `n`, so the mkosi kernel is missing it and nothing asserted it on either side.

**No gate would have caught either.** Neither Incus nor anyone else ships a kernel-config checker for Incus; the closest thing is LXC's own `lxc-checkconfig`, which Incus's requirements page implicitly defers to ("any kernel feature required by the LXC version in use"). Run against the mkosi kernel it reports seven symbols missing — `CHECKPOINT_RESTORE`, `MACVLAN`, `NETFILTER_XT_MATCH_COMMENT` and the four socket-diag interfaces — all of which the Yocto kernel has. It does not know about traffic control, so it would not have caught #1176.

## Fix

1. **tc pieces** (`b215bdb`): `NET_SCHED`, `NET_CLS_ACT`, `NET_SCH_HTB`, `NET_SCH_INGRESS`, `NET_CLS_U32`, `NET_ACT_POLICE`, all `=y`, in both fragments. Built in rather than `=m` for the same reason as `CONFIG_TLS`: no `kernel-module-*` package to forget in the Yocto rootfs (a missing one fails at runtime, not at build time), and no reliance on module autoload from inside the manager's own namespaces. ~100 KB of text in total.
2. **`CHECKPOINT_RESTORE=y`** (`9be802d`) in both fragments — new on mkosi, an assertion on Yocto so neither backend can lose it.
3. **The rest of what `lxc-checkconfig` asks for** (`ecae1f8`): `MACVLAN=y` (Incus `nictype=macvlan`), `NETFILTER_XT_MATCH_COMMENT=m` (`-m comment` on the xtables frontends; the Yocto rootfs already ships `kernel-module-xt-comment`, mkosi installs every module it builds), `UNIX_DIAG`/`INET_DIAG`/`PACKET_DIAG`/`NETLINK_DIAG=y` (`ss`, CRIU). Values match what the Yocto tree already had.
4. **Gate both kernels on `lxc-checkconfig`** (`bb3acfc`): vendored verbatim at `os/common/scripts/lxc-checkconfig` (lxc/lxc `969a3c5`, LGPL-2.1-or-later, license text added under `LICENSES/`), driven by `check-lxc-kernel-config.sh`, which runs it with `CONFIG=<built .config>`, fails on any `missing`/`required` line, ignores the script's host-state probes (cgroup mounts, `/proc/self/ns/cgroup`) and refuses to pass if fewer than 20 symbols came back `enabled`. The only exemptions are `IP_NF_TARGET_MASQUERADE` / `IP6_NF_TARGET_MASQUERADE`, backwards-compat aliases that just `select NETFILTER_XT_TARGET_MASQUERADE` (which both kernels build); the IPv6 one is unreachable on mkosi anyway (needs legacy ip6tables). Called right after `check-kernel-config.sh` in `kernel-build.sh` (mkosi) and `export-artifacts.sh` (Yocto); `acceptance.sh` checks the mkosi wiring.

All new fragment lines live in one block that is byte-identical between the two backends, following the bridge-filtering block. `parity.json` asserts the new symbols on the installed mkosi kernel config.

**Security assessment of `CHECKPOINT_RESTORE`** (asked for in #1180). On x86 the symbol gates: `PR_SET_MM` (needs `CAP_CHECKPOINT_RESTORE` or `CAP_SYS_ADMIN` in the caller's user namespace), the `kernel.ns_last_pid` sysctl and the IPC `*_next_id` sysctls (same check), `PTRACE_O_SUSPEND_SECCOMP` (init-namespace `CAP_SYS_ADMIN`), `PTRACE_SECCOMP_GET_FILTER` / `GET_METADATA` on a ptraced task (`CAP_SYS_ADMIN`), `MSG_COPY` on `msgrcv` (non-destructive read of a queue the caller can already read) and the `ARCH_MAP_VDSO_*` arch_prctl. It also selects `PROC_CHILDREN` and `KCMP` (`KCMP` was already `y` on both backends). Every path is capability- or ptrace-gated guest-userspace surface; none of it faces the host, so it does not change what a malicious host can reach, and it is what every general-purpose distro kernel ships (Debian, Ubuntu, Fedora all set it; `docker checkpoint` / CRIU need it). The CVM is single-tenant, so intra-guest process introspection is not a boundary dstack defends — and the Yocto image has been shipping it since it moved to 6.18.

`docs/guest-netfilter-capabilities.md` records all of the above next to the netfilter matrix (and corrects that table's "Since" column: the netfilter work is in `v0.6.0-rc0`, so it ships in 0.6.0, not 0.6.1).

## Verification

- **mkosi backend**: ran the kernel-config stage of `kernel-build.sh` locally on `linux-6.18.40` (both dstack patches applied): `x86_64_defconfig` → `merge_config.sh` with the final fragment → `olddefconfig`; `check-kernel-config.sh` and `check-lxc-kernel-config.sh` both pass. Resulting `.config` has every requested symbol at the requested value, plus `KCMP=y`, `PROC_CHILDREN=y`, `NET_XGRESS=y`.
- **Yocto backend**: merged the final `dstack-docker.cfg` into the deployed `kernel-config` of a local `linux-yocto` 6.18.39 build with `merge_config.sh` + `olddefconfig` against the bitbake kernel source; both gates pass. The diff against the previous config shows exactly the requested symbols flipping (plus `NETFILTER_SKIP_EGRESS=y`, a `def_bool` that follows `NET_XGRESS`).
- **The new gate fails on the old kernels**: against `next`'s mkosi config it reports the seven symbols above and exits 1; against an empty file it exits 1 with `reported only 2 enabled symbols; refusing to proceed`. On the new configs it counts 30 enabled symbols.
- `os/mkosi/tests/acceptance.sh` passes, `shellcheck` is clean on the wrapper, `reuse lint` lists `LGPL-2.1-or-later` as used with no unused licenses.
- Not done here: a boot test of a candidate image with Incus. The issue reporter offered to rerun the Incus `limits.max` / traffic-measurement and `sysinfo` interception gates on a disposable CVM once a candidate image exists; that is the right place for the end-to-end check.

Closes #1176
Closes #1180
