### PR TITLE
fix(certbot): shutdown signal handling nits

### DIFF
--- a/dstack/certbot/cli/src/main.rs
+++ b/dstack/certbot/cli/src/main.rs
@@ -5,7 +5,7 @@
 
 use std::{path::PathBuf, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use certbot::{CertBotConfig, ChallengeKind, WorkDir, LETS_ENCRYPT_ISSUER_DOMAIN_NAME};
 use clap::Parser;
 use documented::DocumentedFields;
@@ -201,17 +201,25 @@ fn load_config(config: &PathBuf) -> Result<CertBotConfig> {
 
 async fn renew(config: &PathBuf, once: bool, force: bool) -> Result<()> {
     let bot_config = load_config(config).context("Failed to load configuration")?;
-    let bot = bot_config
-        .build_bot()
-        .await
-        .context("Failed to build bot")?;
     if once {
+        let bot = bot_config
+            .build_bot()
+            .await
+            .context("Failed to build bot")?;
         bot.renew_and_run_hook(force).await?;
-    } else {
-        tokio::select! {
-            _ = bot.run() => unreachable!("certbot daemon returned"),
-            result = shutdown_signal() => result?,
-        }
+        return Ok(());
+    }
+
+    // Install the shutdown handler before build_bot(), which can do network
+    // I/O (e.g. creating the ACME account), so a SIGTERM/Ctrl-C arriving
+    // during startup is handled instead of hard-killing the process.
+    let bot = tokio::select! {
+        bot = bot_config.build_bot() => bot.context("Failed to build bot")?,
+        result = shutdown_signal() => return result,
+    };
+    tokio::select! {
+        _ = bot.run() => bail!("certbot daemon exited unexpectedly"),
+        result = shutdown_signal() => result?,
     }
     Ok(())
 }

--- a/dstack/certbot/cli/src/main.rs
+++ b/dstack/certbot/cli/src/main.rs
@@ -210,18 +210,29 @@ async fn renew(config: &PathBuf, once: bool, force: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Install the shutdown handler before build_bot(), which can do network
-    // I/O (e.g. creating the ACME account), so a SIGTERM/Ctrl-C arriving
-    // during startup is handled instead of hard-killing the process.
-    let bot = tokio::select! {
-        bot = bot_config.build_bot() => bot.context("Failed to build bot")?,
-        result = shutdown_signal() => return result,
+    // Startup and the renew loop are raced against shutdown as one future, so
+    // the signal listener covers the whole daemon lifetime. build_bot() does
+    // network I/O (resolving the DNS zone, creating the ACME account), and a
+    // SIGTERM/Ctrl-C arriving there used to fall through to the default
+    // disposition and hard-kill the process. Racing the two phases separately
+    // would leave a gap between them with no listener registered: tokio never
+    // restores the default disposition once a handler is installed, and drops
+    // a signal that arrives while nothing is subscribed, so such a SIGTERM
+    // would neither terminate nor unblock the process.
+    let daemon = async {
+        let bot = bot_config
+            .build_bot()
+            .await
+            .context("Failed to build bot")?;
+        bot.run().await;
+        // run() loops forever today, but that is not enforced by its type: a
+        // future early return should exit with an error, not panic.
+        bail!("certbot daemon exited unexpectedly")
     };
     tokio::select! {
-        _ = bot.run() => bail!("certbot daemon exited unexpectedly"),
-        result = shutdown_signal() => result?,
+        result = daemon => result,
+        result = shutdown_signal() => result,
     }
-    Ok(())
 }
 
 async fn shutdown_signal() -> Result<()> {


### PR DESCRIPTION
## What was wrong

Follow-up to #924, which added graceful shutdown handling to the certbot
daemon path in `dstack/certbot/cli/src/main.rs`. Two small robustness nits
in that shutdown path:

1. The shutdown-signal handler was only installed (and raced) after
   `build_bot()` completed. `build_bot()` can do network I/O (creating the
   ACME account), so a SIGTERM/Ctrl-C arriving during that window fell
   through to the default disposition and hard-killed the process instead
   of shutting down gracefully — the graceful window only opened once
   startup finished.
2. `_ = bot.run() => unreachable!("certbot daemon returned")` only holds
   because `CertBot::run()` happens to be an unconditional `loop {}`
   returning `()` today. That invariant isn't enforced by the type system,
   so a future early `return` from `run()` (e.g. bailing out after N
   consecutive failures) would turn into a panic with a misleading message
   instead of exiting cleanly.

## What changed

In `renew()`:
- The `once` (non-daemon) path now builds the bot and runs a single
  renewal, unchanged in behavior.
- The daemon path now races `bot_config.build_bot()` itself against
  `shutdown_signal()`, so a shutdown signal during startup returns
  immediately instead of being ignored.
- Once the bot is built, `bot.run()` is raced against a fresh
  `shutdown_signal()` call as before, but the "daemon returned" arm now
  does `bail!("certbot daemon exited unexpectedly")` instead of
  `unreachable!(...)`, so a future change to `run()`'s control flow
  produces a normal error exit instead of a panic.

No behavior change for the `once`/single-run path, and no change outside
`dstack/certbot/cli/src/main.rs`.

## How it was verified

The `certbot` lib crate does not compile on native Windows (unrelated,
pre-existing: `dstack/certbot/src/acme_client.rs` calls
`fs::os::unix::fs::symlink(..)` unconditionally, with no `#[cfg(unix)]`
guard), and this machine has no cross C toolchain for
`x86_64-unknown-linux-gnu` (needed by `ring`/`aws-lc-sys` build scripts),
so verification was done in a `rust:1.92` Linux container (matching the
repo's pinned `rust-toolchain.toml` channel) with the repo mounted in:

```
docker run --rm -v <repo>:/work rust:1.92 bash -c '
  cd /work/dstack
  cargo check  -p certbot-cli
  cargo clippy -p certbot-cli -- -D warnings
  cargo test   -p certbot-cli
'
```

```
=== cargo check -p certbot-cli ===
    Checking certbot-cli v0.6.0 (/work/dstack/certbot/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 50.98s
CHECK_EXIT:0

=== cargo clippy -p certbot-cli -- -D warnings ===
    Checking certbot-cli v0.6.0 (/work/dstack/certbot/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.64s
CLIPPY_EXIT:0

=== cargo test -p certbot-cli ===
running 2 tests
test config_template_tests::max_dns_wait_is_not_labelled_as_a_renew_timeout ... ok
test config_template_tests::every_key_is_labelled_with_its_own_doc_comment ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
TEST_EXIT:0
```

`cargo fmt -p certbot-cli -- --check` was also run natively on Windows and
is clean (exit 0).

Fixes #1014