### PR TITLE
Let auto TDX attestation follow the image, not guest RAM

### DIFF
--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -1734,7 +1734,7 @@ fn make_vm_config(
         tdx_attestation_variant_from_requirements(requirements).unwrap_or_else(|| {
             cfg.cvm
                 .tdx_attestation_variant
-                .resolve(manifest.memory, image_supports_tdx_lite(image))
+                .resolve(image_supports_tdx_lite(image))
         })
     } else {
         dstack_types::TdxAttestationVariant::Legacy
@@ -2565,17 +2565,17 @@ mod tests {
         Ok(())
     }
 
+    /// 1 GiB used to fall back to legacy: it is below 3 GiB and not the 2 GiB
+    /// exemption. That heuristic existed for images whose OVMF leaves the setup
+    /// header for QEMU to rewrite, which the build system no longer produces.
     #[test]
-    fn tdx_auto_variant_uses_legacy_for_low_non_2g_memory() -> Result<()> {
+    fn tdx_auto_variant_uses_lite_for_low_non_2g_memory() -> Result<()> {
         let config = test_tdx_config()?;
         let manifest = test_manifest(1024);
         let image = test_tdx_image(true);
         let vm_config = make_vm_config(&config, &manifest, &image, &hex_of(0x22, 32), None, None)?;
 
-        assert!(vm_config.get("tdx_attestation_variant").is_none());
-        // tdx_measurement is attached whenever the image supports it, even
-        // when the resolved variant is legacy, so a verifier can still
-        // choose lite verification for this boot.
+        assert_eq!(vm_config["tdx_attestation_variant"], "lite");
         assert!(vm_config.get("tdx_measurement").is_some());
         assert_eq!(
             vm_config["os_image_hash"]

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -272,20 +272,31 @@ pub enum TdxAttestationVariantConfig {
 }
 
 impl TdxAttestationVariantConfig {
-    const TWO_GIB_MIB: u32 = 2 * 1024;
-    const THREE_GIB_MIB: u32 = 3 * 1024;
-
-    pub fn resolve(self, memory_mib: u32, image_supports_lite: bool) -> TdxAttestationVariant {
+    /// `auto` follows the image and nothing else.
+    ///
+    /// It used to also refuse lite below 3 GiB, exempting exactly 2 GiB,
+    /// because QEMU's setup-header rewrite moves the initrd with guest RAM and
+    /// so makes the patched kernel Authenticode hash memory-dependent. Images
+    /// whose OVMF normalizes the setup header measure the shipped `bzImage`
+    /// instead, which no guest RAM size can move, and that is every image the
+    /// build system can now produce: it hardcodes `kernel_header_normalized`
+    /// and fails when the OVMF patch does not apply.
+    ///
+    /// A pre-normalization image is the one case this no longer covers. The
+    /// no-download verifier still rejects those below the threshold, with an
+    /// error naming the memory sizes and telling the operator to re-emit the
+    /// image, so the failure is explicit rather than a silent mismatch. Set
+    /// `tdx_attestation_variant = "legacy"` to keep running one as is.
+    pub fn resolve(self, image_supports_lite: bool) -> TdxAttestationVariant {
+        use TdxAttestationVariant::{Legacy, Lite};
         match self {
-            Self::Legacy => TdxAttestationVariant::Legacy,
-            Self::Lite => TdxAttestationVariant::Lite,
+            Self::Legacy => Legacy,
+            Self::Lite => Lite,
             Self::Auto => {
-                if memory_mib < Self::THREE_GIB_MIB && memory_mib != Self::TWO_GIB_MIB {
-                    TdxAttestationVariant::Legacy
-                } else if image_supports_lite {
-                    TdxAttestationVariant::Lite
+                if image_supports_lite {
+                    Lite
                 } else {
-                    TdxAttestationVariant::Legacy
+                    Legacy
                 }
             }
         }
@@ -360,9 +371,10 @@ pub struct CvmConfig {
 
     /// TDX attestation/hash scheme policy. `legacy` keeps the existing
     /// digest.txt measurement path; `lite` opts into split measurement CBOR;
-    /// `auto` selects `legacy` for
-    /// CVMs below 3 GiB except exactly 2 GiB, otherwise uses `lite` when the
-    /// image carries TDX measurement material and falls back to `legacy`.
+    /// `auto` uses `lite` when the image carries TDX measurement material and
+    /// falls back to `legacy` when it does not. See
+    /// [`TdxAttestationVariantConfig::resolve`] for why memory size no longer
+    /// takes part.
     #[serde(default)]
     pub tdx_attestation_variant: TdxAttestationVariantConfig,
 
@@ -1164,30 +1176,13 @@ mod tests {
 
         use dstack_types::TdxAttestationVariant::{Legacy, Lite};
 
-        // Explicit settings bypass auto heuristics.
-        assert_eq!(
-            TdxAttestationVariantConfig::Legacy.resolve(2048, true),
-            Legacy
-        );
-        assert_eq!(TdxAttestationVariantConfig::Lite.resolve(1024, false), Lite);
+        // Explicit settings bypass auto entirely.
+        assert_eq!(TdxAttestationVariantConfig::Legacy.resolve(true), Legacy);
+        assert_eq!(TdxAttestationVariantConfig::Lite.resolve(false), Lite);
 
-        // Auto avoids lite for sub-3 GiB memory sizes except exactly 2 GiB.
-        assert_eq!(
-            TdxAttestationVariantConfig::Auto.resolve(1024, true),
-            Legacy
-        );
-        assert_eq!(
-            TdxAttestationVariantConfig::Auto.resolve(2816, true),
-            Legacy
-        );
-        assert_eq!(TdxAttestationVariantConfig::Auto.resolve(2048, true), Lite);
-
-        // At 3 GiB and above, auto follows image support.
-        assert_eq!(TdxAttestationVariantConfig::Auto.resolve(3072, true), Lite);
-        assert_eq!(
-            TdxAttestationVariantConfig::Auto.resolve(3072, false),
-            Legacy
-        );
+        // Auto follows image support alone; memory no longer takes part.
+        assert_eq!(TdxAttestationVariantConfig::Auto.resolve(true), Lite);
+        assert_eq!(TdxAttestationVariantConfig::Auto.resolve(false), Legacy);
     }
 
     fn default_config() -> Config {

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -84,8 +84,10 @@ qemu_hotplug_off = false
 # TDX attestation/hash scheme policy:
 # - "legacy": digest.txt + legacy verifier
 # - "lite": digest.txt + measurement.tdx.cbor + no-QEMU verifier
-# - "auto": legacy for CVM memory below 3 GiB except exactly 2 GiB; otherwise
-#   lite when the image supports it, legacy when it does not.
+# - "auto": lite when the image ships measurement.tdx.cbor, legacy when it does
+#   not. Memory size does not take part: the kernel hash only depended on it
+#   for images whose OVMF leaves the setup header for QEMU to rewrite, and the
+#   build system no longer produces those.
 tdx_attestation_variant = "auto"
 
 host_share_mode = "9p"


### PR DESCRIPTION
## Why

`tdx_attestation_variant = "auto"` refused lite below 3 GiB, exempting exactly
2 GiB:

```rust
if memory_mib < Self::THREE_GIB_MIB && memory_mib != Self::TWO_GIB_MIB {
    TdxAttestationVariant::Legacy
} else if image_supports_lite { ... }
```

That came from QEMU's setup-header rewrite, which moves the initrd with guest
RAM and so makes the patched kernel Authenticode hash memory-dependent — see
`tdx_kernel_hash_uses_precomputed_high_mem` in `dstack-mr/src/kernel.rs`.

Images whose OVMF normalizes the setup header measure the shipped `bzImage`
instead, which no guest RAM size can move. That is every image the build system
can now produce: `os/image/assemble.sh` hardcodes `kernel_header_normalized`
and the OVMF build fails when the normalization patch does not apply.

So the heuristic now only costs deployments the cheaper verification path — a
1 GiB CVM on a current image got legacy despite carrying everything lite needs.

## What changed

`resolve` follows `image_supports_lite` alone and no longer takes the memory
size; `TWO_GIB_MIB` and `THREE_GIB_MIB` are gone. The `vmm.toml` comment and
the field doc are updated to match.

Both tests that encoded the old behaviour are updated. The one in `app.rs` is
rewritten to assert the new outcome — 1 GiB with a lite-capable image now
resolves to `lite` — so the behaviour change is recorded positively rather than
by deletion.

## The case this stops covering

A pre-normalization image below the threshold: the VMM now selects lite, and
the no-download verifier rejects it. That rejection names the required memory
sizes and tells the operator to re-emit the image, so it is an explicit failure
rather than a silent mismatch, and `tdx_attestation_variant = "legacy"` keeps
such an image running as is. The reasoning is recorded on `resolve` itself.

Keeping the guard for exactly that case is possible — it would mean threading
`kernel_header_normalized` into `resolve` — but it puts the memory rule back
for a class of image the build system can no longer emit.

## Testing

`cargo test -p dstack-vmm --all-features` (128 passed), `cargo fmt --all --
--check`, `cargo clippy -p dstack-vmm -- -D warnings --allow unused_variables`.

Independent of #1199; the two do not touch the same code.
