### PR TITLE
fix(os): refresh dynamic linker cache after staging libraries

### DIFF
--- a/os/mkosi/mkosi.postinst
+++ b/os/mkosi/mkosi.postinst
@@ -15,3 +15,7 @@ rm -rf "$B/var/log/apt"
 # Host keys must be unique per booted development VM, never shared by all
 # guests built from one image. OpenSSH generates them on first boot.
 rm -f "$B"/etc/ssh/ssh_host_*_key "$B"/etc/ssh/ssh_host_*_key.pub
+
+# Build outputs are merged after package installation, so refresh the final
+# rootfs cache after manually staged NVIDIA and container-runtime libraries.
+ldconfig -r "$B"

--- a/os/mkosi/parity.json
+++ b/os/mkosi/parity.json
@@ -170,6 +170,11 @@
     "usr/lib/systemd/system/debug-shell.service",
     "usr/lib/systemd/system/systemd-logind.service"
   ],
+  "required_ldconfig_entries": [
+    "libnvidia-ml.so.1",
+    "libnvidia-container.so.1",
+    "libnvidia-container-go.so.1"
+  ],
   "runtime_link_paths": [
     "usr/bin/nvattest",
     "usr/bin/nvidia-smi",

--- a/os/mkosi/tests/check-parity.py
+++ b/os/mkosi/tests/check-parity.py
@@ -91,6 +91,23 @@ for path, expected in spec.get("required_symlink_resolutions", {}).items():
         missing.append(
             f"netfilter frontend:/{path} resolves to {target}, wanted {expected}"
         )
+required_ldconfig_entries = spec.get("required_ldconfig_entries", [])
+if required_ldconfig_entries:
+    result = subprocess.run(
+        ["ldconfig", "-r", rootfs, "-p"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode:
+        missing.append("runtime linker cache: failed to read")
+    else:
+        cached = {
+            line.split()[0] for line in result.stdout.splitlines() if " => " in line
+        }
+        for soname in required_ldconfig_entries:
+            if soname not in cached:
+                missing.append(f"runtime linker cache: {soname}")
 for path in spec.get("runtime_link_paths", []):
     result = subprocess.run(
         ["lddtree", "-R", rootfs, f"/{path}"],


### PR DESCRIPTION
## Problem

The mkosi build stages NVIDIA and container-runtime libraries after Debian's package installation has generated `/etc/ld.so.cache`. The files and symlinks are present in the final rootfs, but the cache has no entries for them. As a result, the NVIDIA container runtime does not inject NVML and `nvidia-smi` inside a GPU container fails with:

```
NVIDIA-SMI couldn't find libnvidia-ml.so library
```

## Fix

- Run `ldconfig` against the final rootfs from `mkosi.postinst` after all staged build outputs have been merged.
- Extend the parity check to require cache entries for NVML and both manually staged libnvidia-container libraries.

## Verification

- Built a complete mkosi image from `mkosi-os-v0.6.0-rc1` with this patch on the B200 test node; mkosi parity and release-format checks passed.
- Mounted the generated rootfs and verified `ldconfig -r <rootfs> -p` contains:
  - `libnvidia-ml.so.1`
  - `libnvidia-container.so.1`
  - `libnvidia-container-go.so.1`
- Deployed the generated image on the B200 test node and verified `nvidia-smi` works inside the GPU container.
- Ran `prek --from-ref origin/next --to-ref HEAD`.
