### PR TITLE
fix(vmm): detect qemu version before each vm start

### DIFF
--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -1305,12 +1305,17 @@ impl App {
         let mr_config = work_dir
             .prepare_mr_config(&manifest, &cfg.cvm, &app_compose)
             .context("Failed to prepare mr_config")?;
+        // Detect the version of the QEMU binary this start will execute so
+        // the declared version cannot go stale if the binary is replaced
+        // while the VMM keeps running.
+        let qemu_version = cfg.cvm.resolve_qemu_version();
         let sys_config_str = make_sys_config(
             cfg,
             &manifest,
             &hex::encode(compose_hash),
             mr_config,
             app_compose.requirements.as_ref(),
+            qemu_version,
         )?;
         fs::write(shared_dir.join(SYS_CONFIG), &sys_config_str)
             .context("Failed to write vm config")?;
@@ -1603,6 +1608,7 @@ pub(crate) fn make_sys_config(
     compose_hash: &str,
     mr_config: Option<String>,
     requirements: Option<&dstack_types::Requirements>,
+    qemu_version: Option<String>,
 ) -> Result<String> {
     let image_path = cfg.image.path.join(&manifest.image);
     let image = Image::load(image_path).context("Failed to load image info")?;
@@ -1644,6 +1650,7 @@ pub(crate) fn make_sys_config(
         compose_hash,
         mr_config.clone(),
         requirements,
+        qemu_version,
     )?;
     let mut sys_config = json!({
         "kms_urls": kms_urls,
@@ -1723,6 +1730,7 @@ fn make_vm_config(
     _compose_hash: &str,
     mr_config: Option<String>,
     requirements: Option<&dstack_types::Requirements>,
+    qemu_version: Option<String>,
 ) -> Result<serde_json::Value> {
     let platform = cfg.cvm.resolved_platform();
     let is_amd_sev_snp = platform == crate::config::CvmPlatform::AmdSevSnp && !manifest.no_tee;
@@ -1804,7 +1812,7 @@ fn make_vm_config(
         memory_size: manifest.memory as u64 * 1024 * 1024,
         qemu_single_pass_add_pages: cfg.cvm.qemu_single_pass_add_pages,
         pic: cfg.cvm.qemu_pic,
-        qemu_version: cfg.cvm.qemu_version.clone(),
+        qemu_version,
         pci_hole64_size: cfg.cvm.qemu_pci_hole64_size,
         hugepages: manifest.hugepages,
         num_gpus: gpus.gpus.len() as u32,
@@ -2512,10 +2520,24 @@ mod tests {
         let image = test_tdx_image(true);
         let compose_hash = hex_of(0x22, 32);
 
-        let bridge_config =
-            make_vm_config(&config, &bridge_manifest, &image, &compose_hash, None, None)?;
-        let user_config =
-            make_vm_config(&config, &user_manifest, &image, &compose_hash, None, None)?;
+        let bridge_config = make_vm_config(
+            &config,
+            &bridge_manifest,
+            &image,
+            &compose_hash,
+            None,
+            None,
+            None,
+        )?;
+        let user_config = make_vm_config(
+            &config,
+            &user_manifest,
+            &image,
+            &compose_hash,
+            None,
+            None,
+            None,
+        )?;
 
         assert_eq!(bridge_config, user_config);
         Ok(())
@@ -2540,6 +2562,7 @@ mod tests {
             &hex_of(0x22, 32),
             None,
             None,
+            None,
         )?;
 
         assert_eq!(vm_config["num_verity_volumes"], 2);
@@ -2559,6 +2582,7 @@ mod tests {
             &hex_of(0x22, 32),
             None,
             None,
+            None,
         )?;
 
         assert_eq!(vm_config["swtpm"], true);
@@ -2573,7 +2597,15 @@ mod tests {
         let config = test_tdx_config()?;
         let manifest = test_manifest(1024);
         let image = test_tdx_image(true);
-        let vm_config = make_vm_config(&config, &manifest, &image, &hex_of(0x22, 32), None, None)?;
+        let vm_config = make_vm_config(
+            &config,
+            &manifest,
+            &image,
+            &hex_of(0x22, 32),
+            None,
+            None,
+            None,
+        )?;
 
         assert_eq!(vm_config["tdx_attestation_variant"], "lite");
         assert!(vm_config.get("tdx_measurement").is_some());
@@ -2591,7 +2623,15 @@ mod tests {
         let config = test_tdx_config()?;
         let manifest = test_manifest(2048);
         let image = test_tdx_image(true);
-        let vm_config = make_vm_config(&config, &manifest, &image, &hex_of(0x22, 32), None, None)?;
+        let vm_config = make_vm_config(
+            &config,
+            &manifest,
+            &image,
+            &hex_of(0x22, 32),
+            None,
+            None,
+            None,
+        )?;
 
         assert_eq!(vm_config["tdx_attestation_variant"], "lite");
         assert!(vm_config.get("tdx_measurement").is_some());
@@ -2609,7 +2649,15 @@ mod tests {
         let config = test_tdx_config()?;
         let manifest = test_manifest(3072);
         let image = test_tdx_image(false);
-        let vm_config = make_vm_config(&config, &manifest, &image, &hex_of(0x22, 32), None, None)?;
+        let vm_config = make_vm_config(
+            &config,
+            &manifest,
+            &image,
+            &hex_of(0x22, 32),
+            None,
+            None,
+            None,
+        )?;
 
         assert!(vm_config.get("tdx_attestation_variant").is_none());
         assert!(vm_config.get("tdx_measurement").is_none());
@@ -2639,6 +2687,7 @@ mod tests {
             &hex_of(0x22, 32),
             None,
             Some(&requirements),
+            None,
         )?;
 
         assert!(vm_config.get("tdx_attestation_variant").is_none());
@@ -2665,6 +2714,7 @@ mod tests {
             &hex_of(0x22, 32),
             None,
             Some(&requirements),
+            None,
         )?;
 
         assert_eq!(vm_config["tdx_attestation_variant"], "lite");
@@ -2761,8 +2811,14 @@ mod tests {
         let build_hash = Sha256::digest(sha256sum.as_bytes()).to_vec();
         fs::write(image_dir.join("digest.txt"), hex::encode(&build_hash))?;
 
-        let sys_config_document =
-            make_sys_config(&config, &manifest, &compose_hash, Some(mr_config), None)?;
+        let sys_config_document = make_sys_config(
+            &config,
+            &manifest,
+            &compose_hash,
+            Some(mr_config),
+            None,
+            None,
+        )?;
         let sys_config: serde_json::Value = serde_json::from_str(&sys_config_document)?;
         assert!(sys_config.get("tee_simulator").is_none());
         // A host must never nominate the trust anchor that authenticates its

--- a/dstack/vmm/src/app.rs
+++ b/dstack/vmm/src/app.rs
@@ -2544,6 +2544,24 @@ mod tests {
     }
 
     #[test]
+    fn vm_config_declares_the_given_qemu_version() -> Result<()> {
+        let config = test_tdx_config()?;
+        let manifest = test_manifest(2048);
+        let image = test_tdx_image(true);
+        let vm_config = make_vm_config(
+            &config,
+            &manifest,
+            &image,
+            &hex_of(0x22, 32),
+            None,
+            None,
+            Some("9.2.1".to_string()),
+        )?;
+        assert_eq!(vm_config["qemu_version"], "9.2.1");
+        Ok(())
+    }
+
+    #[test]
     fn vm_measurement_config_includes_verity_volume_count() -> Result<()> {
         let config = test_tdx_config()?;
         let mut manifest = test_manifest(2048);

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -255,6 +255,36 @@ impl CvmConfig {
     pub fn resolved_platform(&self) -> CvmPlatform {
         self.platform.unwrap_or_else(CvmPlatform::detect)
     }
+
+    /// The QEMU version to declare for a VM being started now.
+    ///
+    /// An explicit `qemu_version` in the config file always wins. Otherwise
+    /// the version is re-detected from the binary currently at `qemu_path`:
+    /// the load-time detection is cached, but the binary can be replaced
+    /// while the VMM keeps running, and the verifier picks an ACPI model from
+    /// the declared version, so a stale value breaks RTMR0 replay. When the
+    /// re-detection fails, fall back to the load-time value, mirroring the
+    /// previous behavior of starting without a fresh version.
+    pub fn resolve_qemu_version(&self) -> Option<String> {
+        if self.qemu_version_explicit {
+            return self.qemu_version.clone();
+        }
+        match detect_qemu_version(&self.qemu_path) {
+            Ok(version) => {
+                if self.qemu_version.as_deref() != Some(version.as_str()) {
+                    info!(
+                        "QEMU version changed since config load: {:?} -> {version}",
+                        self.qemu_version
+                    );
+                }
+                Some(version)
+            }
+            Err(err) => {
+                warn!("failed to detect QEMU version at VM start: {err}");
+                self.qemu_version.clone()
+            }
+        }
+    }
 }
 
 /// VMM-side policy for selecting the TDX attestation/hash scheme.
@@ -363,6 +393,10 @@ pub struct CvmConfig {
     pub qemu_pic: Option<bool>,
     /// QEMU qemu_version
     pub qemu_version: Option<String>,
+    /// Whether `qemu_version` was set explicitly in the config file. Set by
+    /// `Config::extract_or_default`; not part of the config format.
+    #[serde(skip)]
+    qemu_version_explicit: bool,
     /// QEMU pci_hole64_size
     #[serde(with = "size_parser::human_size")]
     pub qemu_pci_hole64_size: u64,
@@ -1041,6 +1075,7 @@ impl Config {
             info!("QEMU path: {}", me.cvm.qemu_path.display());
 
             // Detect QEMU version if not already set
+            me.cvm.qemu_version_explicit = me.cvm.qemu_version.is_some();
             match &me.cvm.qemu_version {
                 None => match detect_qemu_version(&me.cvm.qemu_path) {
                     Ok(version) => {
@@ -1062,6 +1097,75 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn write_fake_qemu(dir: &std::path::Path, version: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join("qemu-system-x86_64");
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\necho 'QEMU emulator version {version} (Debian 2:{version}+dfsg-1)'\n"
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    fn cvm_config_with_qemu(qemu_path: PathBuf) -> CvmConfig {
+        let mut config: Config = Figment::from(load_config_figment(None)).extract().unwrap();
+        config.cvm.qemu_path = qemu_path;
+        config.cvm
+    }
+
+    // Reproduces the production mismatch: the VMM caches the QEMU version at
+    // config load, so when the binary at qemu_path is replaced while the VMM
+    // keeps running, the next VM start declares the stale cached version
+    // while executing the replaced binary.
+    #[cfg(unix)]
+    #[test]
+    fn qemu_version_is_redetected_after_binary_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let qemu_path = write_fake_qemu(dir.path(), "10.1.0");
+        let mut cvm = cvm_config_with_qemu(qemu_path.clone());
+        // Config load caches the version of the binary present at that time.
+        cvm.qemu_version = Some(detect_qemu_version(&qemu_path).unwrap());
+        assert_eq!(cvm.qemu_version.as_deref(), Some("10.1.0"));
+        // The binary is replaced while the VMM keeps running.
+        write_fake_qemu(dir.path(), "9.2.1");
+        // The version declared for the next start must match the binary that
+        // will actually execute.
+        let declared = cvm.resolve_qemu_version();
+        assert_eq!(declared.as_deref(), Some("9.2.1"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_qemu_version_overrides_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let qemu_path = write_fake_qemu(dir.path(), "9.2.1");
+        let mut cvm = cvm_config_with_qemu(qemu_path);
+        cvm.qemu_version = Some("8.2.2".to_string());
+        cvm.qemu_version_explicit = true;
+        assert_eq!(cvm.resolve_qemu_version().as_deref(), Some("8.2.2"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn qemu_version_detection_failure_falls_back_to_load_time_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let qemu_path = write_fake_qemu(dir.path(), "10.1.0");
+        let mut cvm = cvm_config_with_qemu(qemu_path.clone());
+        cvm.qemu_version = Some(detect_qemu_version(&qemu_path).unwrap());
+        // The binary disappears before the next VM start.
+        std::fs::remove_file(&qemu_path).unwrap();
+        assert_eq!(cvm.resolve_qemu_version().as_deref(), Some("10.1.0"));
+        // Without a load-time value there is nothing to fall back to.
+        cvm.qemu_version = None;
+        assert_eq!(cvm.resolve_qemu_version(), None);
+    }
 
     #[test]
     fn auto_restart_config_rejects_hot_loop_and_inverted_backoff() {

--- a/dstack/vmm/src/config.rs
+++ b/dstack/vmm/src/config.rs
@@ -280,7 +280,7 @@ impl CvmConfig {
                 Some(version)
             }
             Err(err) => {
-                warn!("failed to detect QEMU version at VM start: {err}");
+                warn!("failed to detect QEMU version at VM start: {err:?}");
                 self.qemu_version.clone()
             }
         }

--- a/dstack/vmm/src/one_shot.rs
+++ b/dstack/vmm/src/one_shot.rs
@@ -245,12 +245,15 @@ Compose file content (first 200 chars):
     let mr_config = vm_work_dir
         .prepare_mr_config(&manifest, &config.cvm, &app_compose)
         .context("Failed to prepare mr_config")?;
+    // One-shot loads its config immediately before the start, so the
+    // load-time value in `config.cvm.qemu_version` is already fresh.
     let sys_config_str = make_sys_config(
         &config,
         &manifest,
         &compose_hash,
         mr_config,
         app_compose.requirements.as_ref(),
+        config.cvm.qemu_version.clone(),
     )?;
     let sys_config_path = vm_work_dir.shared_dir().join(".sys-config.json");
     fs_err::write(&sys_config_path, &sys_config_str).context("Failed to write sys config")?;

--- a/dstack/vmm/vmm.toml
+++ b/dstack/vmm/vmm.toml
@@ -59,6 +59,8 @@ use_mrconfigid = true
 # QEMU flags
 #qemu_single_pass_add_pages = false
 #qemu_pic = true
+# Explicit QEMU version override. When unset, the version is detected from
+# the binary at qemu_path before every VM start.
 #qemu_version = ""
 # Size of the 64-bit PCI hole. Accepts a plain byte count, hex, or a unit
 # suffix: "512G", "2T", "1P" -- all binary multipliers, as are the "1PB" and


### PR DESCRIPTION
## Problem

The VMM detects the QEMU version once at config load and caches it in `Config.cvm.qemu_version`. Every `vm_config` generated afterwards copies the cached value, while the QEMU actually launched is whatever binary currently sits at `qemu_path`. If the binary is replaced while the VMM keeps running (e.g. a package upgrade or a manual swap), the declared version goes stale and no longer matches the binary being executed.

The verifier picks an ACPI table model from the declared `qemu_version`, so a stale declaration makes RTMR0 replay fail and the CVM unattestable. Observed in production: running VMs on a host were executing `/usr/bin/qemu-system-x86_64` 9.2.1 while their host-shared `.sys-config.json` declared `qemu_version: 10.1.0`, cached from before the binary was replaced. Restarting the VMs refreshed the declaration to 9.2.1 and full quote/event-log verification passed again.

## Fix

Detect the version before every VM start instead of once at config load, and make the `vm_config` written for a start use that same detection result:

- `CvmConfig::resolve_qemu_version()` returns the explicit `qemu_version` from the config file when one is set (a serde-skipped flag records explicitness at config load, so the override contract is unchanged); otherwise it re-runs `qemu --version` against the binary currently at `qemu_path`, logging when the version changed since config load.
- `sync_dynamic_config()` — the single entry point every start funnels through (RPC `StartVm`, auto-start on VMM boot, and the auto-restart task) — resolves the version and threads it through `make_sys_config()` into the `vm_config` it writes for that start.
- If the per-start re-detection fails, it falls back to the load-time value with a warning, mirroring the previous "start without a fresh version" behavior rather than failing the start.
- One-shot mode keeps passing the load-time value: it loads its config immediately before the start, so the value is already fresh and its behavior is unchanged.

This does not bind the declared version to the executed binary atomically — the binary can still be replaced between detection and exec. It removes the staleness window of a long-running VMM, which is the mismatch observed in production.

## Verification

- New regression test `qemu_version_is_redetected_after_binary_replacement`: a fake `qemu-system-x86_64` reporting 10.1.0 is "detected at config load", then replaced with one reporting 9.2.1. Before the fix the next start still declares the stale 10.1.0 (the test fails with `left: Some("10.1.0"), right: Some("9.2.1")`); after the fix it declares 9.2.1.
- New tests `explicit_qemu_version_overrides_detection` (explicit config wins even when the binary reports a different version) and `qemu_version_detection_failure_falls_back_to_load_time_value` (detection failure falls back to the load-time value, then to `None`).
- New test `vm_config_declares_the_given_qemu_version` covering the `make_vm_config` threading: the passed version is what lands in `vm_config`.
- `cargo test -p dstack-vmm`: 132 passed, 0 failed.
- `cargo clippy -- -D warnings -D clippy::expect_used -D clippy::unwrap_used --allow unused_variables` (the CI invocation): clean.
- `cargo fmt --all -- --check` and the prek hooks: clean.
